### PR TITLE
🚧 N3XC7M task: Retry transient runner cancellation intent reads [202607280948-N3XC7M]

### DIFF
--- a/.agentplane/tasks/202607280948-N3XC7M/README.md
+++ b/.agentplane/tasks/202607280948-N3XC7M/README.md
@@ -1,0 +1,128 @@
+---
+id: "202607280948-N3XC7M"
+title: "Retry transient runner cancellation intent reads"
+status: "DOING"
+priority: "high"
+owner: "CODER"
+revision: 7
+origin:
+  system: "manual"
+depends_on: []
+tags:
+  - "code"
+  - "runner"
+  - "ci"
+  - "regression"
+  - "v0.7"
+verify: []
+plan_approval:
+  state: "approved"
+  updated_at: "2026-07-28T09:48:50.744Z"
+  updated_by: "ORCHESTRATOR"
+  note: null
+verification:
+  state: "pending"
+  updated_at: null
+  updated_by: null
+  note: null
+  attempts: 0
+commit: null
+comments:
+  -
+    author: "CODER"
+    body: "Start: continue branch_pr task in the dedicated task worktree."
+events:
+  -
+    type: "status"
+    at: "2026-07-28T09:49:46.640Z"
+    author: "CODER"
+    from: "TODO"
+    to: "DOING"
+    note: "Start: continue branch_pr task in the dedicated task worktree."
+doc_version: 3
+doc_updated_at: "2026-07-28T09:49:46.640Z"
+doc_updated_by: "CODER"
+description: "Fix the CI-proven race where an atomically published runner cancellation intent changes during a stable read and is treated as a fatal execution error. Retry only transient immutable-publication collisions, preserve fail-closed behavior for malformed or unsafe records, and add deterministic regression coverage."
+sections:
+  Summary: |-
+    Retry transient runner cancellation intent reads
+
+    Fix the CI-proven race where an atomically published runner cancellation intent changes during a stable read and is treated as a fatal execution error. Retry only transient immutable-publication collisions, preserve fail-closed behavior for malformed or unsafe records, and add deterministic regression coverage.
+  Scope: |-
+    - In scope: Fix the CI-proven race where an atomically published runner cancellation intent changes during a stable read and is treated as a fatal execution error. Retry only transient immutable-publication collisions, preserve fail-closed behavior for malformed or unsafe records, and add deterministic regression coverage.
+    - Out of scope: unrelated refactors not required for "Retry transient runner cancellation intent reads".
+  Plan: "1. Add a narrowly scoped retry path for transient stable-read collisions when observing immutable runner cancellation intents. 2. Keep ENOENT optionality and unsafe/malformed-record failures fail-closed. 3. Add a deterministic regression that injects one publication-race read failure, then proves cancellation completes. 4. Run focused runner tests, typecheck, and the relevant fast unit gate."
+  Verify Steps: "1. Inject a single transient stable-file publication collision while reading a runner cancellation intent; expected: the read retries and returns the immutable intent. 2. Execute the cancellation lifecycle regression; expected: cancellation yields terminal cancelled state, not failed. 3. Run focused execution-control and lifecycle-cancellation tests, typecheck, and bun run test:fast; expected: all pass."
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: ""
+extensions:
+  agentplane.side_effect_authority:
+    audit:
+      -
+        actor: "USER"
+        at: "2026-07-28T09:50:41.587Z"
+        authorityDigest: "sha256:85ae791ce354cec9aa11f9c7c723dd1171411f847ade6977953bf45ccb47314d"
+        digest: "sha256:93c58638aab8a8213938c16d9d6193729e7be01a2e153ed3914127745fc08122"
+        operationDigest: "sha256:9985527c3943e690522424b7653bdc11b0c9ce90519ce9ebb718de33f669d73a"
+        operationId: "pr.open"
+        outcome: "approved"
+        policyRule: "workflow.external_reversible"
+        previousDigest: null
+        schemaVersion: 1
+        sequence: 1
+        stateFingerprintDigest: "sha256:d907e506b0184d09c4489ef4d0fb2e67a1d050c8db004ca55e64e9999b53774c"
+    grants:
+      -
+        actor: "USER"
+        digest: "sha256:85ae791ce354cec9aa11f9c7c723dd1171411f847ade6977953bf45ccb47314d"
+        expiresAt: "2026-07-28T10:05:41.587Z"
+        id: "authority-0e48b6e5-e106-479c-8676-666931efd6e0"
+        issuedAt: "2026-07-28T09:50:41.587Z"
+        kind: "side_effect_authority"
+        operationDigest: "sha256:9985527c3943e690522424b7653bdc11b0c9ce90519ce9ebb718de33f669d73a"
+        operationId: "pr.open"
+        policyRule: "workflow.external_reversible"
+        schemaVersion: 1
+        stateFingerprintDigest: "sha256:d907e506b0184d09c4489ef4d0fb2e67a1d050c8db004ca55e64e9999b53774c"
+        stateScopeDigest: "sha256:52c328820e5a7f8cccefc775c7f6953048fad851220a86e4c08effc390db0018"
+    schemaVersion: 1
+  workflow_route_baseline:
+    start_head_sha: "89a82f010479eb2583e414fb49c930d4819b5777"
+    version: 1
+id_source: "generated"
+---
+## Summary
+
+Retry transient runner cancellation intent reads
+
+Fix the CI-proven race where an atomically published runner cancellation intent changes during a stable read and is treated as a fatal execution error. Retry only transient immutable-publication collisions, preserve fail-closed behavior for malformed or unsafe records, and add deterministic regression coverage.
+
+## Scope
+
+- In scope: Fix the CI-proven race where an atomically published runner cancellation intent changes during a stable read and is treated as a fatal execution error. Retry only transient immutable-publication collisions, preserve fail-closed behavior for malformed or unsafe records, and add deterministic regression coverage.
+- Out of scope: unrelated refactors not required for "Retry transient runner cancellation intent reads".
+
+## Plan
+
+1. Add a narrowly scoped retry path for transient stable-read collisions when observing immutable runner cancellation intents. 2. Keep ENOENT optionality and unsafe/malformed-record failures fail-closed. 3. Add a deterministic regression that injects one publication-race read failure, then proves cancellation completes. 4. Run focused runner tests, typecheck, and the relevant fast unit gate.
+
+## Verify Steps
+
+1. Inject a single transient stable-file publication collision while reading a runner cancellation intent; expected: the read retries and returns the immutable intent. 2. Execute the cancellation lifecycle regression; expected: cancellation yields terminal cancelled state, not failed. 3. Run focused execution-control and lifecycle-cancellation tests, typecheck, and bun run test:fast; expected: all pass.
+
+## Verification
+
+<!-- BEGIN VERIFICATION RESULTS -->
+<!-- END VERIFICATION RESULTS -->
+
+## Rollback Plan
+
+- Revert task-related commit(s).
+- Re-run required checks to confirm rollback safety.
+
+## Findings

--- a/.agentplane/tasks/202607280948-N3XC7M/README.md
+++ b/.agentplane/tasks/202607280948-N3XC7M/README.md
@@ -1,10 +1,11 @@
 ---
 id: "202607280948-N3XC7M"
 title: "Retry transient runner cancellation intent reads"
-status: "DOING"
+result_summary: "pre-merge closure"
+status: "DONE"
 priority: "high"
 owner: "CODER"
-revision: 8
+revision: 13
 origin:
   system: "manual"
 depends_on: []
@@ -21,14 +22,41 @@ plan_approval:
   updated_by: "ORCHESTRATOR"
   note: null
 verification:
-  state: "pending"
-  updated_at: null
-  updated_by: null
-  note: null
+  state: "ok"
+  updated_at: "2026-07-28T10:06:31.424Z"
+  updated_by: "TESTER"
+  note: "The cancellation-intent regression, impacted runner files, typecheck, formatting, and diff checks pass. The local all-project fast run failed only in unrelated parallel teardown timeouts; hosted CI remains the merge gate."
   attempts: 0
+quality_review:
+  state: "pass"
+  provenance: "human_supplied"
+  updated_at: "2026-07-28T10:10:09.764Z"
+  updated_by: "HUMAN"
+  note: "The bounded retry covers only transient immutable cancellation-intent publication collisions and preserves fail-closed behavior for malformed or unsafe inputs."
+  evaluated_sha: "a224a862c0ba75d09060d1a6b1301005ca6a5173"
+  blueprint_digest: "33b37b14eb7897fb73d306e273fed82660d2b30131380aade76e26cb77d2c31f"
+  evidence_refs:
+    - ".agentplane/tasks/202607280948-N3XC7M/quality/20260728-101009524-recovery-context/evaluator-work-order.json"
+    - ".agentplane/tasks/202607280948-N3XC7M/quality/20260728-101009524-recovery-context/quality-report.json"
+    - ".agentplane/tasks/202607280948-N3XC7M/quality/20260728-101009524-recovery-context/evaluator-prompt.md"
+    - ".agentplane/tasks/202607280948-N3XC7M/quality/20260728-101009524-recovery-context/evaluator-opinion.md"
+    - ".agentplane/tasks/202607280948-N3XC7M/README.md"
+    - ".agentplane/tasks/202607280948-N3XC7M/quality/20260728-101009524-recovery-context/evaluator-diff.patch"
+    - ".agentplane/tasks/202607280948-N3XC7M/quality/20260728-101009524-recovery-context/evaluator-observed-checks.json"
+    - ".agentplane/tasks/202607280948-N3XC7M/quality/20260728-101009524-recovery-context/evaluator-blueprint.json"
+    - ".agentplane/policy/dod.code.md"
+    - ".agentplane/policy/dod.core.md"
+    - ".agentplane/policy/security.must.md"
+    - ".agentplane/policy/workflow.branch_pr.md"
+    - ".agentplane/tasks/202607280948-N3XC7M/quality/20260728-100701613-recovery-context/quality-report.json"
+    - "packages/agentplane/src/runner/adapters/execution-control.ts"
+    - "packages/agentplane/src/runner/adapters/execution-control.test.ts"
+    - "focused vitest: execution-control plus lifecycle-cancel 16/16; typecheck and Prettier passed"
+  findings:
+    - "The current task-artifact commit is reviewed in addition to the source patch; focused runner tests, lifecycle-cancellation regression, typecheck, formatting, and diff checks pass. The full local parallel suite has unrelated teardown timeouts, so hosted CI remains the integration gate."
 commit:
-  hash: "1a49629678f2a08df884ea70aa429ede775151fd"
-  message: "fix: retry runner cancellation intent reads"
+  hash: "a224a862c0ba75d09060d1a6b1301005ca6a5173"
+  message: "🧩 N3XC7M task: refresh task artifacts after commit"
 comments:
   -
     author: "CODER"
@@ -36,6 +64,9 @@ comments:
   -
     author: "CODER"
     body: "Implemented bounded retry for transient cancellation-intent publication collisions; malformed and unsafe reads remain fail-closed. Focused runner tests and typecheck pass; the full fast suite exposed independent teardown timeouts."
+  -
+    author: "CODER"
+    body: "Verified: pre-merge closure packet is ready for the task PR."
 events:
   -
     type: "status"
@@ -51,8 +82,21 @@ events:
     from: "DOING"
     to: "DOING"
     note: "Implemented bounded retry for transient cancellation-intent publication collisions; malformed and unsafe reads remain fail-closed. Focused runner tests and typecheck pass; the full fast suite exposed independent teardown timeouts."
+  -
+    type: "verify"
+    at: "2026-07-28T10:06:31.424Z"
+    author: "TESTER"
+    state: "ok"
+    note: "The cancellation-intent regression, impacted runner files, typecheck, formatting, and diff checks pass. The local all-project fast run failed only in unrelated parallel teardown timeouts; hosted CI remains the merge gate."
+  -
+    type: "status"
+    at: "2026-07-28T10:10:59.604Z"
+    author: "CODER"
+    from: "DOING"
+    to: "DONE"
+    note: "Verified: pre-merge closure packet is ready for the task PR."
 doc_version: 3
-doc_updated_at: "2026-07-28T10:01:26.764Z"
+doc_updated_at: "2026-07-28T10:10:59.604Z"
 doc_updated_by: "CODER"
 description: "Fix the CI-proven race where an atomically published runner cancellation intent changes during a stable read and is treated as a fatal execution error. Retry only transient immutable-publication collisions, preserve fail-closed behavior for malformed or unsafe records, and add deterministic regression coverage."
 sections:
@@ -67,11 +111,44 @@ sections:
   Verify Steps: "1. Inject a single transient stable-file publication collision while reading a runner cancellation intent; expected: the read retries and returns the immutable intent. 2. Execute the cancellation lifecycle regression; expected: cancellation yields terminal cancelled state, not failed. 3. Run focused execution-control and lifecycle-cancellation tests, typecheck, and bun run test:fast; expected: all pass."
   Verification: |-
     <!-- BEGIN VERIFICATION RESULTS -->
+    ### 2026-07-28T10:06:31.424Z — VERIFY — ok
+
+    By: TESTER
+
+    Note: The cancellation-intent regression, impacted runner files, typecheck, formatting, and diff checks pass. The local all-project fast run failed only in unrelated parallel teardown timeouts; hosted CI remains the merge gate.
+    Attempts: 0
+
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-07-28T10:01:26.764Z, excerpt_hash=sha256:57c38b847194d17d574d2f2d38e6804c089ecea9a1e7059f621fe11223019c22
+
+    Details:
+
+    BlueprintSnapshotRef:
+    - state: current
+    - path: /Users/densmirnov/Github/agentplane/.agentplane/tmp/inc-20260727-main-lane.prxk2f/repo/.agentplane/worktrees/202607280948-N3XC7M-retry-transient-runner-cancellation-intent-reads/.agentplane/tasks/202607280948-N3XC7M/blueprint/resolved-snapshot.json
+    - old_digest: 33b37b14eb7897fb73d306e273fed82660d2b30131380aade76e26cb77d2c31f
+    - current_digest: 33b37b14eb7897fb73d306e273fed82660d2b30131380aade76e26cb77d2c31f
+    - route_changed: no
+    - safe_command: agentplane blueprint snapshot 202607280948-N3XC7M
+
+    DecisionContextRef:
+    - operator_action: stop
+    - can_execute_now: false
+    - safe_command: none
+    - diagnostic_command: agentplane task verify-show 202607280948-N3XC7M
+    - source_of_truth: route=task_next_action diagnostic=task_next_action remote=not_checked
+    - freshness: route=computed_local remote=remote_skipped
+    - repeat_allowed: false
+    - repeat_stop_condition: after any non-zero exit or completed mutation, recompute task next-action before a second step
+    - risks: none
+
     <!-- END VERIFICATION RESULTS -->
   Rollback Plan: |-
     - Revert task-related commit(s).
     - Re-run required checks to confirm rollback safety.
-  Findings: ""
+  Findings: |-
+    - Observation: bun run test:fast produced 11 thirty-second timeouts in five unrelated runner test files plus two ENOENT cleanup rejections; the representative files pass when isolated.
+      Impact: The scoped change is locally verified, but the workstation full-parallel lane is not green and cannot substitute for hosted CI.
+      Resolution: Keep the targeted retry regression and isolated runner matrix as local evidence; require GitHub CI before integration and treat the parallel teardown failures as separate infrastructure work.
 extensions:
   agentplane.side_effect_authority:
     audit:
@@ -88,6 +165,19 @@ extensions:
         schemaVersion: 1
         sequence: 1
         stateFingerprintDigest: "sha256:d907e506b0184d09c4489ef4d0fb2e67a1d050c8db004ca55e64e9999b53774c"
+      -
+        actor: "USER"
+        at: "2026-07-28T10:10:36.338Z"
+        authorityDigest: "sha256:13ef57550a5ed94a6eaa98dfa1dcd2053073becfd51a78d49ace405fa21e1e57"
+        digest: "sha256:d60ed679c2b51d8e6e39c2f32f91d0516191d77c51f97a24e70e6b725a1df70b"
+        operationDigest: "sha256:f481bed6c57d7195f876f9e1779b2fdb1ca6690f7b7aabbd58beed9fb33295e6"
+        operationId: "task.pre_merge_close"
+        outcome: "approved"
+        policyRule: "workflow.external_high_risk"
+        previousDigest: "sha256:93c58638aab8a8213938c16d9d6193729e7be01a2e153ed3914127745fc08122"
+        schemaVersion: 1
+        sequence: 2
+        stateFingerprintDigest: "sha256:5e362c88611104d9f59676560b63438dc7c884346011447ed081973d853358b3"
     grants:
       -
         actor: "USER"
@@ -102,6 +192,19 @@ extensions:
         schemaVersion: 1
         stateFingerprintDigest: "sha256:d907e506b0184d09c4489ef4d0fb2e67a1d050c8db004ca55e64e9999b53774c"
         stateScopeDigest: "sha256:52c328820e5a7f8cccefc775c7f6953048fad851220a86e4c08effc390db0018"
+      -
+        actor: "USER"
+        digest: "sha256:13ef57550a5ed94a6eaa98dfa1dcd2053073becfd51a78d49ace405fa21e1e57"
+        expiresAt: "2026-07-28T10:25:36.338Z"
+        id: "authority-36e4c965-a190-407f-990d-429352303b4e"
+        issuedAt: "2026-07-28T10:10:36.338Z"
+        kind: "side_effect_authority"
+        operationDigest: "sha256:f481bed6c57d7195f876f9e1779b2fdb1ca6690f7b7aabbd58beed9fb33295e6"
+        operationId: "task.pre_merge_close"
+        policyRule: "workflow.external_high_risk"
+        schemaVersion: 1
+        stateFingerprintDigest: "sha256:5e362c88611104d9f59676560b63438dc7c884346011447ed081973d853358b3"
+        stateScopeDigest: "sha256:256b4833ef8cc3f131de14d1295804fc082b6db8c3f3188188ab27b74da80005"
     schemaVersion: 1
   workflow_route_baseline:
     start_head_sha: "89a82f010479eb2583e414fb49c930d4819b5777"
@@ -130,6 +233,36 @@ Fix the CI-proven race where an atomically published runner cancellation intent 
 ## Verification
 
 <!-- BEGIN VERIFICATION RESULTS -->
+### 2026-07-28T10:06:31.424Z — VERIFY — ok
+
+By: TESTER
+
+Note: The cancellation-intent regression, impacted runner files, typecheck, formatting, and diff checks pass. The local all-project fast run failed only in unrelated parallel teardown timeouts; hosted CI remains the merge gate.
+Attempts: 0
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-07-28T10:01:26.764Z, excerpt_hash=sha256:57c38b847194d17d574d2f2d38e6804c089ecea9a1e7059f621fe11223019c22
+
+Details:
+
+BlueprintSnapshotRef:
+- state: current
+- path: /Users/densmirnov/Github/agentplane/.agentplane/tmp/inc-20260727-main-lane.prxk2f/repo/.agentplane/worktrees/202607280948-N3XC7M-retry-transient-runner-cancellation-intent-reads/.agentplane/tasks/202607280948-N3XC7M/blueprint/resolved-snapshot.json
+- old_digest: 33b37b14eb7897fb73d306e273fed82660d2b30131380aade76e26cb77d2c31f
+- current_digest: 33b37b14eb7897fb73d306e273fed82660d2b30131380aade76e26cb77d2c31f
+- route_changed: no
+- safe_command: agentplane blueprint snapshot 202607280948-N3XC7M
+
+DecisionContextRef:
+- operator_action: stop
+- can_execute_now: false
+- safe_command: none
+- diagnostic_command: agentplane task verify-show 202607280948-N3XC7M
+- source_of_truth: route=task_next_action diagnostic=task_next_action remote=not_checked
+- freshness: route=computed_local remote=remote_skipped
+- repeat_allowed: false
+- repeat_stop_condition: after any non-zero exit or completed mutation, recompute task next-action before a second step
+- risks: none
+
 <!-- END VERIFICATION RESULTS -->
 
 ## Rollback Plan
@@ -138,3 +271,7 @@ Fix the CI-proven race where an atomically published runner cancellation intent 
 - Re-run required checks to confirm rollback safety.
 
 ## Findings
+
+- Observation: bun run test:fast produced 11 thirty-second timeouts in five unrelated runner test files plus two ENOENT cleanup rejections; the representative files pass when isolated.
+  Impact: The scoped change is locally verified, but the workstation full-parallel lane is not green and cannot substitute for hosted CI.
+  Resolution: Keep the targeted retry regression and isolated runner matrix as local evidence; require GitHub CI before integration and treat the parallel teardown failures as separate infrastructure work.

--- a/.agentplane/tasks/202607280948-N3XC7M/README.md
+++ b/.agentplane/tasks/202607280948-N3XC7M/README.md
@@ -5,7 +5,7 @@ result_summary: "pre-merge closure"
 status: "DONE"
 priority: "high"
 owner: "CODER"
-revision: 13
+revision: 14
 origin:
   system: "manual"
 depends_on: []
@@ -178,6 +178,19 @@ extensions:
         schemaVersion: 1
         sequence: 2
         stateFingerprintDigest: "sha256:5e362c88611104d9f59676560b63438dc7c884346011447ed081973d853358b3"
+      -
+        actor: "USER"
+        at: "2026-07-28T10:13:45.821Z"
+        authorityDigest: "sha256:5d1fa0490262beb562a0c8ae963de9409e74555793e2ebe63bcc40c945cd09e6"
+        digest: "sha256:4eb9b162968c9322e083ca4feefa9de6e353dc31148966b024680a01892ec85f"
+        operationDigest: "sha256:0bdf8379515b6201cdd404d5094d0b95cf0436940a7a9073c022c0b4bed6d9a8"
+        operationId: "route.remote.refresh"
+        outcome: "approved"
+        policyRule: "workflow.external_reversible"
+        previousDigest: "sha256:d60ed679c2b51d8e6e39c2f32f91d0516191d77c51f97a24e70e6b725a1df70b"
+        schemaVersion: 1
+        sequence: 3
+        stateFingerprintDigest: "sha256:ab660492a48b6745e10b8f1b5c700bf05bfc620cf7f2fbd7644622089f135491"
     grants:
       -
         actor: "USER"
@@ -205,6 +218,19 @@ extensions:
         schemaVersion: 1
         stateFingerprintDigest: "sha256:5e362c88611104d9f59676560b63438dc7c884346011447ed081973d853358b3"
         stateScopeDigest: "sha256:256b4833ef8cc3f131de14d1295804fc082b6db8c3f3188188ab27b74da80005"
+      -
+        actor: "USER"
+        digest: "sha256:5d1fa0490262beb562a0c8ae963de9409e74555793e2ebe63bcc40c945cd09e6"
+        expiresAt: "2026-07-28T10:28:45.821Z"
+        id: "authority-a25a3982-c8e2-41da-8697-1baddbf79034"
+        issuedAt: "2026-07-28T10:13:45.821Z"
+        kind: "side_effect_authority"
+        operationDigest: "sha256:0bdf8379515b6201cdd404d5094d0b95cf0436940a7a9073c022c0b4bed6d9a8"
+        operationId: "route.remote.refresh"
+        policyRule: "workflow.external_reversible"
+        schemaVersion: 1
+        stateFingerprintDigest: "sha256:ab660492a48b6745e10b8f1b5c700bf05bfc620cf7f2fbd7644622089f135491"
+        stateScopeDigest: "sha256:fcf7f804eac8c7c3091e9cbb3a949a36295426ec7bc9d586287c073562d28244"
     schemaVersion: 1
   workflow_route_baseline:
     start_head_sha: "89a82f010479eb2583e414fb49c930d4819b5777"

--- a/.agentplane/tasks/202607280948-N3XC7M/README.md
+++ b/.agentplane/tasks/202607280948-N3XC7M/README.md
@@ -5,7 +5,7 @@ result_summary: "pre-merge closure"
 status: "DONE"
 priority: "high"
 owner: "CODER"
-revision: 15
+revision: 16
 origin:
   system: "manual"
 depends_on: []
@@ -204,6 +204,19 @@ extensions:
         schemaVersion: 1
         sequence: 4
         stateFingerprintDigest: "sha256:7b0b263f6317bcf9a951d41f6f37ec57e587ee40faf3533d8151a5ed225801fa"
+      -
+        actor: "USER"
+        at: "2026-07-28T10:15:56.406Z"
+        authorityDigest: "sha256:c38b68f1a3d152462de88f3a63bbcb2455c532f4738395d78c35701822356bba"
+        digest: "sha256:68907103cfbd9923ecf56d9b7a0ef8308a98a8b84b05ff97a547bde9597d6ce9"
+        operationDigest: "sha256:d44788b5faa2e143375e0a2564793860e1dfb7b1fd9591d3cc2491397bd95ef2"
+        operationId: "integration.enqueue"
+        outcome: "approved"
+        policyRule: "workflow.external_high_risk"
+        previousDigest: "sha256:57dfcd00c0cfb4c206f908f292ca7e4a9eecdc0a299668d74744be12ecc434eb"
+        schemaVersion: 1
+        sequence: 5
+        stateFingerprintDigest: "sha256:6b9d0e003da690f42115b63dbdea5938e050646f65b59f286ea88b306a0dd2cc"
     grants:
       -
         actor: "USER"
@@ -257,6 +270,19 @@ extensions:
         schemaVersion: 1
         stateFingerprintDigest: "sha256:7b0b263f6317bcf9a951d41f6f37ec57e587ee40faf3533d8151a5ed225801fa"
         stateScopeDigest: "sha256:130c63fe1a88ee7452cdf0afe8c6685476ef91f437df5f5c6a2c60525bffa0c2"
+      -
+        actor: "USER"
+        digest: "sha256:c38b68f1a3d152462de88f3a63bbcb2455c532f4738395d78c35701822356bba"
+        expiresAt: "2026-07-28T10:30:56.406Z"
+        id: "authority-4c41d570-910b-465a-aff9-b78ab1deb2f3"
+        issuedAt: "2026-07-28T10:15:56.406Z"
+        kind: "side_effect_authority"
+        operationDigest: "sha256:d44788b5faa2e143375e0a2564793860e1dfb7b1fd9591d3cc2491397bd95ef2"
+        operationId: "integration.enqueue"
+        policyRule: "workflow.external_high_risk"
+        schemaVersion: 1
+        stateFingerprintDigest: "sha256:6b9d0e003da690f42115b63dbdea5938e050646f65b59f286ea88b306a0dd2cc"
+        stateScopeDigest: "sha256:ba1fdca9f7aa058971942c656d7ea19b4ba6840ba104d64aa1e3cfae328fca14"
     schemaVersion: 1
   workflow_route_baseline:
     start_head_sha: "89a82f010479eb2583e414fb49c930d4819b5777"

--- a/.agentplane/tasks/202607280948-N3XC7M/README.md
+++ b/.agentplane/tasks/202607280948-N3XC7M/README.md
@@ -5,7 +5,7 @@ result_summary: "pre-merge closure"
 status: "DONE"
 priority: "high"
 owner: "CODER"
-revision: 14
+revision: 15
 origin:
   system: "manual"
 depends_on: []
@@ -191,6 +191,19 @@ extensions:
         schemaVersion: 1
         sequence: 3
         stateFingerprintDigest: "sha256:ab660492a48b6745e10b8f1b5c700bf05bfc620cf7f2fbd7644622089f135491"
+      -
+        actor: "USER"
+        at: "2026-07-28T10:14:31.323Z"
+        authorityDigest: "sha256:2dfad72f906263c6e8adf746a741034a440633a431fec54ffe20d468ccf61d89"
+        digest: "sha256:57dfcd00c0cfb4c206f908f292ca7e4a9eecdc0a299668d74744be12ecc434eb"
+        operationDigest: "sha256:ad2ed4a40b6c641c579a2ff1bf13a56bc4a0213523400a8145e79e44b306cb4d"
+        operationId: "pr.head.publish"
+        outcome: "approved"
+        policyRule: "workflow.external_reversible"
+        previousDigest: "sha256:4eb9b162968c9322e083ca4feefa9de6e353dc31148966b024680a01892ec85f"
+        schemaVersion: 1
+        sequence: 4
+        stateFingerprintDigest: "sha256:7b0b263f6317bcf9a951d41f6f37ec57e587ee40faf3533d8151a5ed225801fa"
     grants:
       -
         actor: "USER"
@@ -231,6 +244,19 @@ extensions:
         schemaVersion: 1
         stateFingerprintDigest: "sha256:ab660492a48b6745e10b8f1b5c700bf05bfc620cf7f2fbd7644622089f135491"
         stateScopeDigest: "sha256:fcf7f804eac8c7c3091e9cbb3a949a36295426ec7bc9d586287c073562d28244"
+      -
+        actor: "USER"
+        digest: "sha256:2dfad72f906263c6e8adf746a741034a440633a431fec54ffe20d468ccf61d89"
+        expiresAt: "2026-07-28T10:29:31.323Z"
+        id: "authority-91ffafae-20d8-4ac6-ae77-8f652cee690f"
+        issuedAt: "2026-07-28T10:14:31.323Z"
+        kind: "side_effect_authority"
+        operationDigest: "sha256:ad2ed4a40b6c641c579a2ff1bf13a56bc4a0213523400a8145e79e44b306cb4d"
+        operationId: "pr.head.publish"
+        policyRule: "workflow.external_reversible"
+        schemaVersion: 1
+        stateFingerprintDigest: "sha256:7b0b263f6317bcf9a951d41f6f37ec57e587ee40faf3533d8151a5ed225801fa"
+        stateScopeDigest: "sha256:130c63fe1a88ee7452cdf0afe8c6685476ef91f437df5f5c6a2c60525bffa0c2"
     schemaVersion: 1
   workflow_route_baseline:
     start_head_sha: "89a82f010479eb2583e414fb49c930d4819b5777"

--- a/.agentplane/tasks/202607280948-N3XC7M/README.md
+++ b/.agentplane/tasks/202607280948-N3XC7M/README.md
@@ -4,7 +4,7 @@ title: "Retry transient runner cancellation intent reads"
 status: "DOING"
 priority: "high"
 owner: "CODER"
-revision: 7
+revision: 8
 origin:
   system: "manual"
 depends_on: []
@@ -26,11 +26,16 @@ verification:
   updated_by: null
   note: null
   attempts: 0
-commit: null
+commit:
+  hash: "1a49629678f2a08df884ea70aa429ede775151fd"
+  message: "fix: retry runner cancellation intent reads"
 comments:
   -
     author: "CODER"
     body: "Start: continue branch_pr task in the dedicated task worktree."
+  -
+    author: "CODER"
+    body: "Implemented bounded retry for transient cancellation-intent publication collisions; malformed and unsafe reads remain fail-closed. Focused runner tests and typecheck pass; the full fast suite exposed independent teardown timeouts."
 events:
   -
     type: "status"
@@ -39,8 +44,15 @@ events:
     from: "TODO"
     to: "DOING"
     note: "Start: continue branch_pr task in the dedicated task worktree."
+  -
+    type: "status"
+    at: "2026-07-28T10:01:26.764Z"
+    author: "CODER"
+    from: "DOING"
+    to: "DOING"
+    note: "Implemented bounded retry for transient cancellation-intent publication collisions; malformed and unsafe reads remain fail-closed. Focused runner tests and typecheck pass; the full fast suite exposed independent teardown timeouts."
 doc_version: 3
-doc_updated_at: "2026-07-28T09:49:46.640Z"
+doc_updated_at: "2026-07-28T10:01:26.764Z"
 doc_updated_by: "CODER"
 description: "Fix the CI-proven race where an atomically published runner cancellation intent changes during a stable read and is treated as a fatal execution error. Retry only transient immutable-publication collisions, preserve fail-closed behavior for malformed or unsafe records, and add deterministic regression coverage."
 sections:

--- a/.agentplane/tasks/202607280948-N3XC7M/blueprint/resolved-snapshot.json
+++ b/.agentplane/tasks/202607280948-N3XC7M/blueprint/resolved-snapshot.json
@@ -1,0 +1,600 @@
+{
+  "schemaVersion": 1,
+  "artifactKind": "agentplane.blueprint.resolved_snapshot",
+  "resolverInput": {
+    "taskId": "202607280948-N3XC7M",
+    "title": "Retry transient runner cancellation intent reads",
+    "description": "Fix the CI-proven race where an atomically published runner cancellation intent changes during a stable read and is treated as a fatal execution error. Retry only transient immutable-publication collisions, preserve fail-closed behavior for malformed or unsafe records, and add deterministic regression coverage.",
+    "tags": [
+      "code",
+      "runner",
+      "ci",
+      "regression",
+      "v0.7"
+    ],
+    "owner": "CODER",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "mutation": "code",
+    "touchedPaths": [],
+    "recipeHints": [],
+    "riskFlags": []
+  },
+  "selectedBlueprint": {
+    "id": "quality.regression",
+    "version": 1,
+    "title": "Quality regression",
+    "taskKinds": [
+      "code"
+    ],
+    "workflowModes": [
+      "branch_pr"
+    ]
+  },
+  "plan": {
+    "schemaVersion": 1,
+    "blueprintId": "quality.regression",
+    "blueprintVersion": 1,
+    "title": "Quality regression",
+    "taskId": "202607280948-N3XC7M",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "taskIntent": {
+      "mutationScope": "code"
+    },
+    "whySelected": [
+      "specialized code domain resolved to quality.regression",
+      "workflow mode: branch_pr",
+      "mutation scope: code"
+    ],
+    "states": [
+      {
+        "id": "intake",
+        "kind": "intake",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": []
+      },
+      {
+        "id": "scope",
+        "kind": "scope",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "assumptions"
+        ]
+      },
+      {
+        "id": "approval_gate",
+        "kind": "approval_gate",
+        "mode": "approval",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "approval"
+        ]
+      },
+      {
+        "id": "context_resolve",
+        "kind": "context_resolve",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [
+          ".agentplane/policy/security.must.md",
+          ".agentplane/policy/dod.core.md",
+          ".agentplane/policy/dod.code.md",
+          ".agentplane/policy/workflow.branch_pr.md"
+        ],
+        "evidenceKinds": [
+          "context_manifest",
+          "artifact"
+        ]
+      },
+      {
+        "id": "worktree_start",
+        "kind": "worktree_start",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "work_unit",
+        "kind": "work_unit",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths",
+          "check_result"
+        ]
+      },
+      {
+        "id": "fast_local_checks",
+        "kind": "fast_local_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane task verify-show <task-id>",
+          "project focused checks"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "pr_artifact",
+        "kind": "pr_artifact",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "artifact",
+          "external_link"
+        ]
+      },
+      {
+        "id": "verify_record",
+        "kind": "verify_record",
+        "mode": "record",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result",
+          "weak_links"
+        ]
+      },
+      {
+        "id": "quality_gate",
+        "kind": "quality_gate",
+        "mode": "agentic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane evaluator run <task-id> --provenance human_supplied|evaluator_supplied --verdict pass|rework|blocked|human_review"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "quality_report"
+        ]
+      },
+      {
+        "id": "hosted_checks",
+        "kind": "hosted_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result",
+          "external_link"
+        ]
+      },
+      {
+        "id": "publish_or_integrate",
+        "kind": "publish_or_integrate",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane integrate <task-id> --branch <branch> --run-verify"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit",
+          "external_link"
+        ]
+      },
+      {
+        "id": "finish",
+        "kind": "finish",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit"
+        ]
+      }
+    ],
+    "requiredEvidence": [
+      {
+        "id": "regression.original_failure",
+        "kind": "artifact",
+        "producedBy": "context_resolve",
+        "required": true,
+        "description": "Original failure log or check output."
+      },
+      {
+        "id": "regression.reproduction",
+        "kind": "check_result",
+        "producedBy": "work_unit",
+        "required": true,
+        "description": "Local reproduction or explicit non-reproduction result."
+      },
+      {
+        "id": "regression.focused_check",
+        "kind": "check_result",
+        "producedBy": "fast_local_checks",
+        "required": true,
+        "description": "Focused regression check."
+      },
+      {
+        "id": "regression.matrix_or_scope",
+        "kind": "assumptions",
+        "producedBy": "scope",
+        "required": true,
+        "description": "Affected test/check matrix or bounded scope."
+      },
+      {
+        "id": "regression.full_gate",
+        "kind": "check_result",
+        "producedBy": "hosted_checks",
+        "required": true,
+        "description": "Full relevant gate or hosted check evidence."
+      },
+      {
+        "id": "regression.flake_classification",
+        "kind": "weak_links",
+        "producedBy": "verify_record",
+        "required": true,
+        "description": "Flake classification or residual risk."
+      },
+      {
+        "id": "regression.quality",
+        "kind": "quality_report",
+        "producedBy": "quality_gate",
+        "required": true,
+        "description": "EVALUATOR quality verdict."
+      },
+      {
+        "id": "regression.commit",
+        "kind": "commit",
+        "producedBy": "publish_or_integrate",
+        "required": true,
+        "description": "Integration commit."
+      }
+    ],
+    "policyModules": [
+      ".agentplane/policy/dod.code.md",
+      ".agentplane/policy/dod.core.md",
+      ".agentplane/policy/security.must.md",
+      ".agentplane/policy/workflow.branch_pr.md"
+    ],
+    "allowedCommands": [
+      "affected matrix or full relevant gate",
+      "agentplane evaluator run <task-id> --provenance human_supplied|evaluator_supplied --verdict pass|rework|blocked|human_review",
+      "agentplane integrate <task-id> --branch <branch> --run-verify",
+      "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+      "agentplane task verify-show <task-id>",
+      "agentplane verify <task-id> --ok|--rework",
+      "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+      "failure reproduction command",
+      "focused regression check",
+      "project focused checks"
+    ],
+    "contextBudget": {
+      "maxPolicyModules": 4,
+      "maxPromptBlocks": 16,
+      "rationale": "Regression work needs failure evidence, focused reproduction, and the relevant quality gate."
+    },
+    "contextManifest": [],
+    "acceptedRecipeExtensions": [],
+    "rejectedRecipeExtensions": [],
+    "stopReasons": []
+  },
+  "nodes": [
+    {
+      "id": "intake",
+      "kind": "intake",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": []
+    },
+    {
+      "id": "scope",
+      "kind": "scope",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "assumptions"
+      ]
+    },
+    {
+      "id": "approval_gate",
+      "kind": "approval_gate",
+      "mode": "approval",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "approval"
+      ]
+    },
+    {
+      "id": "context_resolve",
+      "kind": "context_resolve",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [
+        ".agentplane/policy/security.must.md",
+        ".agentplane/policy/dod.core.md",
+        ".agentplane/policy/dod.code.md",
+        ".agentplane/policy/workflow.branch_pr.md"
+      ],
+      "evidenceKinds": [
+        "context_manifest",
+        "artifact"
+      ]
+    },
+    {
+      "id": "worktree_start",
+      "kind": "worktree_start",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "work_unit",
+      "kind": "work_unit",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths",
+        "check_result"
+      ]
+    },
+    {
+      "id": "fast_local_checks",
+      "kind": "fast_local_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane task verify-show <task-id>",
+        "project focused checks"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "pr_artifact",
+      "kind": "pr_artifact",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "artifact",
+        "external_link"
+      ]
+    },
+    {
+      "id": "verify_record",
+      "kind": "verify_record",
+      "mode": "record",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result",
+        "weak_links"
+      ]
+    },
+    {
+      "id": "quality_gate",
+      "kind": "quality_gate",
+      "mode": "agentic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane evaluator run <task-id> --provenance human_supplied|evaluator_supplied --verdict pass|rework|blocked|human_review"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "quality_report"
+      ]
+    },
+    {
+      "id": "hosted_checks",
+      "kind": "hosted_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result",
+        "external_link"
+      ]
+    },
+    {
+      "id": "publish_or_integrate",
+      "kind": "publish_or_integrate",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane integrate <task-id> --branch <branch> --run-verify"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit",
+        "external_link"
+      ]
+    },
+    {
+      "id": "finish",
+      "kind": "finish",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit"
+      ]
+    }
+  ],
+  "requiredEvidence": [
+    {
+      "id": "regression.original_failure",
+      "kind": "artifact",
+      "producedBy": "context_resolve",
+      "required": true,
+      "description": "Original failure log or check output."
+    },
+    {
+      "id": "regression.reproduction",
+      "kind": "check_result",
+      "producedBy": "work_unit",
+      "required": true,
+      "description": "Local reproduction or explicit non-reproduction result."
+    },
+    {
+      "id": "regression.focused_check",
+      "kind": "check_result",
+      "producedBy": "fast_local_checks",
+      "required": true,
+      "description": "Focused regression check."
+    },
+    {
+      "id": "regression.matrix_or_scope",
+      "kind": "assumptions",
+      "producedBy": "scope",
+      "required": true,
+      "description": "Affected test/check matrix or bounded scope."
+    },
+    {
+      "id": "regression.full_gate",
+      "kind": "check_result",
+      "producedBy": "hosted_checks",
+      "required": true,
+      "description": "Full relevant gate or hosted check evidence."
+    },
+    {
+      "id": "regression.flake_classification",
+      "kind": "weak_links",
+      "producedBy": "verify_record",
+      "required": true,
+      "description": "Flake classification or residual risk."
+    },
+    {
+      "id": "regression.quality",
+      "kind": "quality_report",
+      "producedBy": "quality_gate",
+      "required": true,
+      "description": "EVALUATOR quality verdict."
+    },
+    {
+      "id": "regression.commit",
+      "kind": "commit",
+      "producedBy": "publish_or_integrate",
+      "required": true,
+      "description": "Integration commit."
+    }
+  ],
+  "policyModules": [
+    ".agentplane/policy/dod.code.md",
+    ".agentplane/policy/dod.core.md",
+    ".agentplane/policy/security.must.md",
+    ".agentplane/policy/workflow.branch_pr.md"
+  ],
+  "allowedCommands": [
+    "affected matrix or full relevant gate",
+    "agentplane evaluator run <task-id> --provenance human_supplied|evaluator_supplied --verdict pass|rework|blocked|human_review",
+    "agentplane integrate <task-id> --branch <branch> --run-verify",
+    "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+    "agentplane task verify-show <task-id>",
+    "agentplane verify <task-id> --ok|--rework",
+    "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+    "failure reproduction command",
+    "focused regression check",
+    "project focused checks"
+  ],
+  "contextBudget": {
+    "maxPolicyModules": 4,
+    "maxPromptBlocks": 16,
+    "rationale": "Regression work needs failure evidence, focused reproduction, and the relevant quality gate."
+  },
+  "contextManifest": [],
+  "acceptedRecipeExtensions": [],
+  "rejectedRecipeExtensions": [],
+  "stopReasons": [],
+  "selectionReasons": [
+    "specialized code domain resolved to quality.regression",
+    "workflow mode: branch_pr",
+    "mutation scope: code"
+  ],
+  "digest": {
+    "algorithm": "sha256",
+    "value": "33b37b14eb7897fb73d306e273fed82660d2b30131380aade76e26cb77d2c31f"
+  }
+}

--- a/.agentplane/tasks/202607280948-N3XC7M/pr/diffstat.txt
+++ b/.agentplane/tasks/202607280948-N3XC7M/pr/diffstat.txt
@@ -1,0 +1,3 @@
+ .../src/runner/adapters/execution-control.test.ts  | 69 +++++++++++++++++++++-
+ .../src/runner/adapters/execution-control.ts       | 40 +++++++++----
+ 2 files changed, 97 insertions(+), 12 deletions(-)

--- a/.agentplane/tasks/202607280948-N3XC7M/pr/github-body.md
+++ b/.agentplane/tasks/202607280948-N3XC7M/pr/github-body.md
@@ -1,0 +1,33 @@
+Task: `202607280948-N3XC7M`
+Title: Retry transient runner cancellation intent reads
+Canonical task record: `.agentplane/tasks/202607280948-N3XC7M/README.md`
+
+## Summary
+
+Retry transient runner cancellation intent reads
+
+Fix the CI-proven race where an atomically published runner cancellation intent changes during a stable read and is treated as a fatal execution error. Retry only transient immutable-publication collisions, preserve fail-closed behavior for malformed or unsafe records, and add deterministic regression coverage.
+
+## Scope
+
+- In scope: Fix the CI-proven race where an atomically published runner cancellation intent changes during a stable read and is treated as a fatal execution error. Retry only transient immutable-publication collisions, preserve fail-closed behavior for malformed or unsafe records, and add deterministic regression coverage.
+- Out of scope: unrelated refactors not required for "Retry transient runner cancellation intent reads".
+
+## Verification
+
+- State: pending
+- Note: Not recorded yet.
+- Canonical workflow state lives in the task README.
+
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-07-28T09:49:46.757Z
+- Branch: task/202607280948-N3XC7M/retry-transient-runner-cancellation-intent-reads
+- Head: computed live by `agentplane pr check` / `agentplane integrate`
+
+```text
+No changes detected.
+```
+
+</details>

--- a/.agentplane/tasks/202607280948-N3XC7M/pr/github-body.md
+++ b/.agentplane/tasks/202607280948-N3XC7M/pr/github-body.md
@@ -15,19 +15,27 @@ Fix the CI-proven race where an atomically published runner cancellation intent 
 
 ## Verification
 
-- State: pending
-- Note: Not recorded yet.
+- State: ok
+- Note:
+
+```text
+The cancellation-intent regression, impacted runner files, typecheck, formatting, and diff checks
+pass. The local all-project fast run failed only in unrelated parallel teardown timeouts; hosted CI
+remains the merge gate.
+```
 - Canonical workflow state lives in the task README.
 
 <details>
 <summary>Raw evidence</summary>
 
-- Updated: 2026-07-28T09:49:46.757Z
+- Updated: 2026-07-28T09:51:06.067Z
 - Branch: task/202607280948-N3XC7M/retry-transient-runner-cancellation-intent-reads
 - Head: computed live by `agentplane pr check` / `agentplane integrate`
 
 ```text
-No changes detected.
+ .../src/runner/adapters/execution-control.test.ts  | 69 +++++++++++++++++++++-
+ .../src/runner/adapters/execution-control.ts       | 40 +++++++++----
+ 2 files changed, 97 insertions(+), 12 deletions(-)
 ```
 
 </details>

--- a/.agentplane/tasks/202607280948-N3XC7M/pr/github-title.txt
+++ b/.agentplane/tasks/202607280948-N3XC7M/pr/github-title.txt
@@ -1,1 +1,1 @@
-🚧 N3XC7M task: Retry transient runner cancellation intent reads [202607280948-N3XC7M]
+✅ N3XC7M task: Retry transient runner cancellation intent reads [202607280948-N3XC7M]

--- a/.agentplane/tasks/202607280948-N3XC7M/pr/github-title.txt
+++ b/.agentplane/tasks/202607280948-N3XC7M/pr/github-title.txt
@@ -1,0 +1,1 @@
+🚧 N3XC7M task: Retry transient runner cancellation intent reads [202607280948-N3XC7M]

--- a/.agentplane/tasks/202607280948-N3XC7M/pr/meta.json
+++ b/.agentplane/tasks/202607280948-N3XC7M/pr/meta.json
@@ -4,9 +4,12 @@
   "created_at": "2026-07-28T09:49:46.757Z",
   "diffstat_sha256": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
   "last_verified_at": null,
+  "pr_number": 4656,
+  "pr_url": "https://github.com/basilisk-labs/agentplane/pull/4656",
   "schema_version": 1,
+  "status": "OPEN",
   "task_id": "202607280948-N3XC7M",
-  "updated_at": "2026-07-28T09:49:46.757Z",
+  "updated_at": "2026-07-28T09:51:06.067Z",
   "verify": {
     "status": "skipped"
   }

--- a/.agentplane/tasks/202607280948-N3XC7M/pr/meta.json
+++ b/.agentplane/tasks/202607280948-N3XC7M/pr/meta.json
@@ -2,15 +2,23 @@
   "base": "main",
   "branch": "task/202607280948-N3XC7M/retry-transient-runner-cancellation-intent-reads",
   "created_at": "2026-07-28T09:49:46.757Z",
-  "diffstat_sha256": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-  "last_verified_at": null,
+  "diffstat_sha256": "sha256:e60f3ea0c356c3bfbb8ea5a3de2db40469761282b4dfc78e8f53f11d01050521",
+  "last_verified_at": "2026-07-28T10:06:31.424Z",
+  "last_verified_diffstat_sha256": "sha256:e60f3ea0c356c3bfbb8ea5a3de2db40469761282b4dfc78e8f53f11d01050521",
   "pr_number": 4656,
   "pr_url": "https://github.com/basilisk-labs/agentplane/pull/4656",
+  "pre_merge_closure": {
+    "basis_commit": "a224a862c0ba75d09060d1a6b1301005ca6a5173",
+    "branch": "task/202607280948-N3XC7M/retry-transient-runner-cancellation-intent-reads",
+    "pr_number": 4656,
+    "recorded_at": "2026-07-28T10:10:59.665Z",
+    "state": "closed_before_merge"
+  },
   "schema_version": 1,
   "status": "OPEN",
   "task_id": "202607280948-N3XC7M",
   "updated_at": "2026-07-28T09:51:06.067Z",
   "verify": {
-    "status": "skipped"
+    "status": "pass"
   }
 }

--- a/.agentplane/tasks/202607280948-N3XC7M/pr/meta.json
+++ b/.agentplane/tasks/202607280948-N3XC7M/pr/meta.json
@@ -1,0 +1,13 @@
+{
+  "base": "main",
+  "branch": "task/202607280948-N3XC7M/retry-transient-runner-cancellation-intent-reads",
+  "created_at": "2026-07-28T09:49:46.757Z",
+  "diffstat_sha256": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "last_verified_at": null,
+  "schema_version": 1,
+  "task_id": "202607280948-N3XC7M",
+  "updated_at": "2026-07-28T09:49:46.757Z",
+  "verify": {
+    "status": "skipped"
+  }
+}

--- a/.agentplane/tasks/202607280948-N3XC7M/pr/review.md
+++ b/.agentplane/tasks/202607280948-N3XC7M/pr/review.md
@@ -6,7 +6,7 @@ Created: 2026-07-28T09:49:46.757Z
 
 - Task: `202607280948-N3XC7M`
 - Title: Retry transient runner cancellation intent reads
-- Status: DOING
+- Status: DONE
 - Branch: `task/202607280948-N3XC7M/retry-transient-runner-cancellation-intent-reads`
 - Canonical task record: `.agentplane/tasks/202607280948-N3XC7M/README.md`
 

--- a/.agentplane/tasks/202607280948-N3XC7M/pr/review.md
+++ b/.agentplane/tasks/202607280948-N3XC7M/pr/review.md
@@ -12,8 +12,8 @@ Created: 2026-07-28T09:49:46.757Z
 
 ## Verification
 
-- State: pending
-- Note: Not recorded yet.
+- State: ok
+- Note: The cancellation-intent regression, impacted runner files, typecheck, formatting, and diff checks pass. The local all-project fast run failed only in unrelated parallel teardown timeouts; hosted CI remains the merge gate.
 - Canonical workflow state lives in the task README.
 
 ## Handoff Notes
@@ -24,12 +24,14 @@ Created: 2026-07-28T09:49:46.757Z
 <details>
 <summary>Raw evidence</summary>
 
-- Updated: 2026-07-28T09:49:46.757Z
+- Updated: 2026-07-28T09:51:06.067Z
 - Branch: task/202607280948-N3XC7M/retry-transient-runner-cancellation-intent-reads
 - Head: computed live by `agentplane pr check` / `agentplane integrate`
 
 ```text
-No changes detected.
+ .../src/runner/adapters/execution-control.test.ts  | 69 +++++++++++++++++++++-
+ .../src/runner/adapters/execution-control.ts       | 40 +++++++++----
+ 2 files changed, 97 insertions(+), 12 deletions(-)
 ```
 
 </details>

--- a/.agentplane/tasks/202607280948-N3XC7M/pr/review.md
+++ b/.agentplane/tasks/202607280948-N3XC7M/pr/review.md
@@ -1,0 +1,36 @@
+# PR Review
+
+Created: 2026-07-28T09:49:46.757Z
+
+## Task
+
+- Task: `202607280948-N3XC7M`
+- Title: Retry transient runner cancellation intent reads
+- Status: DOING
+- Branch: `task/202607280948-N3XC7M/retry-transient-runner-cancellation-intent-reads`
+- Canonical task record: `.agentplane/tasks/202607280948-N3XC7M/README.md`
+
+## Verification
+
+- State: pending
+- Note: Not recorded yet.
+- Canonical workflow state lives in the task README.
+
+## Handoff Notes
+
+- No handoff notes recorded yet. Use `agentplane pr note ...` to append one.
+
+<!-- BEGIN AUTO SUMMARY -->
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-07-28T09:49:46.757Z
+- Branch: task/202607280948-N3XC7M/retry-transient-runner-cancellation-intent-reads
+- Head: computed live by `agentplane pr check` / `agentplane integrate`
+
+```text
+No changes detected.
+```
+
+</details>
+<!-- END AUTO SUMMARY -->

--- a/.agentplane/tasks/202607280948-N3XC7M/quality/20260728-100701613-recovery-context/evaluator-blueprint.json
+++ b/.agentplane/tasks/202607280948-N3XC7M/quality/20260728-100701613-recovery-context/evaluator-blueprint.json
@@ -1,0 +1,600 @@
+{
+  "schemaVersion": 1,
+  "artifactKind": "agentplane.blueprint.resolved_snapshot",
+  "resolverInput": {
+    "taskId": "202607280948-N3XC7M",
+    "title": "Retry transient runner cancellation intent reads",
+    "description": "Fix the CI-proven race where an atomically published runner cancellation intent changes during a stable read and is treated as a fatal execution error. Retry only transient immutable-publication collisions, preserve fail-closed behavior for malformed or unsafe records, and add deterministic regression coverage.",
+    "tags": [
+      "code",
+      "runner",
+      "ci",
+      "regression",
+      "v0.7"
+    ],
+    "owner": "CODER",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "mutation": "code",
+    "touchedPaths": [],
+    "recipeHints": [],
+    "riskFlags": []
+  },
+  "selectedBlueprint": {
+    "id": "quality.regression",
+    "version": 1,
+    "title": "Quality regression",
+    "taskKinds": [
+      "code"
+    ],
+    "workflowModes": [
+      "branch_pr"
+    ]
+  },
+  "plan": {
+    "schemaVersion": 1,
+    "blueprintId": "quality.regression",
+    "blueprintVersion": 1,
+    "title": "Quality regression",
+    "taskId": "202607280948-N3XC7M",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "taskIntent": {
+      "mutationScope": "code"
+    },
+    "whySelected": [
+      "specialized code domain resolved to quality.regression",
+      "workflow mode: branch_pr",
+      "mutation scope: code"
+    ],
+    "states": [
+      {
+        "id": "intake",
+        "kind": "intake",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": []
+      },
+      {
+        "id": "scope",
+        "kind": "scope",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "assumptions"
+        ]
+      },
+      {
+        "id": "approval_gate",
+        "kind": "approval_gate",
+        "mode": "approval",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "approval"
+        ]
+      },
+      {
+        "id": "context_resolve",
+        "kind": "context_resolve",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [
+          ".agentplane/policy/security.must.md",
+          ".agentplane/policy/dod.core.md",
+          ".agentplane/policy/dod.code.md",
+          ".agentplane/policy/workflow.branch_pr.md"
+        ],
+        "evidenceKinds": [
+          "context_manifest",
+          "artifact"
+        ]
+      },
+      {
+        "id": "worktree_start",
+        "kind": "worktree_start",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "work_unit",
+        "kind": "work_unit",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths",
+          "check_result"
+        ]
+      },
+      {
+        "id": "fast_local_checks",
+        "kind": "fast_local_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane task verify-show <task-id>",
+          "project focused checks"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "pr_artifact",
+        "kind": "pr_artifact",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "artifact",
+          "external_link"
+        ]
+      },
+      {
+        "id": "verify_record",
+        "kind": "verify_record",
+        "mode": "record",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result",
+          "weak_links"
+        ]
+      },
+      {
+        "id": "quality_gate",
+        "kind": "quality_gate",
+        "mode": "agentic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane evaluator run <task-id> --provenance human_supplied|evaluator_supplied --verdict pass|rework|blocked|human_review"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "quality_report"
+        ]
+      },
+      {
+        "id": "hosted_checks",
+        "kind": "hosted_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result",
+          "external_link"
+        ]
+      },
+      {
+        "id": "publish_or_integrate",
+        "kind": "publish_or_integrate",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane integrate <task-id> --branch <branch> --run-verify"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit",
+          "external_link"
+        ]
+      },
+      {
+        "id": "finish",
+        "kind": "finish",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit"
+        ]
+      }
+    ],
+    "requiredEvidence": [
+      {
+        "id": "regression.original_failure",
+        "kind": "artifact",
+        "producedBy": "context_resolve",
+        "required": true,
+        "description": "Original failure log or check output."
+      },
+      {
+        "id": "regression.reproduction",
+        "kind": "check_result",
+        "producedBy": "work_unit",
+        "required": true,
+        "description": "Local reproduction or explicit non-reproduction result."
+      },
+      {
+        "id": "regression.focused_check",
+        "kind": "check_result",
+        "producedBy": "fast_local_checks",
+        "required": true,
+        "description": "Focused regression check."
+      },
+      {
+        "id": "regression.matrix_or_scope",
+        "kind": "assumptions",
+        "producedBy": "scope",
+        "required": true,
+        "description": "Affected test/check matrix or bounded scope."
+      },
+      {
+        "id": "regression.full_gate",
+        "kind": "check_result",
+        "producedBy": "hosted_checks",
+        "required": true,
+        "description": "Full relevant gate or hosted check evidence."
+      },
+      {
+        "id": "regression.flake_classification",
+        "kind": "weak_links",
+        "producedBy": "verify_record",
+        "required": true,
+        "description": "Flake classification or residual risk."
+      },
+      {
+        "id": "regression.quality",
+        "kind": "quality_report",
+        "producedBy": "quality_gate",
+        "required": true,
+        "description": "EVALUATOR quality verdict."
+      },
+      {
+        "id": "regression.commit",
+        "kind": "commit",
+        "producedBy": "publish_or_integrate",
+        "required": true,
+        "description": "Integration commit."
+      }
+    ],
+    "policyModules": [
+      ".agentplane/policy/dod.code.md",
+      ".agentplane/policy/dod.core.md",
+      ".agentplane/policy/security.must.md",
+      ".agentplane/policy/workflow.branch_pr.md"
+    ],
+    "allowedCommands": [
+      "affected matrix or full relevant gate",
+      "agentplane evaluator run <task-id> --provenance human_supplied|evaluator_supplied --verdict pass|rework|blocked|human_review",
+      "agentplane integrate <task-id> --branch <branch> --run-verify",
+      "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+      "agentplane task verify-show <task-id>",
+      "agentplane verify <task-id> --ok|--rework",
+      "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+      "failure reproduction command",
+      "focused regression check",
+      "project focused checks"
+    ],
+    "contextBudget": {
+      "maxPolicyModules": 4,
+      "maxPromptBlocks": 16,
+      "rationale": "Regression work needs failure evidence, focused reproduction, and the relevant quality gate."
+    },
+    "contextManifest": [],
+    "acceptedRecipeExtensions": [],
+    "rejectedRecipeExtensions": [],
+    "stopReasons": []
+  },
+  "nodes": [
+    {
+      "id": "intake",
+      "kind": "intake",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": []
+    },
+    {
+      "id": "scope",
+      "kind": "scope",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "assumptions"
+      ]
+    },
+    {
+      "id": "approval_gate",
+      "kind": "approval_gate",
+      "mode": "approval",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "approval"
+      ]
+    },
+    {
+      "id": "context_resolve",
+      "kind": "context_resolve",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [
+        ".agentplane/policy/security.must.md",
+        ".agentplane/policy/dod.core.md",
+        ".agentplane/policy/dod.code.md",
+        ".agentplane/policy/workflow.branch_pr.md"
+      ],
+      "evidenceKinds": [
+        "context_manifest",
+        "artifact"
+      ]
+    },
+    {
+      "id": "worktree_start",
+      "kind": "worktree_start",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "work_unit",
+      "kind": "work_unit",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths",
+        "check_result"
+      ]
+    },
+    {
+      "id": "fast_local_checks",
+      "kind": "fast_local_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane task verify-show <task-id>",
+        "project focused checks"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "pr_artifact",
+      "kind": "pr_artifact",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "artifact",
+        "external_link"
+      ]
+    },
+    {
+      "id": "verify_record",
+      "kind": "verify_record",
+      "mode": "record",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result",
+        "weak_links"
+      ]
+    },
+    {
+      "id": "quality_gate",
+      "kind": "quality_gate",
+      "mode": "agentic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane evaluator run <task-id> --provenance human_supplied|evaluator_supplied --verdict pass|rework|blocked|human_review"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "quality_report"
+      ]
+    },
+    {
+      "id": "hosted_checks",
+      "kind": "hosted_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result",
+        "external_link"
+      ]
+    },
+    {
+      "id": "publish_or_integrate",
+      "kind": "publish_or_integrate",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane integrate <task-id> --branch <branch> --run-verify"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit",
+        "external_link"
+      ]
+    },
+    {
+      "id": "finish",
+      "kind": "finish",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit"
+      ]
+    }
+  ],
+  "requiredEvidence": [
+    {
+      "id": "regression.original_failure",
+      "kind": "artifact",
+      "producedBy": "context_resolve",
+      "required": true,
+      "description": "Original failure log or check output."
+    },
+    {
+      "id": "regression.reproduction",
+      "kind": "check_result",
+      "producedBy": "work_unit",
+      "required": true,
+      "description": "Local reproduction or explicit non-reproduction result."
+    },
+    {
+      "id": "regression.focused_check",
+      "kind": "check_result",
+      "producedBy": "fast_local_checks",
+      "required": true,
+      "description": "Focused regression check."
+    },
+    {
+      "id": "regression.matrix_or_scope",
+      "kind": "assumptions",
+      "producedBy": "scope",
+      "required": true,
+      "description": "Affected test/check matrix or bounded scope."
+    },
+    {
+      "id": "regression.full_gate",
+      "kind": "check_result",
+      "producedBy": "hosted_checks",
+      "required": true,
+      "description": "Full relevant gate or hosted check evidence."
+    },
+    {
+      "id": "regression.flake_classification",
+      "kind": "weak_links",
+      "producedBy": "verify_record",
+      "required": true,
+      "description": "Flake classification or residual risk."
+    },
+    {
+      "id": "regression.quality",
+      "kind": "quality_report",
+      "producedBy": "quality_gate",
+      "required": true,
+      "description": "EVALUATOR quality verdict."
+    },
+    {
+      "id": "regression.commit",
+      "kind": "commit",
+      "producedBy": "publish_or_integrate",
+      "required": true,
+      "description": "Integration commit."
+    }
+  ],
+  "policyModules": [
+    ".agentplane/policy/dod.code.md",
+    ".agentplane/policy/dod.core.md",
+    ".agentplane/policy/security.must.md",
+    ".agentplane/policy/workflow.branch_pr.md"
+  ],
+  "allowedCommands": [
+    "affected matrix or full relevant gate",
+    "agentplane evaluator run <task-id> --provenance human_supplied|evaluator_supplied --verdict pass|rework|blocked|human_review",
+    "agentplane integrate <task-id> --branch <branch> --run-verify",
+    "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+    "agentplane task verify-show <task-id>",
+    "agentplane verify <task-id> --ok|--rework",
+    "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+    "failure reproduction command",
+    "focused regression check",
+    "project focused checks"
+  ],
+  "contextBudget": {
+    "maxPolicyModules": 4,
+    "maxPromptBlocks": 16,
+    "rationale": "Regression work needs failure evidence, focused reproduction, and the relevant quality gate."
+  },
+  "contextManifest": [],
+  "acceptedRecipeExtensions": [],
+  "rejectedRecipeExtensions": [],
+  "stopReasons": [],
+  "selectionReasons": [
+    "specialized code domain resolved to quality.regression",
+    "workflow mode: branch_pr",
+    "mutation scope: code"
+  ],
+  "digest": {
+    "algorithm": "sha256",
+    "value": "33b37b14eb7897fb73d306e273fed82660d2b30131380aade76e26cb77d2c31f"
+  }
+}

--- a/.agentplane/tasks/202607280948-N3XC7M/quality/20260728-100701613-recovery-context/evaluator-diff.patch
+++ b/.agentplane/tasks/202607280948-N3XC7M/quality/20260728-100701613-recovery-context/evaluator-diff.patch
@@ -1,0 +1,175 @@
+diff --git a/.agentplane/tasks/202607280948-N3XC7M/pr/meta.json b/.agentplane/tasks/202607280948-N3XC7M/pr/meta.json
+index 370b616b6..3604bddad 100644
+--- a/.agentplane/tasks/202607280948-N3XC7M/pr/meta.json
++++ b/.agentplane/tasks/202607280948-N3XC7M/pr/meta.json
+@@ -4,9 +4,12 @@
+   "created_at": "2026-07-28T09:49:46.757Z",
+   "diffstat_sha256": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+   "last_verified_at": null,
++  "pr_number": 4656,
++  "pr_url": "https://github.com/basilisk-labs/agentplane/pull/4656",
+   "schema_version": 1,
++  "status": "OPEN",
+   "task_id": "202607280948-N3XC7M",
+-  "updated_at": "2026-07-28T09:49:46.757Z",
++  "updated_at": "2026-07-28T09:51:06.067Z",
+   "verify": {
+     "status": "skipped"
+   }
+diff --git a/packages/agentplane/src/runner/adapters/execution-control.test.ts b/packages/agentplane/src/runner/adapters/execution-control.test.ts
+index 18d1f091f..e2a942fbf 100644
+--- a/packages/agentplane/src/runner/adapters/execution-control.test.ts
++++ b/packages/agentplane/src/runner/adapters/execution-control.test.ts
+@@ -2,16 +2,22 @@ import { mkdir, mkdtemp, rm } from "node:fs/promises";
+ import os from "node:os";
+ import path from "node:path";
+ 
+-import { afterEach, describe, expect, it } from "vitest";
++import { afterEach, describe, expect, it, vi } from "vitest";
+ 
+ import type { RunnerInvocation } from "../types.js";
++import * as stableFile from "../stable-file.js";
+ 
+-import { claimRunnerPreSpawnDecision } from "./execution-control.js";
++import {
++  claimRunnerPreSpawnDecision,
++  publishRunnerCancellationIntent,
++  readRunnerCancellationIntent,
++} from "./execution-control.js";
+ 
+ describe("runner immutable execution control", () => {
+   let tempDir = "";
+ 
+   afterEach(async () => {
++    vi.restoreAllMocks();
+     if (tempDir) await rm(tempDir, { recursive: true, force: true });
+     tempDir = "";
+   });
+@@ -86,4 +92,63 @@ describe("runner immutable execution control", () => {
+     expect(retry.won).toBe(false);
+     expect(retry.record).toEqual(published.record);
+   });
++
++  it("retries a transient cancellation-intent publication collision", async () => {
++    tempDir = await mkdtemp(path.join(os.tmpdir(), "agentplane-execution-control-"));
++    const runDir = path.join(tempDir, "run");
++    await mkdir(runDir);
++    const invocation = {
++      adapter_id: "custom",
++      run_id: "run-cancellation-intent-read-collision",
++      work_order_id: "run-cancellation-intent-read-collision",
++      repository_root: tempDir,
++      run_dir: runDir,
++      bundle_path: path.join(runDir, "bundle.json"),
++      state_path: path.join(runDir, "run-state.json"),
++      events_path: path.join(runDir, "events.jsonl"),
++      result_path: path.join(runDir, "result.json"),
++      receipt_path: path.join(runDir, "receipt.json"),
++      trace_path: path.join(runDir, "trace.jsonl"),
++      stderr_path: path.join(runDir, "stderr.log"),
++      trace_policy: {
++        mode: "raw",
++        max_tail_bytes: 1024,
++        capture_stderr: true,
++      },
++      timeout_policy: {
++        wall_clock_ms: 1000,
++        idle_ms: 1000,
++        terminate_grace_ms: 100,
++      },
++      argv: ["runner"],
++      env: {},
++      dry_run: false,
++    } as RunnerInvocation;
++    const published = await publishRunnerCancellationIntent({
++      invocation,
++      requested_at: "2026-07-28T09:52:00.000Z",
++      signal: "SIGTERM",
++    });
++    const originalRead = stableFile.readStableRegularTextNoFollow;
++    let cancellationIntentReadCount = 0;
++    vi.spyOn(stableFile, "readStableRegularTextNoFollow").mockImplementation(async (...args) => {
++      if (args[1] === "runner cancellation intent") {
++        cancellationIntentReadCount += 1;
++        if (cancellationIntentReadCount === 1) {
++          throw new Error(`runner cancellation intent changed before it could be read: ${args[0]}`);
++        }
++      }
++      return await originalRead(...args);
++    });
++    const observed = await readRunnerCancellationIntent(invocation);
++
++    expect(published.won).toBe(true);
++    expect(cancellationIntentReadCount).toBe(2);
++    expect(observed).toEqual({
++      schema_version: 1,
++      run_id: invocation.run_id,
++      requested_at: "2026-07-28T09:52:00.000Z",
++      signal: "SIGTERM",
++    });
++  });
+ });
+diff --git a/packages/agentplane/src/runner/adapters/execution-control.ts b/packages/agentplane/src/runner/adapters/execution-control.ts
+index 34ad38171..8f47e68fc 100644
+--- a/packages/agentplane/src/runner/adapters/execution-control.ts
++++ b/packages/agentplane/src/runner/adapters/execution-control.ts
+@@ -18,6 +18,7 @@ const RUNNER_PRE_SPAWN_DECISION_FILENAME = ".runner-pre-spawn-decision.json";
+ const RUNNER_CHILD_SPAWN_CLAIM_FILENAME = ".runner-child-spawn-claim.json";
+ const RUNNER_CANCELLATION_INTENT_FILENAME = ".runner-cancellation-intent.json";
+ const DEFAULT_START_OWNER_LEASE_MS = 3000;
++const CANCELLATION_INTENT_READ_ATTEMPTS = 4;
+ 
+ export type RunnerStartOwnerLease = {
+   owner_id: string;
+@@ -135,6 +136,16 @@ function parseRunnerChildSpawnClaim(raw: string, expectedRunId: string): RunnerC
+   return parsed as RunnerChildSpawnClaim;
+ }
+ 
++function isTransientCancellationIntentReadCollision(error: unknown): boolean {
++  const message = error instanceof Error ? error.message : String(error);
++  return (
++    message.startsWith("runner cancellation intent ") &&
++    (message.includes(" changed before it could be read:") ||
++      message.includes(" changed while it was being read:") ||
++      message.includes(" path changed while it was being read:"))
++  );
++}
++
+ async function publishImmutableRunnerControlRecord<T>(opts: {
+   run_dir: string;
+   filename: string;
+@@ -351,15 +362,24 @@ export async function readRunnerCancellationIntent(
+   invocation: RunnerInvocation,
+ ): Promise<RunnerCancellationIntent | null> {
+   const intentPath = path.join(invocation.run_dir, RUNNER_CANCELLATION_INTENT_FILENAME);
+-  try {
+-    return parseRunnerCancellationIntent(
+-      await readStableRegularTextNoFollow(intentPath, "runner cancellation intent", {
+-        max_bytes: 4096,
+-      }),
+-      invocation.run_id,
+-    );
+-  } catch (error) {
+-    if ((error as NodeJS.ErrnoException | null)?.code === "ENOENT") return null;
+-    throw error;
++  for (let attempt = 1; attempt <= CANCELLATION_INTENT_READ_ATTEMPTS; attempt += 1) {
++    try {
++      return parseRunnerCancellationIntent(
++        await readStableRegularTextNoFollow(intentPath, "runner cancellation intent", {
++          max_bytes: 4096,
++        }),
++        invocation.run_id,
++      );
++    } catch (error) {
++      if ((error as NodeJS.ErrnoException | null)?.code === "ENOENT") return null;
++      if (
++        !isTransientCancellationIntentReadCollision(error) ||
++        attempt === CANCELLATION_INTENT_READ_ATTEMPTS
++      ) {
++        throw error;
++      }
++      await new Promise<void>((resolve) => setImmediate(resolve));
++    }
+   }
++  return null;
+ }

--- a/.agentplane/tasks/202607280948-N3XC7M/quality/20260728-100701613-recovery-context/evaluator-observed-checks.json
+++ b/.agentplane/tasks/202607280948-N3XC7M/quality/20260728-100701613-recovery-context/evaluator-observed-checks.json
@@ -1,0 +1,12 @@
+{
+  "task_status": "DOING",
+  "declared_checks": [],
+  "verification": {
+    "state": "ok",
+    "attempts": 0,
+    "updated_at": "2026-07-28T10:06:31.424Z",
+    "updated_by": "TESTER",
+    "note": "The cancellation-intent regression, impacted runner files, typecheck, formatting, and diff checks pass. The local all-project fast run failed only in unrelated parallel teardown timeouts; hosted CI remains the merge gate."
+  },
+  "runner_history": []
+}

--- a/.agentplane/tasks/202607280948-N3XC7M/quality/20260728-100701613-recovery-context/evaluator-opinion.md
+++ b/.agentplane/tasks/202607280948-N3XC7M/quality/20260728-100701613-recovery-context/evaluator-opinion.md
@@ -1,0 +1,22 @@
+# Semantic quality review: pass
+
+Provenance: human_supplied
+
+The patch retries only stable-file identity collisions during immutable cancellation-intent publication, preserves fail-closed handling for all other errors, and adds a deterministic one-collision regression.
+
+## Findings
+- Scope is limited to readRunnerCancellationIntent; malformed records, unsafe paths, and exhausted collision retries still propagate errors.
+
+## Evidence
+- packages/agentplane/src/runner/adapters/execution-control.ts
+- packages/agentplane/src/runner/adapters/execution-control.test.ts
+- focused vitest: execution-control plus lifecycle-cancel 16/16; typecheck and Prettier passed
+
+## Missing Tests
+- none recorded
+
+## Hidden Assumptions
+- none recorded
+
+## Residual Risks
+- The workstation all-project fast suite has an unrelated parallel runner teardown failure; GitHub CI is required before integration.

--- a/.agentplane/tasks/202607280948-N3XC7M/quality/20260728-100701613-recovery-context/evaluator-prompt.md
+++ b/.agentplane/tasks/202607280948-N3XC7M/quality/20260728-100701613-recovery-context/evaluator-prompt.md
@@ -1,0 +1,82 @@
+# AgentPlane EVALUATOR episode
+
+AgentPlane prepared and froze the authoritative review input. Perform the semantic evaluation; do not reproduce CLI discovery or lifecycle work.
+This prompt does not execute an evaluator. A caller must run the evaluator in the work-order authority boundary and persist its returned typed result at the declared output path.
+Do not edit implementation, task lifecycle, policy, or evidence files. You may read the frozen evidence and run read-only checks only.
+
+- task_id: 202607280948-N3XC7M
+- task_readme: .agentplane/tasks/202607280948-N3XC7M/README.md
+- work_order: .agentplane/tasks/202607280948-N3XC7M/quality/20260728-100701613-recovery-context/evaluator-work-order.json
+- result_output: .agentplane/tasks/202607280948-N3XC7M/quality/20260728-100701613-recovery-context/evaluator-result.json
+- report_path: .agentplane/tasks/202607280948-N3XC7M/quality/20260728-100701613-recovery-context/quality-report.json
+- provenance: human_supplied
+
+## Required result
+
+Return exactly one `sgr.evaluator_result.v1` JSON object through the evaluator result channel. The caller, not the read-only evaluator, persists it at `result_output`. It must contain:
+- schema_version: 1
+- kind: evaluator_result
+- evaluator_id: the evaluator id from the work order
+- verdict: pass | rework | blocked | human_review
+- findings: typed findings with id, severity, summary, broken_invariant, and non-empty evidence_refs
+- missing_tests and hidden_assumptions: string arrays
+- recovery_context: required non-empty string for rework, blocked, or human_review; for human_review it must be the single decision question for the human owner
+
+Every findings[].evidence_refs[].path must be an exact path from work_order.evidence. Do not add fields, commands, patches, lifecycle transitions, or a verdict outside this JSON result.
+The CLI validates the schema, frozen evidence digests, task revision, evaluated SHA, and blueprint before it records quality state.
+
+## Evaluator module
+
+---
+id: recovery-context
+title: Recovery Context Invariant Review
+version: 1
+status: preview
+profile: EVALUATOR
+tags:
+  - recovery
+  - invariants
+  - concurrency
+---
+
+# Recovery Context Invariant Review
+
+Use this evaluator only when the primary implementation path already produced a concrete change or when recovery context is needed after an interruption.
+
+## Inputs
+
+- Task id, task README, approved plan, and Verify Steps.
+- Current diff or PR patch.
+- Relevant comments, review findings, incidents, and recovery/handoff context.
+- Known concurrent-agent activity and task-artifact drift classification, if present.
+
+## Review Procedure
+
+1. Reconstruct the intended contract from the task, not from the implementation summary.
+2. Compare the diff against explicit invariants, stop rules, negative cases, and user constraints.
+3. Check whether recovery context changes the interpretation of the task or exposes stale assumptions.
+4. Inspect concurrency-sensitive paths and classify whether observed drift belongs to active agent work, stale handoff, or unrelated workspace drift.
+5. Identify missing tests, missing docs, or verification that only proves the happy path.
+6. Do not execute fixes. Return review findings only.
+7. When recording the result, use `agentplane evaluator run <task-id> --provenance evaluator_supplied` so the task gets prompt,
+   `quality-report.json`, and opinion artifacts. A bare `verify --by EVALUATOR` note is legacy
+   evidence and is not sufficient for finish/integrate gates.
+
+## Output
+
+Return a concise structured review:
+
+- `verdict`: `pass`, `rework`, `blocked`, or `human_review`.
+- `findings`: ordered by severity, each with file/path evidence and the broken invariant.
+- `evidence_refs`: concrete files, checks, PRs, traces, or reports inspected; pass reviews must
+  include the generated `quality-report.json`.
+- `missing_tests`: concrete tests or checks that would have caught the issue.
+- `hidden_assumptions`: assumptions the implementation relies on but did not prove.
+- `residual_risks`: known risks after the review.
+- `recovery_context`: what the next agent should know only if normal context is insufficient.
+
+## Stop Rules
+
+- Use `blocked` when required task context, diff, or recovery context is missing.
+- Use `rework` when behavior diverges from the approved contract even if local checks pass.
+- Use `pass` only when the implementation and verification evidence cover positive, negative, and concurrency-sensitive paths relevant to the task.

--- a/.agentplane/tasks/202607280948-N3XC7M/quality/20260728-100701613-recovery-context/evaluator-work-order.json
+++ b/.agentplane/tasks/202607280948-N3XC7M/quality/20260728-100701613-recovery-context/evaluator-work-order.json
@@ -1,0 +1,93 @@
+{
+  "schema_version": 1,
+  "kind": "evaluator_work_order",
+  "work_order_id": "evaluator-work-order-202607280948-N3XC7M-40169a4470548e5ad373871e",
+  "prepared_at": "2026-07-28T10:07:01.613Z",
+  "task": {
+    "id": "202607280948-N3XC7M",
+    "revision": 9,
+    "objective": "Retry transient runner cancellation intent reads\n\nFix the CI-proven race where an atomically published runner cancellation intent changes during a stable read and is treated as a fatal execution error. Retry only transient immutable-publication collisions, preserve fail-closed behavior for malformed or unsafe records, and add deterministic regression coverage.",
+    "acceptance_criteria": [
+      "- In scope: Fix the CI-proven race where an atomically published runner cancellation intent changes during a stable read and is treated as a fatal execution error. Retry only transient immutable-publication collisions, preserve fail-closed behavior for malformed or unsafe records, and add deterministic regression coverage.\n- Out of scope: unrelated refactors not required for \"Retry transient runner cancellation intent reads\".",
+      "1. Add a narrowly scoped retry path for transient stable-read collisions when observing immutable runner cancellation intents. 2. Keep ENOENT optionality and unsafe/malformed-record failures fail-closed. 3. Add a deterministic regression that injects one publication-race read failure, then proves cancellation completes. 4. Run focused runner tests, typecheck, and the relevant fast unit gate.",
+      "1. Inject a single transient stable-file publication collision while reading a runner cancellation intent; expected: the read retries and returns the immutable intent. 2. Execute the cancellation lifecycle regression; expected: cancellation yields terminal cancelled state, not failed. 3. Run focused execution-control and lifecycle-cancellation tests, typecheck, and bun run test:fast; expected: all pass."
+    ]
+  },
+  "evaluated_sha": "1a49629678f2a08df884ea70aa429ede775151fd",
+  "blueprint_digest": "33b37b14eb7897fb73d306e273fed82660d2b30131380aade76e26cb77d2c31f",
+  "evaluator": {
+    "id": "recovery-context",
+    "profile": "EVALUATOR",
+    "prompt_module_path": ".agentplane/evaluators/recovery-context.md"
+  },
+  "authority": {
+    "sandbox": "read-only",
+    "writable_roots": [],
+    "allowed_tool_classes": [
+      "repository_read",
+      "git_read",
+      "run_checks",
+      "report_result"
+    ],
+    "external_side_effects": []
+  },
+  "result_contract": "sgr.evaluator_result.v1",
+  "evidence": [
+    {
+      "id": "task-document",
+      "kind": "task_document",
+      "path": ".agentplane/tasks/202607280948-N3XC7M/README.md",
+      "sha256": "sha256:b15dc42768f96bc3b7667fecb47595530c5454f140e8aeadab76f8a8286b900d",
+      "required": true
+    },
+    {
+      "id": "actual-diff",
+      "kind": "actual_diff",
+      "path": ".agentplane/tasks/202607280948-N3XC7M/quality/20260728-100701613-recovery-context/evaluator-diff.patch",
+      "sha256": "sha256:d8fa916c7154bf4cbe245eb655d7d49fec37640a5edf067a02ebfe438c82f1ce",
+      "required": true
+    },
+    {
+      "id": "observed-checks",
+      "kind": "observed_checks",
+      "path": ".agentplane/tasks/202607280948-N3XC7M/quality/20260728-100701613-recovery-context/evaluator-observed-checks.json",
+      "sha256": "sha256:29583402ceef7aaf0fd790d0fdad82571f882a2370adaa97ee90561eca04546e",
+      "required": true
+    },
+    {
+      "id": "blueprint",
+      "kind": "blueprint",
+      "path": ".agentplane/tasks/202607280948-N3XC7M/quality/20260728-100701613-recovery-context/evaluator-blueprint.json",
+      "sha256": "sha256:7d25b3159ac78780236ee7c2dbb663e92b792333cafa0542e05c382fb2908dae",
+      "required": true
+    },
+    {
+      "id": "policy-1",
+      "kind": "policy_module",
+      "path": ".agentplane/policy/dod.code.md",
+      "sha256": "sha256:3fec50dfe0db2f9495a3fa96f36d95fb34262033299d57f6f3775af4b7cc1486",
+      "required": true
+    },
+    {
+      "id": "policy-2",
+      "kind": "policy_module",
+      "path": ".agentplane/policy/dod.core.md",
+      "sha256": "sha256:f6c11b8a2c55760c17af15f79fe13791b3e7bba4852fc7d311fc0657e490b0c7",
+      "required": true
+    },
+    {
+      "id": "policy-3",
+      "kind": "policy_module",
+      "path": ".agentplane/policy/security.must.md",
+      "sha256": "sha256:96d01012e7ab67873bcb7a2cdd3818efa2c1fa500ee2eaf0e316f67e15bbcab2",
+      "required": true
+    },
+    {
+      "id": "policy-4",
+      "kind": "policy_module",
+      "path": ".agentplane/policy/workflow.branch_pr.md",
+      "sha256": "sha256:12d3b942042c276d30593803ddcfe12b20dc794e3e8bfbd97b6ce59df13ba82b",
+      "required": true
+    }
+  ]
+}

--- a/.agentplane/tasks/202607280948-N3XC7M/quality/20260728-100701613-recovery-context/quality-report.json
+++ b/.agentplane/tasks/202607280948-N3XC7M/quality/20260728-100701613-recovery-context/quality-report.json
@@ -1,0 +1,25 @@
+{
+  "schema_version": 1,
+  "task_id": "202607280948-N3XC7M",
+  "evaluator_id": "recovery-context",
+  "evaluator_profile": "EVALUATOR",
+  "generated_at": "2026-07-28T10:07:01.865Z",
+  "provenance": "human_supplied",
+  "verdict": "pass",
+  "summary": "The patch retries only stable-file identity collisions during immutable cancellation-intent publication, preserves fail-closed handling for all other errors, and adds a deterministic one-collision regression.",
+  "evaluated_sha": "1a49629678f2a08df884ea70aa429ede775151fd",
+  "blueprint_digest": "33b37b14eb7897fb73d306e273fed82660d2b30131380aade76e26cb77d2c31f",
+  "findings": [
+    "Scope is limited to readRunnerCancellationIntent; malformed records, unsafe paths, and exhausted collision retries still propagate errors."
+  ],
+  "evidence_refs": [
+    "packages/agentplane/src/runner/adapters/execution-control.ts",
+    "packages/agentplane/src/runner/adapters/execution-control.test.ts",
+    "focused vitest: execution-control plus lifecycle-cancel 16/16; typecheck and Prettier passed"
+  ],
+  "missing_tests": [],
+  "hidden_assumptions": [],
+  "residual_risks": [
+    "The workstation all-project fast suite has an unrelated parallel runner teardown failure; GitHub CI is required before integration."
+  ]
+}

--- a/.agentplane/tasks/202607280948-N3XC7M/quality/20260728-101009524-recovery-context/evaluator-blueprint.json
+++ b/.agentplane/tasks/202607280948-N3XC7M/quality/20260728-101009524-recovery-context/evaluator-blueprint.json
@@ -1,0 +1,600 @@
+{
+  "schemaVersion": 1,
+  "artifactKind": "agentplane.blueprint.resolved_snapshot",
+  "resolverInput": {
+    "taskId": "202607280948-N3XC7M",
+    "title": "Retry transient runner cancellation intent reads",
+    "description": "Fix the CI-proven race where an atomically published runner cancellation intent changes during a stable read and is treated as a fatal execution error. Retry only transient immutable-publication collisions, preserve fail-closed behavior for malformed or unsafe records, and add deterministic regression coverage.",
+    "tags": [
+      "code",
+      "runner",
+      "ci",
+      "regression",
+      "v0.7"
+    ],
+    "owner": "CODER",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "mutation": "code",
+    "touchedPaths": [],
+    "recipeHints": [],
+    "riskFlags": []
+  },
+  "selectedBlueprint": {
+    "id": "quality.regression",
+    "version": 1,
+    "title": "Quality regression",
+    "taskKinds": [
+      "code"
+    ],
+    "workflowModes": [
+      "branch_pr"
+    ]
+  },
+  "plan": {
+    "schemaVersion": 1,
+    "blueprintId": "quality.regression",
+    "blueprintVersion": 1,
+    "title": "Quality regression",
+    "taskId": "202607280948-N3XC7M",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "taskIntent": {
+      "mutationScope": "code"
+    },
+    "whySelected": [
+      "specialized code domain resolved to quality.regression",
+      "workflow mode: branch_pr",
+      "mutation scope: code"
+    ],
+    "states": [
+      {
+        "id": "intake",
+        "kind": "intake",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": []
+      },
+      {
+        "id": "scope",
+        "kind": "scope",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "assumptions"
+        ]
+      },
+      {
+        "id": "approval_gate",
+        "kind": "approval_gate",
+        "mode": "approval",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "approval"
+        ]
+      },
+      {
+        "id": "context_resolve",
+        "kind": "context_resolve",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [
+          ".agentplane/policy/security.must.md",
+          ".agentplane/policy/dod.core.md",
+          ".agentplane/policy/dod.code.md",
+          ".agentplane/policy/workflow.branch_pr.md"
+        ],
+        "evidenceKinds": [
+          "context_manifest",
+          "artifact"
+        ]
+      },
+      {
+        "id": "worktree_start",
+        "kind": "worktree_start",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "work_unit",
+        "kind": "work_unit",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths",
+          "check_result"
+        ]
+      },
+      {
+        "id": "fast_local_checks",
+        "kind": "fast_local_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane task verify-show <task-id>",
+          "project focused checks"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "pr_artifact",
+        "kind": "pr_artifact",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "artifact",
+          "external_link"
+        ]
+      },
+      {
+        "id": "verify_record",
+        "kind": "verify_record",
+        "mode": "record",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result",
+          "weak_links"
+        ]
+      },
+      {
+        "id": "quality_gate",
+        "kind": "quality_gate",
+        "mode": "agentic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane evaluator run <task-id> --provenance human_supplied|evaluator_supplied --verdict pass|rework|blocked|human_review"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "quality_report"
+        ]
+      },
+      {
+        "id": "hosted_checks",
+        "kind": "hosted_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result",
+          "external_link"
+        ]
+      },
+      {
+        "id": "publish_or_integrate",
+        "kind": "publish_or_integrate",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane integrate <task-id> --branch <branch> --run-verify"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit",
+          "external_link"
+        ]
+      },
+      {
+        "id": "finish",
+        "kind": "finish",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit"
+        ]
+      }
+    ],
+    "requiredEvidence": [
+      {
+        "id": "regression.original_failure",
+        "kind": "artifact",
+        "producedBy": "context_resolve",
+        "required": true,
+        "description": "Original failure log or check output."
+      },
+      {
+        "id": "regression.reproduction",
+        "kind": "check_result",
+        "producedBy": "work_unit",
+        "required": true,
+        "description": "Local reproduction or explicit non-reproduction result."
+      },
+      {
+        "id": "regression.focused_check",
+        "kind": "check_result",
+        "producedBy": "fast_local_checks",
+        "required": true,
+        "description": "Focused regression check."
+      },
+      {
+        "id": "regression.matrix_or_scope",
+        "kind": "assumptions",
+        "producedBy": "scope",
+        "required": true,
+        "description": "Affected test/check matrix or bounded scope."
+      },
+      {
+        "id": "regression.full_gate",
+        "kind": "check_result",
+        "producedBy": "hosted_checks",
+        "required": true,
+        "description": "Full relevant gate or hosted check evidence."
+      },
+      {
+        "id": "regression.flake_classification",
+        "kind": "weak_links",
+        "producedBy": "verify_record",
+        "required": true,
+        "description": "Flake classification or residual risk."
+      },
+      {
+        "id": "regression.quality",
+        "kind": "quality_report",
+        "producedBy": "quality_gate",
+        "required": true,
+        "description": "EVALUATOR quality verdict."
+      },
+      {
+        "id": "regression.commit",
+        "kind": "commit",
+        "producedBy": "publish_or_integrate",
+        "required": true,
+        "description": "Integration commit."
+      }
+    ],
+    "policyModules": [
+      ".agentplane/policy/dod.code.md",
+      ".agentplane/policy/dod.core.md",
+      ".agentplane/policy/security.must.md",
+      ".agentplane/policy/workflow.branch_pr.md"
+    ],
+    "allowedCommands": [
+      "affected matrix or full relevant gate",
+      "agentplane evaluator run <task-id> --provenance human_supplied|evaluator_supplied --verdict pass|rework|blocked|human_review",
+      "agentplane integrate <task-id> --branch <branch> --run-verify",
+      "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+      "agentplane task verify-show <task-id>",
+      "agentplane verify <task-id> --ok|--rework",
+      "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+      "failure reproduction command",
+      "focused regression check",
+      "project focused checks"
+    ],
+    "contextBudget": {
+      "maxPolicyModules": 4,
+      "maxPromptBlocks": 16,
+      "rationale": "Regression work needs failure evidence, focused reproduction, and the relevant quality gate."
+    },
+    "contextManifest": [],
+    "acceptedRecipeExtensions": [],
+    "rejectedRecipeExtensions": [],
+    "stopReasons": []
+  },
+  "nodes": [
+    {
+      "id": "intake",
+      "kind": "intake",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": []
+    },
+    {
+      "id": "scope",
+      "kind": "scope",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "assumptions"
+      ]
+    },
+    {
+      "id": "approval_gate",
+      "kind": "approval_gate",
+      "mode": "approval",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "approval"
+      ]
+    },
+    {
+      "id": "context_resolve",
+      "kind": "context_resolve",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [
+        ".agentplane/policy/security.must.md",
+        ".agentplane/policy/dod.core.md",
+        ".agentplane/policy/dod.code.md",
+        ".agentplane/policy/workflow.branch_pr.md"
+      ],
+      "evidenceKinds": [
+        "context_manifest",
+        "artifact"
+      ]
+    },
+    {
+      "id": "worktree_start",
+      "kind": "worktree_start",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "work_unit",
+      "kind": "work_unit",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths",
+        "check_result"
+      ]
+    },
+    {
+      "id": "fast_local_checks",
+      "kind": "fast_local_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane task verify-show <task-id>",
+        "project focused checks"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "pr_artifact",
+      "kind": "pr_artifact",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "artifact",
+        "external_link"
+      ]
+    },
+    {
+      "id": "verify_record",
+      "kind": "verify_record",
+      "mode": "record",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result",
+        "weak_links"
+      ]
+    },
+    {
+      "id": "quality_gate",
+      "kind": "quality_gate",
+      "mode": "agentic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane evaluator run <task-id> --provenance human_supplied|evaluator_supplied --verdict pass|rework|blocked|human_review"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "quality_report"
+      ]
+    },
+    {
+      "id": "hosted_checks",
+      "kind": "hosted_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result",
+        "external_link"
+      ]
+    },
+    {
+      "id": "publish_or_integrate",
+      "kind": "publish_or_integrate",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane integrate <task-id> --branch <branch> --run-verify"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit",
+        "external_link"
+      ]
+    },
+    {
+      "id": "finish",
+      "kind": "finish",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit"
+      ]
+    }
+  ],
+  "requiredEvidence": [
+    {
+      "id": "regression.original_failure",
+      "kind": "artifact",
+      "producedBy": "context_resolve",
+      "required": true,
+      "description": "Original failure log or check output."
+    },
+    {
+      "id": "regression.reproduction",
+      "kind": "check_result",
+      "producedBy": "work_unit",
+      "required": true,
+      "description": "Local reproduction or explicit non-reproduction result."
+    },
+    {
+      "id": "regression.focused_check",
+      "kind": "check_result",
+      "producedBy": "fast_local_checks",
+      "required": true,
+      "description": "Focused regression check."
+    },
+    {
+      "id": "regression.matrix_or_scope",
+      "kind": "assumptions",
+      "producedBy": "scope",
+      "required": true,
+      "description": "Affected test/check matrix or bounded scope."
+    },
+    {
+      "id": "regression.full_gate",
+      "kind": "check_result",
+      "producedBy": "hosted_checks",
+      "required": true,
+      "description": "Full relevant gate or hosted check evidence."
+    },
+    {
+      "id": "regression.flake_classification",
+      "kind": "weak_links",
+      "producedBy": "verify_record",
+      "required": true,
+      "description": "Flake classification or residual risk."
+    },
+    {
+      "id": "regression.quality",
+      "kind": "quality_report",
+      "producedBy": "quality_gate",
+      "required": true,
+      "description": "EVALUATOR quality verdict."
+    },
+    {
+      "id": "regression.commit",
+      "kind": "commit",
+      "producedBy": "publish_or_integrate",
+      "required": true,
+      "description": "Integration commit."
+    }
+  ],
+  "policyModules": [
+    ".agentplane/policy/dod.code.md",
+    ".agentplane/policy/dod.core.md",
+    ".agentplane/policy/security.must.md",
+    ".agentplane/policy/workflow.branch_pr.md"
+  ],
+  "allowedCommands": [
+    "affected matrix or full relevant gate",
+    "agentplane evaluator run <task-id> --provenance human_supplied|evaluator_supplied --verdict pass|rework|blocked|human_review",
+    "agentplane integrate <task-id> --branch <branch> --run-verify",
+    "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+    "agentplane task verify-show <task-id>",
+    "agentplane verify <task-id> --ok|--rework",
+    "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+    "failure reproduction command",
+    "focused regression check",
+    "project focused checks"
+  ],
+  "contextBudget": {
+    "maxPolicyModules": 4,
+    "maxPromptBlocks": 16,
+    "rationale": "Regression work needs failure evidence, focused reproduction, and the relevant quality gate."
+  },
+  "contextManifest": [],
+  "acceptedRecipeExtensions": [],
+  "rejectedRecipeExtensions": [],
+  "stopReasons": [],
+  "selectionReasons": [
+    "specialized code domain resolved to quality.regression",
+    "workflow mode: branch_pr",
+    "mutation scope: code"
+  ],
+  "digest": {
+    "algorithm": "sha256",
+    "value": "33b37b14eb7897fb73d306e273fed82660d2b30131380aade76e26cb77d2c31f"
+  }
+}

--- a/.agentplane/tasks/202607280948-N3XC7M/quality/20260728-101009524-recovery-context/evaluator-diff.patch
+++ b/.agentplane/tasks/202607280948-N3XC7M/quality/20260728-101009524-recovery-context/evaluator-diff.patch
@@ -1,0 +1,48 @@
+diff --git a/.agentplane/tasks/202607280948-N3XC7M/README.md b/.agentplane/tasks/202607280948-N3XC7M/README.md
+index a61016984..91998f5c8 100644
+--- a/.agentplane/tasks/202607280948-N3XC7M/README.md
++++ b/.agentplane/tasks/202607280948-N3XC7M/README.md
+@@ -4,7 +4,7 @@ title: "Retry transient runner cancellation intent reads"
+ status: "DOING"
+ priority: "high"
+ owner: "CODER"
+-revision: 7
++revision: 8
+ origin:
+   system: "manual"
+ depends_on: []
+@@ -26,11 +26,16 @@ verification:
+   updated_by: null
+   note: null
+   attempts: 0
+-commit: null
++commit:
++  hash: "1a49629678f2a08df884ea70aa429ede775151fd"
++  message: "fix: retry runner cancellation intent reads"
+ comments:
+   -
+     author: "CODER"
+     body: "Start: continue branch_pr task in the dedicated task worktree."
++  -
++    author: "CODER"
++    body: "Implemented bounded retry for transient cancellation-intent publication collisions; malformed and unsafe reads remain fail-closed. Focused runner tests and typecheck pass; the full fast suite exposed independent teardown timeouts."
+ events:
+   -
+     type: "status"
+@@ -39,8 +44,15 @@ events:
+     from: "TODO"
+     to: "DOING"
+     note: "Start: continue branch_pr task in the dedicated task worktree."
++  -
++    type: "status"
++    at: "2026-07-28T10:01:26.764Z"
++    author: "CODER"
++    from: "DOING"
++    to: "DOING"
++    note: "Implemented bounded retry for transient cancellation-intent publication collisions; malformed and unsafe reads remain fail-closed. Focused runner tests and typecheck pass; the full fast suite exposed independent teardown timeouts."
+ doc_version: 3
+-doc_updated_at: "2026-07-28T09:49:46.640Z"
++doc_updated_at: "2026-07-28T10:01:26.764Z"
+ doc_updated_by: "CODER"
+ description: "Fix the CI-proven race where an atomically published runner cancellation intent changes during a stable read and is treated as a fatal execution error. Retry only transient immutable-publication collisions, preserve fail-closed behavior for malformed or unsafe records, and add deterministic regression coverage."
+ sections:

--- a/.agentplane/tasks/202607280948-N3XC7M/quality/20260728-101009524-recovery-context/evaluator-observed-checks.json
+++ b/.agentplane/tasks/202607280948-N3XC7M/quality/20260728-101009524-recovery-context/evaluator-observed-checks.json
@@ -1,0 +1,12 @@
+{
+  "task_status": "DOING",
+  "declared_checks": [],
+  "verification": {
+    "state": "ok",
+    "attempts": 0,
+    "updated_at": "2026-07-28T10:06:31.424Z",
+    "updated_by": "TESTER",
+    "note": "The cancellation-intent regression, impacted runner files, typecheck, formatting, and diff checks pass. The local all-project fast run failed only in unrelated parallel teardown timeouts; hosted CI remains the merge gate."
+  },
+  "runner_history": []
+}

--- a/.agentplane/tasks/202607280948-N3XC7M/quality/20260728-101009524-recovery-context/evaluator-opinion.md
+++ b/.agentplane/tasks/202607280948-N3XC7M/quality/20260728-101009524-recovery-context/evaluator-opinion.md
@@ -1,0 +1,23 @@
+# Semantic quality review: pass
+
+Provenance: human_supplied
+
+The bounded retry covers only transient immutable cancellation-intent publication collisions and preserves fail-closed behavior for malformed or unsafe inputs.
+
+## Findings
+- The current task-artifact commit is reviewed in addition to the source patch; focused runner tests, lifecycle-cancellation regression, typecheck, formatting, and diff checks pass. The full local parallel suite has unrelated teardown timeouts, so hosted CI remains the integration gate.
+
+## Evidence
+- .agentplane/tasks/202607280948-N3XC7M/quality/20260728-100701613-recovery-context/quality-report.json
+- packages/agentplane/src/runner/adapters/execution-control.ts
+- packages/agentplane/src/runner/adapters/execution-control.test.ts
+- focused vitest: execution-control plus lifecycle-cancel 16/16; typecheck and Prettier passed
+
+## Missing Tests
+- none recorded
+
+## Hidden Assumptions
+- none recorded
+
+## Residual Risks
+- The workstation-wide parallel fast suite remains unstable outside this change; do not integrate without green hosted CI.

--- a/.agentplane/tasks/202607280948-N3XC7M/quality/20260728-101009524-recovery-context/evaluator-prompt.md
+++ b/.agentplane/tasks/202607280948-N3XC7M/quality/20260728-101009524-recovery-context/evaluator-prompt.md
@@ -1,0 +1,82 @@
+# AgentPlane EVALUATOR episode
+
+AgentPlane prepared and froze the authoritative review input. Perform the semantic evaluation; do not reproduce CLI discovery or lifecycle work.
+This prompt does not execute an evaluator. A caller must run the evaluator in the work-order authority boundary and persist its returned typed result at the declared output path.
+Do not edit implementation, task lifecycle, policy, or evidence files. You may read the frozen evidence and run read-only checks only.
+
+- task_id: 202607280948-N3XC7M
+- task_readme: .agentplane/tasks/202607280948-N3XC7M/README.md
+- work_order: .agentplane/tasks/202607280948-N3XC7M/quality/20260728-101009524-recovery-context/evaluator-work-order.json
+- result_output: .agentplane/tasks/202607280948-N3XC7M/quality/20260728-101009524-recovery-context/evaluator-result.json
+- report_path: .agentplane/tasks/202607280948-N3XC7M/quality/20260728-101009524-recovery-context/quality-report.json
+- provenance: human_supplied
+
+## Required result
+
+Return exactly one `sgr.evaluator_result.v1` JSON object through the evaluator result channel. The caller, not the read-only evaluator, persists it at `result_output`. It must contain:
+- schema_version: 1
+- kind: evaluator_result
+- evaluator_id: the evaluator id from the work order
+- verdict: pass | rework | blocked | human_review
+- findings: typed findings with id, severity, summary, broken_invariant, and non-empty evidence_refs
+- missing_tests and hidden_assumptions: string arrays
+- recovery_context: required non-empty string for rework, blocked, or human_review; for human_review it must be the single decision question for the human owner
+
+Every findings[].evidence_refs[].path must be an exact path from work_order.evidence. Do not add fields, commands, patches, lifecycle transitions, or a verdict outside this JSON result.
+The CLI validates the schema, frozen evidence digests, task revision, evaluated SHA, and blueprint before it records quality state.
+
+## Evaluator module
+
+---
+id: recovery-context
+title: Recovery Context Invariant Review
+version: 1
+status: preview
+profile: EVALUATOR
+tags:
+  - recovery
+  - invariants
+  - concurrency
+---
+
+# Recovery Context Invariant Review
+
+Use this evaluator only when the primary implementation path already produced a concrete change or when recovery context is needed after an interruption.
+
+## Inputs
+
+- Task id, task README, approved plan, and Verify Steps.
+- Current diff or PR patch.
+- Relevant comments, review findings, incidents, and recovery/handoff context.
+- Known concurrent-agent activity and task-artifact drift classification, if present.
+
+## Review Procedure
+
+1. Reconstruct the intended contract from the task, not from the implementation summary.
+2. Compare the diff against explicit invariants, stop rules, negative cases, and user constraints.
+3. Check whether recovery context changes the interpretation of the task or exposes stale assumptions.
+4. Inspect concurrency-sensitive paths and classify whether observed drift belongs to active agent work, stale handoff, or unrelated workspace drift.
+5. Identify missing tests, missing docs, or verification that only proves the happy path.
+6. Do not execute fixes. Return review findings only.
+7. When recording the result, use `agentplane evaluator run <task-id> --provenance evaluator_supplied` so the task gets prompt,
+   `quality-report.json`, and opinion artifacts. A bare `verify --by EVALUATOR` note is legacy
+   evidence and is not sufficient for finish/integrate gates.
+
+## Output
+
+Return a concise structured review:
+
+- `verdict`: `pass`, `rework`, `blocked`, or `human_review`.
+- `findings`: ordered by severity, each with file/path evidence and the broken invariant.
+- `evidence_refs`: concrete files, checks, PRs, traces, or reports inspected; pass reviews must
+  include the generated `quality-report.json`.
+- `missing_tests`: concrete tests or checks that would have caught the issue.
+- `hidden_assumptions`: assumptions the implementation relies on but did not prove.
+- `residual_risks`: known risks after the review.
+- `recovery_context`: what the next agent should know only if normal context is insufficient.
+
+## Stop Rules
+
+- Use `blocked` when required task context, diff, or recovery context is missing.
+- Use `rework` when behavior diverges from the approved contract even if local checks pass.
+- Use `pass` only when the implementation and verification evidence cover positive, negative, and concurrency-sensitive paths relevant to the task.

--- a/.agentplane/tasks/202607280948-N3XC7M/quality/20260728-101009524-recovery-context/evaluator-work-order.json
+++ b/.agentplane/tasks/202607280948-N3XC7M/quality/20260728-101009524-recovery-context/evaluator-work-order.json
@@ -1,0 +1,93 @@
+{
+  "schema_version": 1,
+  "kind": "evaluator_work_order",
+  "work_order_id": "evaluator-work-order-202607280948-N3XC7M-5df63a953799155e4457a98d",
+  "prepared_at": "2026-07-28T10:10:09.524Z",
+  "task": {
+    "id": "202607280948-N3XC7M",
+    "revision": 10,
+    "objective": "Retry transient runner cancellation intent reads\n\nFix the CI-proven race where an atomically published runner cancellation intent changes during a stable read and is treated as a fatal execution error. Retry only transient immutable-publication collisions, preserve fail-closed behavior for malformed or unsafe records, and add deterministic regression coverage.",
+    "acceptance_criteria": [
+      "- In scope: Fix the CI-proven race where an atomically published runner cancellation intent changes during a stable read and is treated as a fatal execution error. Retry only transient immutable-publication collisions, preserve fail-closed behavior for malformed or unsafe records, and add deterministic regression coverage.\n- Out of scope: unrelated refactors not required for \"Retry transient runner cancellation intent reads\".",
+      "1. Add a narrowly scoped retry path for transient stable-read collisions when observing immutable runner cancellation intents. 2. Keep ENOENT optionality and unsafe/malformed-record failures fail-closed. 3. Add a deterministic regression that injects one publication-race read failure, then proves cancellation completes. 4. Run focused runner tests, typecheck, and the relevant fast unit gate.",
+      "1. Inject a single transient stable-file publication collision while reading a runner cancellation intent; expected: the read retries and returns the immutable intent. 2. Execute the cancellation lifecycle regression; expected: cancellation yields terminal cancelled state, not failed. 3. Run focused execution-control and lifecycle-cancellation tests, typecheck, and bun run test:fast; expected: all pass."
+    ]
+  },
+  "evaluated_sha": "a224a862c0ba75d09060d1a6b1301005ca6a5173",
+  "blueprint_digest": "33b37b14eb7897fb73d306e273fed82660d2b30131380aade76e26cb77d2c31f",
+  "evaluator": {
+    "id": "recovery-context",
+    "profile": "EVALUATOR",
+    "prompt_module_path": ".agentplane/evaluators/recovery-context.md"
+  },
+  "authority": {
+    "sandbox": "read-only",
+    "writable_roots": [],
+    "allowed_tool_classes": [
+      "repository_read",
+      "git_read",
+      "run_checks",
+      "report_result"
+    ],
+    "external_side_effects": []
+  },
+  "result_contract": "sgr.evaluator_result.v1",
+  "evidence": [
+    {
+      "id": "task-document",
+      "kind": "task_document",
+      "path": ".agentplane/tasks/202607280948-N3XC7M/README.md",
+      "sha256": "sha256:cb01ffaa6f27ff4539763a020cfb43b3042ca1816175a64c67bbfb3ac94521fc",
+      "required": true
+    },
+    {
+      "id": "actual-diff",
+      "kind": "actual_diff",
+      "path": ".agentplane/tasks/202607280948-N3XC7M/quality/20260728-101009524-recovery-context/evaluator-diff.patch",
+      "sha256": "sha256:b049254ed23c518b6d4f7d96b4e8fba00f2a04c5d7e0f616acb3764b0e5633fd",
+      "required": true
+    },
+    {
+      "id": "observed-checks",
+      "kind": "observed_checks",
+      "path": ".agentplane/tasks/202607280948-N3XC7M/quality/20260728-101009524-recovery-context/evaluator-observed-checks.json",
+      "sha256": "sha256:29583402ceef7aaf0fd790d0fdad82571f882a2370adaa97ee90561eca04546e",
+      "required": true
+    },
+    {
+      "id": "blueprint",
+      "kind": "blueprint",
+      "path": ".agentplane/tasks/202607280948-N3XC7M/quality/20260728-101009524-recovery-context/evaluator-blueprint.json",
+      "sha256": "sha256:7d25b3159ac78780236ee7c2dbb663e92b792333cafa0542e05c382fb2908dae",
+      "required": true
+    },
+    {
+      "id": "policy-1",
+      "kind": "policy_module",
+      "path": ".agentplane/policy/dod.code.md",
+      "sha256": "sha256:3fec50dfe0db2f9495a3fa96f36d95fb34262033299d57f6f3775af4b7cc1486",
+      "required": true
+    },
+    {
+      "id": "policy-2",
+      "kind": "policy_module",
+      "path": ".agentplane/policy/dod.core.md",
+      "sha256": "sha256:f6c11b8a2c55760c17af15f79fe13791b3e7bba4852fc7d311fc0657e490b0c7",
+      "required": true
+    },
+    {
+      "id": "policy-3",
+      "kind": "policy_module",
+      "path": ".agentplane/policy/security.must.md",
+      "sha256": "sha256:96d01012e7ab67873bcb7a2cdd3818efa2c1fa500ee2eaf0e316f67e15bbcab2",
+      "required": true
+    },
+    {
+      "id": "policy-4",
+      "kind": "policy_module",
+      "path": ".agentplane/policy/workflow.branch_pr.md",
+      "sha256": "sha256:12d3b942042c276d30593803ddcfe12b20dc794e3e8bfbd97b6ce59df13ba82b",
+      "required": true
+    }
+  ]
+}

--- a/.agentplane/tasks/202607280948-N3XC7M/quality/20260728-101009524-recovery-context/quality-report.json
+++ b/.agentplane/tasks/202607280948-N3XC7M/quality/20260728-101009524-recovery-context/quality-report.json
@@ -1,0 +1,26 @@
+{
+  "schema_version": 1,
+  "task_id": "202607280948-N3XC7M",
+  "evaluator_id": "recovery-context",
+  "evaluator_profile": "EVALUATOR",
+  "generated_at": "2026-07-28T10:10:09.764Z",
+  "provenance": "human_supplied",
+  "verdict": "pass",
+  "summary": "The bounded retry covers only transient immutable cancellation-intent publication collisions and preserves fail-closed behavior for malformed or unsafe inputs.",
+  "evaluated_sha": "a224a862c0ba75d09060d1a6b1301005ca6a5173",
+  "blueprint_digest": "33b37b14eb7897fb73d306e273fed82660d2b30131380aade76e26cb77d2c31f",
+  "findings": [
+    "The current task-artifact commit is reviewed in addition to the source patch; focused runner tests, lifecycle-cancellation regression, typecheck, formatting, and diff checks pass. The full local parallel suite has unrelated teardown timeouts, so hosted CI remains the integration gate."
+  ],
+  "evidence_refs": [
+    ".agentplane/tasks/202607280948-N3XC7M/quality/20260728-100701613-recovery-context/quality-report.json",
+    "packages/agentplane/src/runner/adapters/execution-control.ts",
+    "packages/agentplane/src/runner/adapters/execution-control.test.ts",
+    "focused vitest: execution-control plus lifecycle-cancel 16/16; typecheck and Prettier passed"
+  ],
+  "missing_tests": [],
+  "hidden_assumptions": [],
+  "residual_risks": [
+    "The workstation-wide parallel fast suite remains unstable outside this change; do not integrate without green hosted CI."
+  ]
+}

--- a/packages/agentplane/src/runner/adapters/execution-control.test.ts
+++ b/packages/agentplane/src/runner/adapters/execution-control.test.ts
@@ -2,16 +2,22 @@ import { mkdir, mkdtemp, rm } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import type { RunnerInvocation } from "../types.js";
+import * as stableFile from "../stable-file.js";
 
-import { claimRunnerPreSpawnDecision } from "./execution-control.js";
+import {
+  claimRunnerPreSpawnDecision,
+  publishRunnerCancellationIntent,
+  readRunnerCancellationIntent,
+} from "./execution-control.js";
 
 describe("runner immutable execution control", () => {
   let tempDir = "";
 
   afterEach(async () => {
+    vi.restoreAllMocks();
     if (tempDir) await rm(tempDir, { recursive: true, force: true });
     tempDir = "";
   });
@@ -85,5 +91,64 @@ describe("runner immutable execution control", () => {
     });
     expect(retry.won).toBe(false);
     expect(retry.record).toEqual(published.record);
+  });
+
+  it("retries a transient cancellation-intent publication collision", async () => {
+    tempDir = await mkdtemp(path.join(os.tmpdir(), "agentplane-execution-control-"));
+    const runDir = path.join(tempDir, "run");
+    await mkdir(runDir);
+    const invocation = {
+      adapter_id: "custom",
+      run_id: "run-cancellation-intent-read-collision",
+      work_order_id: "run-cancellation-intent-read-collision",
+      repository_root: tempDir,
+      run_dir: runDir,
+      bundle_path: path.join(runDir, "bundle.json"),
+      state_path: path.join(runDir, "run-state.json"),
+      events_path: path.join(runDir, "events.jsonl"),
+      result_path: path.join(runDir, "result.json"),
+      receipt_path: path.join(runDir, "receipt.json"),
+      trace_path: path.join(runDir, "trace.jsonl"),
+      stderr_path: path.join(runDir, "stderr.log"),
+      trace_policy: {
+        mode: "raw",
+        max_tail_bytes: 1024,
+        capture_stderr: true,
+      },
+      timeout_policy: {
+        wall_clock_ms: 1000,
+        idle_ms: 1000,
+        terminate_grace_ms: 100,
+      },
+      argv: ["runner"],
+      env: {},
+      dry_run: false,
+    } as RunnerInvocation;
+    const published = await publishRunnerCancellationIntent({
+      invocation,
+      requested_at: "2026-07-28T09:52:00.000Z",
+      signal: "SIGTERM",
+    });
+    const originalRead = stableFile.readStableRegularTextNoFollow;
+    let cancellationIntentReadCount = 0;
+    vi.spyOn(stableFile, "readStableRegularTextNoFollow").mockImplementation(async (...args) => {
+      if (args[1] === "runner cancellation intent") {
+        cancellationIntentReadCount += 1;
+        if (cancellationIntentReadCount === 1) {
+          throw new Error(`runner cancellation intent changed before it could be read: ${args[0]}`);
+        }
+      }
+      return await originalRead(...args);
+    });
+    const observed = await readRunnerCancellationIntent(invocation);
+
+    expect(published.won).toBe(true);
+    expect(cancellationIntentReadCount).toBe(2);
+    expect(observed).toEqual({
+      schema_version: 1,
+      run_id: invocation.run_id,
+      requested_at: "2026-07-28T09:52:00.000Z",
+      signal: "SIGTERM",
+    });
   });
 });

--- a/packages/agentplane/src/runner/adapters/execution-control.ts
+++ b/packages/agentplane/src/runner/adapters/execution-control.ts
@@ -18,6 +18,7 @@ const RUNNER_PRE_SPAWN_DECISION_FILENAME = ".runner-pre-spawn-decision.json";
 const RUNNER_CHILD_SPAWN_CLAIM_FILENAME = ".runner-child-spawn-claim.json";
 const RUNNER_CANCELLATION_INTENT_FILENAME = ".runner-cancellation-intent.json";
 const DEFAULT_START_OWNER_LEASE_MS = 3000;
+const CANCELLATION_INTENT_READ_ATTEMPTS = 4;
 
 export type RunnerStartOwnerLease = {
   owner_id: string;
@@ -133,6 +134,16 @@ function parseRunnerChildSpawnClaim(raw: string, expectedRunId: string): RunnerC
     throw new Error(`Invalid runner child spawn claim for run_id=${expectedRunId}.`);
   }
   return parsed as RunnerChildSpawnClaim;
+}
+
+function isTransientCancellationIntentReadCollision(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  return (
+    message.startsWith("runner cancellation intent ") &&
+    (message.includes(" changed before it could be read:") ||
+      message.includes(" changed while it was being read:") ||
+      message.includes(" path changed while it was being read:"))
+  );
 }
 
 async function publishImmutableRunnerControlRecord<T>(opts: {
@@ -351,15 +362,24 @@ export async function readRunnerCancellationIntent(
   invocation: RunnerInvocation,
 ): Promise<RunnerCancellationIntent | null> {
   const intentPath = path.join(invocation.run_dir, RUNNER_CANCELLATION_INTENT_FILENAME);
-  try {
-    return parseRunnerCancellationIntent(
-      await readStableRegularTextNoFollow(intentPath, "runner cancellation intent", {
-        max_bytes: 4096,
-      }),
-      invocation.run_id,
-    );
-  } catch (error) {
-    if ((error as NodeJS.ErrnoException | null)?.code === "ENOENT") return null;
-    throw error;
+  for (let attempt = 1; attempt <= CANCELLATION_INTENT_READ_ATTEMPTS; attempt += 1) {
+    try {
+      return parseRunnerCancellationIntent(
+        await readStableRegularTextNoFollow(intentPath, "runner cancellation intent", {
+          max_bytes: 4096,
+        }),
+        invocation.run_id,
+      );
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException | null)?.code === "ENOENT") return null;
+      if (
+        !isTransientCancellationIntentReadCollision(error) ||
+        attempt === CANCELLATION_INTENT_READ_ATTEMPTS
+      ) {
+        throw error;
+      }
+      await new Promise<void>((resolve) => setImmediate(resolve));
+    }
   }
+  return null;
 }


### PR DESCRIPTION
Task: `202607280948-N3XC7M`
Title: Retry transient runner cancellation intent reads
Canonical task record: `.agentplane/tasks/202607280948-N3XC7M/README.md`

## Summary

Retry transient runner cancellation intent reads

Fix the CI-proven race where an atomically published runner cancellation intent changes during a stable read and is treated as a fatal execution error. Retry only transient immutable-publication collisions, preserve fail-closed behavior for malformed or unsafe records, and add deterministic regression coverage.

## Scope

- In scope: Fix the CI-proven race where an atomically published runner cancellation intent changes during a stable read and is treated as a fatal execution error. Retry only transient immutable-publication collisions, preserve fail-closed behavior for malformed or unsafe records, and add deterministic regression coverage.
- Out of scope: unrelated refactors not required for "Retry transient runner cancellation intent reads".

## Verification

- State: pending
- Note: Not recorded yet.
- Canonical workflow state lives in the task README.

<details>
<summary>Raw evidence</summary>

- Updated: 2026-07-28T09:49:46.757Z
- Branch: task/202607280948-N3XC7M/retry-transient-runner-cancellation-intent-reads
- Head: computed live by `agentplane pr check` / `agentplane integrate`

```text
No changes detected.
```

</details>
