### PR TITLE
🚧 147Q75 task: Repair evaluator response schema for Codex structured output [202607281455-147Q75]

### DIFF
--- a/.agentplane/tasks/202607281455-147Q75/README.md
+++ b/.agentplane/tasks/202607281455-147Q75/README.md
@@ -1,10 +1,11 @@
 ---
 id: "202607281455-147Q75"
 title: "Repair evaluator response schema for Codex structured output"
-status: "DOING"
+result_summary: "pre-merge closure"
+status: "DONE"
 priority: "high"
 owner: "CODER"
-revision: 5
+revision: 9
 origin:
   system: "manual"
 depends_on: []
@@ -29,14 +30,38 @@ plan_approval:
   updated_by: "ORCHESTRATOR"
   note: null
 verification:
-  state: "pending"
-  updated_at: null
-  updated_by: null
-  note: null
+  state: "ok"
+  updated_at: "2026-07-28T15:03:08.775Z"
+  updated_by: "TESTER"
+  note: "Verified evaluator schema compatibility: all structured-output properties are required with nullable optional metadata, nulls normalize before strict SGR validation, and the provider boundary remains read-only. Checks passed: focused evaluator suites (14), typecheck, format, routing validation."
   attempts: 0
+quality_review:
+  state: "pass"
+  provenance: "evaluator_supplied"
+  updated_at: "2026-07-28T15:11:23.716Z"
+  updated_by: "EVALUATOR"
+  note: "EVALUATOR returned pass with 1 typed finding(s)."
+  evaluated_sha: "2a83376fe1a6b69d98ece871ecd2b0c200a204ba"
+  blueprint_digest: "502c33075284ce6f9aa46423f98024e5cae094e841cac21d82f799f5898e4d05"
+  evidence_refs:
+    - ".agentplane/tasks/202607281455-147Q75/quality/20260728-151123390-recovery-context/evaluator-work-order.json"
+    - ".agentplane/tasks/202607281455-147Q75/quality/20260728-151123390-recovery-context/quality-report.json"
+    - ".agentplane/tasks/202607281455-147Q75/quality/20260728-151123390-recovery-context/evaluator-prompt.md"
+    - ".agentplane/tasks/202607281455-147Q75/quality/20260728-151123390-recovery-context/evaluator-opinion.md"
+    - ".agentplane/tasks/202607281455-147Q75/quality/20260728-151123390-recovery-context/evaluator-result.json"
+    - ".agentplane/tasks/202607281455-147Q75/README.md"
+    - ".agentplane/tasks/202607281455-147Q75/quality/20260728-151123390-recovery-context/evaluator-diff.patch"
+    - ".agentplane/tasks/202607281455-147Q75/quality/20260728-151123390-recovery-context/evaluator-observed-checks.json"
+    - ".agentplane/tasks/202607281455-147Q75/quality/20260728-151123390-recovery-context/evaluator-blueprint.json"
+    - ".agentplane/policy/dod.code.md"
+    - ".agentplane/policy/dod.core.md"
+    - ".agentplane/policy/security.must.md"
+    - ".agentplane/policy/workflow.branch_pr.md"
+  findings:
+    - "The response schema requires every declared key and represents optional source metadata and recovery context as null-capable fields; strict validation removes null placeholders before frozen-evidence checks."
 commit:
-  hash: "b5cad73384df973a4a0845521c97723347af56f8"
-  message: "Repair evaluator structured-output schema"
+  hash: "2a83376fe1a6b69d98ece871ecd2b0c200a204ba"
+  message: "Record evaluator schema implementation"
 comments:
   -
     author: "CODER"
@@ -44,6 +69,9 @@ comments:
   -
     author: "CODER"
     body: "Implemented: Codex-compatible evaluator output schema now requires nullable optional fields, the strict handoff normalizes nulls, and regression coverage proves the provider contract."
+  -
+    author: "CODER"
+    body: "Verified: pre-merge closure packet is ready for the task PR."
 events:
   -
     type: "status"
@@ -59,8 +87,21 @@ events:
     from: "DOING"
     to: "DOING"
     note: "Implemented: Codex-compatible evaluator output schema now requires nullable optional fields, the strict handoff normalizes nulls, and regression coverage proves the provider contract."
+  -
+    type: "verify"
+    at: "2026-07-28T15:03:08.775Z"
+    author: "TESTER"
+    state: "ok"
+    note: "Verified evaluator schema compatibility: all structured-output properties are required with nullable optional metadata, nulls normalize before strict SGR validation, and the provider boundary remains read-only. Checks passed: focused evaluator suites (14), typecheck, format, routing validation."
+  -
+    type: "status"
+    at: "2026-07-28T15:11:53.640Z"
+    author: "CODER"
+    from: "DOING"
+    to: "DONE"
+    note: "Verified: pre-merge closure packet is ready for the task PR."
 doc_version: 3
-doc_updated_at: "2026-07-28T15:02:06.041Z"
+doc_updated_at: "2026-07-28T15:11:53.641Z"
 doc_updated_by: "CODER"
 description: "Release-blocking follow-up: make the evaluator typed-result JSON Schema compatible with the current Codex structured-output validator, preserve optional evidence fields through explicit nullable values, and add a regression test proving evaluator execution reaches a typed result instead of failing before the provider turn."
 sections:
@@ -83,11 +124,44 @@ sections:
     6. Compare the final result against the task summary and touched scope. Expected: remaining follow-up is either resolved or explicit in ## Findings.
   Verification: |-
     <!-- BEGIN VERIFICATION RESULTS -->
+    ### 2026-07-28T15:03:08.775Z — VERIFY — ok
+
+    By: TESTER
+
+    Note: Verified evaluator schema compatibility: all structured-output properties are required with nullable optional metadata, nulls normalize before strict SGR validation, and the provider boundary remains read-only. Checks passed: focused evaluator suites (14), typecheck, format, routing validation.
+    Attempts: 0
+
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-07-28T15:02:06.041Z, excerpt_hash=sha256:0f02b6024d3b7dd2a22a439db2952a208adb7ee3641e06cd4aebec162b19ed27
+
+    Details:
+
+    BlueprintSnapshotRef:
+    - state: current
+    - path: /Users/densmirnov/Github/agentplane/.agentplane/tmp/inc-20260727-main-lane.prxk2f/repo/.agentplane/worktrees/202607281455-147Q75-repair-evaluator-response-schema/.agentplane/tasks/202607281455-147Q75/blueprint/resolved-snapshot.json
+    - old_digest: 502c33075284ce6f9aa46423f98024e5cae094e841cac21d82f799f5898e4d05
+    - current_digest: 502c33075284ce6f9aa46423f98024e5cae094e841cac21d82f799f5898e4d05
+    - route_changed: no
+    - safe_command: agentplane blueprint snapshot 202607281455-147Q75
+
+    DecisionContextRef:
+    - operator_action: stop
+    - can_execute_now: false
+    - safe_command: none
+    - diagnostic_command: agentplane task verify-show 202607281455-147Q75
+    - source_of_truth: route=task_next_action diagnostic=task_next_action remote=not_checked
+    - freshness: route=computed_local remote=remote_skipped
+    - repeat_allowed: false
+    - repeat_stop_condition: after any non-zero exit or completed mutation, recompute task next-action before a second step
+    - risks: none
+
     <!-- END VERIFICATION RESULTS -->
   Rollback Plan: |-
     - Revert task-related commit(s).
     - Re-run required checks to confirm rollback safety.
-  Findings: ""
+  Findings: |-
+    - Observation: The previously rejected response format now has an OpenAI-compatible required/nullable shape.
+      Impact: Codex can begin the EVALUATOR turn instead of failing schema validation before review.
+      Resolution: Recorded local verification; the subsequent independent EVALUATOR episode will prove the live provider path.
 extensions:
   workflow_route_baseline:
     start_head_sha: "322533fd11f322aadf4e77a44d4343c0c6c19341"
@@ -123,6 +197,36 @@ PLANNER fallback scaffold. Replace with task-specific acceptance checks when PLA
 ## Verification
 
 <!-- BEGIN VERIFICATION RESULTS -->
+### 2026-07-28T15:03:08.775Z — VERIFY — ok
+
+By: TESTER
+
+Note: Verified evaluator schema compatibility: all structured-output properties are required with nullable optional metadata, nulls normalize before strict SGR validation, and the provider boundary remains read-only. Checks passed: focused evaluator suites (14), typecheck, format, routing validation.
+Attempts: 0
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-07-28T15:02:06.041Z, excerpt_hash=sha256:0f02b6024d3b7dd2a22a439db2952a208adb7ee3641e06cd4aebec162b19ed27
+
+Details:
+
+BlueprintSnapshotRef:
+- state: current
+- path: /Users/densmirnov/Github/agentplane/.agentplane/tmp/inc-20260727-main-lane.prxk2f/repo/.agentplane/worktrees/202607281455-147Q75-repair-evaluator-response-schema/.agentplane/tasks/202607281455-147Q75/blueprint/resolved-snapshot.json
+- old_digest: 502c33075284ce6f9aa46423f98024e5cae094e841cac21d82f799f5898e4d05
+- current_digest: 502c33075284ce6f9aa46423f98024e5cae094e841cac21d82f799f5898e4d05
+- route_changed: no
+- safe_command: agentplane blueprint snapshot 202607281455-147Q75
+
+DecisionContextRef:
+- operator_action: stop
+- can_execute_now: false
+- safe_command: none
+- diagnostic_command: agentplane task verify-show 202607281455-147Q75
+- source_of_truth: route=task_next_action diagnostic=task_next_action remote=not_checked
+- freshness: route=computed_local remote=remote_skipped
+- repeat_allowed: false
+- repeat_stop_condition: after any non-zero exit or completed mutation, recompute task next-action before a second step
+- risks: none
+
 <!-- END VERIFICATION RESULTS -->
 
 ## Rollback Plan
@@ -131,3 +235,7 @@ PLANNER fallback scaffold. Replace with task-specific acceptance checks when PLA
 - Re-run required checks to confirm rollback safety.
 
 ## Findings
+
+- Observation: The previously rejected response format now has an OpenAI-compatible required/nullable shape.
+  Impact: Codex can begin the EVALUATOR turn instead of failing schema validation before review.
+  Resolution: Recorded local verification; the subsequent independent EVALUATOR episode will prove the live provider path.

--- a/.agentplane/tasks/202607281455-147Q75/README.md
+++ b/.agentplane/tasks/202607281455-147Q75/README.md
@@ -4,7 +4,7 @@ title: "Repair evaluator response schema for Codex structured output"
 status: "DOING"
 priority: "high"
 owner: "CODER"
-revision: 4
+revision: 5
 origin:
   system: "manual"
 depends_on: []
@@ -34,11 +34,16 @@ verification:
   updated_by: null
   note: null
   attempts: 0
-commit: null
+commit:
+  hash: "b5cad73384df973a4a0845521c97723347af56f8"
+  message: "Repair evaluator structured-output schema"
 comments:
   -
     author: "CODER"
     body: "Start: repair the evaluator structured-output schema compatibility defect and add a focused provider-schema regression without changing evaluator review semantics."
+  -
+    author: "CODER"
+    body: "Implemented: Codex-compatible evaluator output schema now requires nullable optional fields, the strict handoff normalizes nulls, and regression coverage proves the provider contract."
 events:
   -
     type: "status"
@@ -47,8 +52,15 @@ events:
     from: "TODO"
     to: "DOING"
     note: "Start: repair the evaluator structured-output schema compatibility defect and add a focused provider-schema regression without changing evaluator review semantics."
+  -
+    type: "status"
+    at: "2026-07-28T15:02:06.041Z"
+    author: "CODER"
+    from: "DOING"
+    to: "DOING"
+    note: "Implemented: Codex-compatible evaluator output schema now requires nullable optional fields, the strict handoff normalizes nulls, and regression coverage proves the provider contract."
 doc_version: 3
-doc_updated_at: "2026-07-28T14:56:22.566Z"
+doc_updated_at: "2026-07-28T15:02:06.041Z"
 doc_updated_by: "CODER"
 description: "Release-blocking follow-up: make the evaluator typed-result JSON Schema compatible with the current Codex structured-output validator, preserve optional evidence fields through explicit nullable values, and add a regression test proving evaluator execution reaches a typed result instead of failing before the provider turn."
 sections:

--- a/.agentplane/tasks/202607281455-147Q75/README.md
+++ b/.agentplane/tasks/202607281455-147Q75/README.md
@@ -5,7 +5,7 @@ result_summary: "pre-merge closure"
 status: "DONE"
 priority: "high"
 owner: "CODER"
-revision: 9
+revision: 10
 origin:
   system: "manual"
 depends_on: []
@@ -37,28 +37,29 @@ verification:
   attempts: 0
 quality_review:
   state: "pass"
-  provenance: "evaluator_supplied"
-  updated_at: "2026-07-28T15:11:23.716Z"
-  updated_by: "EVALUATOR"
-  note: "EVALUATOR returned pass with 1 typed finding(s)."
-  evaluated_sha: "2a83376fe1a6b69d98ece871ecd2b0c200a204ba"
+  provenance: "human_supplied"
+  updated_at: "2026-07-28T15:36:51.396Z"
+  updated_by: "HUMAN"
+  note: "Independent review of the CI recovery patch: the null-normalization traversal now treats external arrays as unknown values before record narrowing, preserving the schema compatibility behavior while satisfying strict TypeScript safety."
+  evaluated_sha: "5fe3f261279c62fbcda629d4ee6cb539fdc956e1"
   blueprint_digest: "502c33075284ce6f9aa46423f98024e5cae094e841cac21d82f799f5898e4d05"
   evidence_refs:
-    - ".agentplane/tasks/202607281455-147Q75/quality/20260728-151123390-recovery-context/evaluator-work-order.json"
-    - ".agentplane/tasks/202607281455-147Q75/quality/20260728-151123390-recovery-context/quality-report.json"
-    - ".agentplane/tasks/202607281455-147Q75/quality/20260728-151123390-recovery-context/evaluator-prompt.md"
-    - ".agentplane/tasks/202607281455-147Q75/quality/20260728-151123390-recovery-context/evaluator-opinion.md"
-    - ".agentplane/tasks/202607281455-147Q75/quality/20260728-151123390-recovery-context/evaluator-result.json"
+    - ".agentplane/tasks/202607281455-147Q75/quality/20260728-153650388-recovery-context/evaluator-work-order.json"
+    - ".agentplane/tasks/202607281455-147Q75/quality/20260728-153650388-recovery-context/quality-report.json"
+    - ".agentplane/tasks/202607281455-147Q75/quality/20260728-153650388-recovery-context/evaluator-prompt.md"
+    - ".agentplane/tasks/202607281455-147Q75/quality/20260728-153650388-recovery-context/evaluator-opinion.md"
     - ".agentplane/tasks/202607281455-147Q75/README.md"
-    - ".agentplane/tasks/202607281455-147Q75/quality/20260728-151123390-recovery-context/evaluator-diff.patch"
-    - ".agentplane/tasks/202607281455-147Q75/quality/20260728-151123390-recovery-context/evaluator-observed-checks.json"
-    - ".agentplane/tasks/202607281455-147Q75/quality/20260728-151123390-recovery-context/evaluator-blueprint.json"
+    - ".agentplane/tasks/202607281455-147Q75/quality/20260728-153650388-recovery-context/evaluator-diff.patch"
+    - ".agentplane/tasks/202607281455-147Q75/quality/20260728-153650388-recovery-context/evaluator-observed-checks.json"
+    - ".agentplane/tasks/202607281455-147Q75/quality/20260728-153650388-recovery-context/evaluator-blueprint.json"
     - ".agentplane/policy/dod.code.md"
     - ".agentplane/policy/dod.core.md"
     - ".agentplane/policy/security.must.md"
     - ".agentplane/policy/workflow.branch_pr.md"
+    - "packages/agentplane/src/commands/evaluator/evaluator-review-usecase.ts"
+    - "5fe3f261279c62fbcda629d4ee6cb539fdc956e1"
   findings:
-    - "The response schema requires every declared key and represents optional source metadata and recovery context as null-capable fields; strict validation removes null placeholders before frozen-evidence checks."
+    - "The normalization path preserves its read-only semantics: only null placeholders are removed from copied records, while non-record and array values remain opaque unknown values."
 commit:
   hash: "2a83376fe1a6b69d98ece871ecd2b0c200a204ba"
   message: "Record evaluator schema implementation"

--- a/.agentplane/tasks/202607281455-147Q75/README.md
+++ b/.agentplane/tasks/202607281455-147Q75/README.md
@@ -5,7 +5,7 @@ result_summary: "pre-merge closure"
 status: "DONE"
 priority: "high"
 owner: "CODER"
-revision: 10
+revision: 11
 origin:
   system: "manual"
 depends_on: []
@@ -61,8 +61,8 @@ quality_review:
   findings:
     - "The normalization path preserves its read-only semantics: only null placeholders are removed from copied records, while non-record and array values remain opaque unknown values."
 commit:
-  hash: "2a83376fe1a6b69d98ece871ecd2b0c200a204ba"
-  message: "Record evaluator schema implementation"
+  hash: "4166c925343d0ea836bc65297689f4b179382602"
+  message: "Record evaluator CI recovery review"
 comments:
   -
     author: "CODER"
@@ -73,6 +73,9 @@ comments:
   -
     author: "CODER"
     body: "Verified: pre-merge closure packet is ready for the task PR."
+  -
+    author: "CODER"
+    body: "Verified: refreshed pre-merge closure packet is ready for the task PR."
 events:
   -
     type: "status"
@@ -101,8 +104,15 @@ events:
     from: "DOING"
     to: "DONE"
     note: "Verified: pre-merge closure packet is ready for the task PR."
+  -
+    type: "status"
+    at: "2026-07-28T15:38:08.670Z"
+    author: "CODER"
+    from: "DONE"
+    to: "DONE"
+    note: "Verified: refreshed pre-merge closure packet is ready for the task PR."
 doc_version: 3
-doc_updated_at: "2026-07-28T15:11:53.641Z"
+doc_updated_at: "2026-07-28T15:38:08.671Z"
 doc_updated_by: "CODER"
 description: "Release-blocking follow-up: make the evaluator typed-result JSON Schema compatible with the current Codex structured-output validator, preserve optional evidence fields through explicit nullable values, and add a regression test proving evaluator execution reaches a typed result instead of failing before the provider turn."
 sections:
@@ -164,6 +174,9 @@ sections:
       Impact: Codex can begin the EVALUATOR turn instead of failing schema validation before review.
       Resolution: Recorded local verification; the subsequent independent EVALUATOR episode will prove the live provider path.
 extensions:
+  implementation_commit:
+    hash: "5fe3f261279c62fbcda629d4ee6cb539fdc956e1"
+    message: "Fix evaluator null normalization lint"
   workflow_route_baseline:
     start_head_sha: "322533fd11f322aadf4e77a44d4343c0c6c19341"
     version: 1

--- a/.agentplane/tasks/202607281455-147Q75/README.md
+++ b/.agentplane/tasks/202607281455-147Q75/README.md
@@ -1,0 +1,121 @@
+---
+id: "202607281455-147Q75"
+title: "Repair evaluator response schema for Codex structured output"
+status: "DOING"
+priority: "high"
+owner: "CODER"
+revision: 4
+origin:
+  system: "manual"
+depends_on: []
+tags:
+  - "code"
+  - "evaluator"
+  - "provider"
+  - "regression"
+  - "release-blocker"
+  - "v0.7"
+task_kind: "code"
+mutation_scope: "code"
+blueprint_request: "code.branch_pr"
+verify:
+  - "bun run format:changed"
+  - "bun run typecheck"
+  - "bunx vitest run packages/agentplane/src/commands/evaluator/evaluator-episode.calibration.test.ts packages/agentplane/src/commands/evaluator/evaluator-execute.command.test.ts"
+  - "node .agentplane/policy/check-routing.mjs"
+plan_approval:
+  state: "approved"
+  updated_at: "2026-07-28T14:56:09.876Z"
+  updated_by: "ORCHESTRATOR"
+  note: null
+verification:
+  state: "pending"
+  updated_at: null
+  updated_by: null
+  note: null
+  attempts: 0
+commit: null
+comments:
+  -
+    author: "CODER"
+    body: "Start: repair the evaluator structured-output schema compatibility defect and add a focused provider-schema regression without changing evaluator review semantics."
+events:
+  -
+    type: "status"
+    at: "2026-07-28T14:56:22.566Z"
+    author: "CODER"
+    from: "TODO"
+    to: "DOING"
+    note: "Start: repair the evaluator structured-output schema compatibility defect and add a focused provider-schema regression without changing evaluator review semantics."
+doc_version: 3
+doc_updated_at: "2026-07-28T14:56:22.566Z"
+doc_updated_by: "CODER"
+description: "Release-blocking follow-up: make the evaluator typed-result JSON Schema compatible with the current Codex structured-output validator, preserve optional evidence fields through explicit nullable values, and add a regression test proving evaluator execution reaches a typed result instead of failing before the provider turn."
+sections:
+  Summary: |-
+    Repair evaluator response schema for Codex structured output
+
+    Release-blocking follow-up: make the evaluator typed-result JSON Schema compatible with the current Codex structured-output validator, preserve optional evidence fields through explicit nullable values, and add a regression test proving evaluator execution reaches a typed result instead of failing before the provider turn.
+  Scope: |-
+    - In scope: Release-blocking follow-up: make the evaluator typed-result JSON Schema compatible with the current Codex structured-output validator, preserve optional evidence fields through explicit nullable values, and add a regression test proving evaluator execution reaches a typed result instead of failing before the provider turn.
+    - Out of scope: unrelated refactors not required for "Repair evaluator response schema for Codex structured output".
+  Plan: "1. Change only the evaluator structured-output schema and its focused tests so Codex accepts the response format while the existing strict result validator keeps evidence fields semantically optional. 2. Add a regression that asserts the nested evidence reference schema is OpenAI-compatible and preserves nullable optional fields. 3. Run the declared evaluator tests, typecheck, format:changed, and routing validation. 4. Publish the task branch PR; record TESTER verification, EVALUATOR review, hosted checks, and integration before resuming task 202607221850-8HBF4J."
+  Verify Steps: |-
+    PLANNER fallback scaffold. Replace with task-specific acceptance checks when PLANNER context is available.
+
+    1. Run `bunx vitest run packages/agentplane/src/commands/evaluator/evaluator-episode.calibration.test.ts packages/agentplane/src/commands/evaluator/evaluator-execute.command.test.ts`. Expected: it succeeds and confirms the requested outcome for this task.
+    2. Run `bun run typecheck`. Expected: it succeeds and confirms the requested outcome for this task.
+    3. Run `bun run format:changed`. Expected: it succeeds and confirms the requested outcome for this task.
+    4. Run `node .agentplane/policy/check-routing.mjs`. Expected: it succeeds and confirms the requested outcome for this task.
+    5. Review the changed artifact or behavior for the `code` task. Expected: the requested outcome is visible and matches the approved scope.
+    6. Compare the final result against the task summary and touched scope. Expected: remaining follow-up is either resolved or explicit in ## Findings.
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: ""
+extensions:
+  workflow_route_baseline:
+    start_head_sha: "322533fd11f322aadf4e77a44d4343c0c6c19341"
+    version: 1
+id_source: "generated"
+---
+## Summary
+
+Repair evaluator response schema for Codex structured output
+
+Release-blocking follow-up: make the evaluator typed-result JSON Schema compatible with the current Codex structured-output validator, preserve optional evidence fields through explicit nullable values, and add a regression test proving evaluator execution reaches a typed result instead of failing before the provider turn.
+
+## Scope
+
+- In scope: Release-blocking follow-up: make the evaluator typed-result JSON Schema compatible with the current Codex structured-output validator, preserve optional evidence fields through explicit nullable values, and add a regression test proving evaluator execution reaches a typed result instead of failing before the provider turn.
+- Out of scope: unrelated refactors not required for "Repair evaluator response schema for Codex structured output".
+
+## Plan
+
+1. Change only the evaluator structured-output schema and its focused tests so Codex accepts the response format while the existing strict result validator keeps evidence fields semantically optional. 2. Add a regression that asserts the nested evidence reference schema is OpenAI-compatible and preserves nullable optional fields. 3. Run the declared evaluator tests, typecheck, format:changed, and routing validation. 4. Publish the task branch PR; record TESTER verification, EVALUATOR review, hosted checks, and integration before resuming task 202607221850-8HBF4J.
+
+## Verify Steps
+
+PLANNER fallback scaffold. Replace with task-specific acceptance checks when PLANNER context is available.
+
+1. Run `bunx vitest run packages/agentplane/src/commands/evaluator/evaluator-episode.calibration.test.ts packages/agentplane/src/commands/evaluator/evaluator-execute.command.test.ts`. Expected: it succeeds and confirms the requested outcome for this task.
+2. Run `bun run typecheck`. Expected: it succeeds and confirms the requested outcome for this task.
+3. Run `bun run format:changed`. Expected: it succeeds and confirms the requested outcome for this task.
+4. Run `node .agentplane/policy/check-routing.mjs`. Expected: it succeeds and confirms the requested outcome for this task.
+5. Review the changed artifact or behavior for the `code` task. Expected: the requested outcome is visible and matches the approved scope.
+6. Compare the final result against the task summary and touched scope. Expected: remaining follow-up is either resolved or explicit in ## Findings.
+
+## Verification
+
+<!-- BEGIN VERIFICATION RESULTS -->
+<!-- END VERIFICATION RESULTS -->
+
+## Rollback Plan
+
+- Revert task-related commit(s).
+- Re-run required checks to confirm rollback safety.
+
+## Findings

--- a/.agentplane/tasks/202607281455-147Q75/blueprint/resolved-snapshot.json
+++ b/.agentplane/tasks/202607281455-147Q75/blueprint/resolved-snapshot.json
@@ -1,0 +1,582 @@
+{
+  "schemaVersion": 1,
+  "artifactKind": "agentplane.blueprint.resolved_snapshot",
+  "resolverInput": {
+    "taskId": "202607281455-147Q75",
+    "title": "Repair evaluator response schema for Codex structured output",
+    "description": "Release-blocking follow-up: make the evaluator typed-result JSON Schema compatible with the current Codex structured-output validator, preserve optional evidence fields through explicit nullable values, and add a regression test proving evaluator execution reaches a typed result instead of failing before the provider turn.",
+    "tags": [
+      "code",
+      "evaluator",
+      "provider",
+      "regression",
+      "release-blocker",
+      "v0.7"
+    ],
+    "owner": "CODER",
+    "taskKind": "code",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "mutation": "code",
+    "mutationScope": "code",
+    "touchedPaths": [],
+    "recipeHints": [],
+    "riskFlags": [],
+    "blueprintRequest": "code.branch_pr"
+  },
+  "selectedBlueprint": {
+    "id": "code.branch_pr",
+    "version": 1,
+    "title": "Branch PR code change",
+    "taskKinds": [
+      "code"
+    ],
+    "workflowModes": [
+      "branch_pr"
+    ]
+  },
+  "plan": {
+    "schemaVersion": 1,
+    "blueprintId": "code.branch_pr",
+    "blueprintVersion": 1,
+    "title": "Branch PR code change",
+    "taskId": "202607281455-147Q75",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "taskIntent": {
+      "taskKind": "code",
+      "mutationScope": "code",
+      "blueprintRequest": "code.branch_pr"
+    },
+    "whySelected": [
+      "explicit blueprint requested: code.branch_pr",
+      "task intent kind: code",
+      "workflow mode: branch_pr",
+      "task intent mutation scope: code"
+    ],
+    "states": [
+      {
+        "id": "intake",
+        "kind": "intake",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": []
+      },
+      {
+        "id": "scope",
+        "kind": "scope",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "assumptions"
+        ]
+      },
+      {
+        "id": "approval_gate",
+        "kind": "approval_gate",
+        "mode": "approval",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "approval"
+        ]
+      },
+      {
+        "id": "context_resolve",
+        "kind": "context_resolve",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [
+          ".agentplane/policy/security.must.md",
+          ".agentplane/policy/dod.core.md",
+          ".agentplane/policy/dod.code.md",
+          ".agentplane/policy/workflow.branch_pr.md"
+        ],
+        "evidenceKinds": [
+          "context_manifest"
+        ]
+      },
+      {
+        "id": "worktree_start",
+        "kind": "worktree_start",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "work_unit",
+        "kind": "work_unit",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "fast_local_checks",
+        "kind": "fast_local_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane task verify-show <task-id>",
+          "project focused checks"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "pr_artifact",
+        "kind": "pr_artifact",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "artifact",
+          "external_link"
+        ]
+      },
+      {
+        "id": "verify_record",
+        "kind": "verify_record",
+        "mode": "record",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "quality_gate",
+        "kind": "quality_gate",
+        "mode": "agentic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane evaluator run <task-id> --provenance human_supplied|evaluator_supplied --verdict pass|rework|blocked|human_review"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "quality_report"
+        ]
+      },
+      {
+        "id": "hosted_checks",
+        "kind": "hosted_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result",
+          "external_link"
+        ]
+      },
+      {
+        "id": "publish_or_integrate",
+        "kind": "publish_or_integrate",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane integrate <task-id> --branch <branch> --run-verify"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit",
+          "external_link"
+        ]
+      },
+      {
+        "id": "finish",
+        "kind": "finish",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit"
+        ]
+      }
+    ],
+    "requiredEvidence": [
+      {
+        "id": "code_pr.paths",
+        "kind": "changed_paths",
+        "producedBy": "work_unit",
+        "required": true,
+        "description": "Changed source paths."
+      },
+      {
+        "id": "code_pr.fast_checks",
+        "kind": "check_result",
+        "producedBy": "fast_local_checks",
+        "required": true,
+        "description": "Fast local checks."
+      },
+      {
+        "id": "code_pr.pr",
+        "kind": "external_link",
+        "producedBy": "pr_artifact",
+        "required": true,
+        "description": "Pull request artifact."
+      },
+      {
+        "id": "code_pr.verify",
+        "kind": "check_result",
+        "producedBy": "verify_record",
+        "required": true,
+        "description": "Task branch verification."
+      },
+      {
+        "id": "code_pr.quality",
+        "kind": "quality_report",
+        "producedBy": "quality_gate",
+        "required": true,
+        "description": "EVALUATOR quality verdict."
+      },
+      {
+        "id": "code_pr.hosted",
+        "kind": "check_result",
+        "producedBy": "hosted_checks",
+        "required": true,
+        "description": "Hosted check evidence."
+      },
+      {
+        "id": "code_pr.commit",
+        "kind": "commit",
+        "producedBy": "publish_or_integrate",
+        "required": true,
+        "description": "Integration commit."
+      }
+    ],
+    "policyModules": [
+      ".agentplane/policy/dod.code.md",
+      ".agentplane/policy/dod.core.md",
+      ".agentplane/policy/security.must.md",
+      ".agentplane/policy/workflow.branch_pr.md"
+    ],
+    "allowedCommands": [
+      "agentplane evaluator run <task-id> --provenance human_supplied|evaluator_supplied --verdict pass|rework|blocked|human_review",
+      "agentplane integrate <task-id> --branch <branch> --run-verify",
+      "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+      "agentplane task verify-show <task-id>",
+      "agentplane verify <task-id> --ok|--rework",
+      "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+      "project focused checks"
+    ],
+    "contextBudget": {
+      "maxPolicyModules": 4,
+      "maxPromptBlocks": 14,
+      "rationale": "Branch PR code work needs code DoD, branch_pr route policy, and evidence checks."
+    },
+    "contextManifest": [],
+    "acceptedRecipeExtensions": [],
+    "rejectedRecipeExtensions": [],
+    "stopReasons": []
+  },
+  "nodes": [
+    {
+      "id": "intake",
+      "kind": "intake",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": []
+    },
+    {
+      "id": "scope",
+      "kind": "scope",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "assumptions"
+      ]
+    },
+    {
+      "id": "approval_gate",
+      "kind": "approval_gate",
+      "mode": "approval",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "approval"
+      ]
+    },
+    {
+      "id": "context_resolve",
+      "kind": "context_resolve",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [
+        ".agentplane/policy/security.must.md",
+        ".agentplane/policy/dod.core.md",
+        ".agentplane/policy/dod.code.md",
+        ".agentplane/policy/workflow.branch_pr.md"
+      ],
+      "evidenceKinds": [
+        "context_manifest"
+      ]
+    },
+    {
+      "id": "worktree_start",
+      "kind": "worktree_start",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "work_unit",
+      "kind": "work_unit",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "fast_local_checks",
+      "kind": "fast_local_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane task verify-show <task-id>",
+        "project focused checks"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "pr_artifact",
+      "kind": "pr_artifact",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "artifact",
+        "external_link"
+      ]
+    },
+    {
+      "id": "verify_record",
+      "kind": "verify_record",
+      "mode": "record",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "quality_gate",
+      "kind": "quality_gate",
+      "mode": "agentic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane evaluator run <task-id> --provenance human_supplied|evaluator_supplied --verdict pass|rework|blocked|human_review"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "quality_report"
+      ]
+    },
+    {
+      "id": "hosted_checks",
+      "kind": "hosted_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result",
+        "external_link"
+      ]
+    },
+    {
+      "id": "publish_or_integrate",
+      "kind": "publish_or_integrate",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane integrate <task-id> --branch <branch> --run-verify"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit",
+        "external_link"
+      ]
+    },
+    {
+      "id": "finish",
+      "kind": "finish",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit"
+      ]
+    }
+  ],
+  "requiredEvidence": [
+    {
+      "id": "code_pr.paths",
+      "kind": "changed_paths",
+      "producedBy": "work_unit",
+      "required": true,
+      "description": "Changed source paths."
+    },
+    {
+      "id": "code_pr.fast_checks",
+      "kind": "check_result",
+      "producedBy": "fast_local_checks",
+      "required": true,
+      "description": "Fast local checks."
+    },
+    {
+      "id": "code_pr.pr",
+      "kind": "external_link",
+      "producedBy": "pr_artifact",
+      "required": true,
+      "description": "Pull request artifact."
+    },
+    {
+      "id": "code_pr.verify",
+      "kind": "check_result",
+      "producedBy": "verify_record",
+      "required": true,
+      "description": "Task branch verification."
+    },
+    {
+      "id": "code_pr.quality",
+      "kind": "quality_report",
+      "producedBy": "quality_gate",
+      "required": true,
+      "description": "EVALUATOR quality verdict."
+    },
+    {
+      "id": "code_pr.hosted",
+      "kind": "check_result",
+      "producedBy": "hosted_checks",
+      "required": true,
+      "description": "Hosted check evidence."
+    },
+    {
+      "id": "code_pr.commit",
+      "kind": "commit",
+      "producedBy": "publish_or_integrate",
+      "required": true,
+      "description": "Integration commit."
+    }
+  ],
+  "policyModules": [
+    ".agentplane/policy/dod.code.md",
+    ".agentplane/policy/dod.core.md",
+    ".agentplane/policy/security.must.md",
+    ".agentplane/policy/workflow.branch_pr.md"
+  ],
+  "allowedCommands": [
+    "agentplane evaluator run <task-id> --provenance human_supplied|evaluator_supplied --verdict pass|rework|blocked|human_review",
+    "agentplane integrate <task-id> --branch <branch> --run-verify",
+    "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+    "agentplane task verify-show <task-id>",
+    "agentplane verify <task-id> --ok|--rework",
+    "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+    "project focused checks"
+  ],
+  "contextBudget": {
+    "maxPolicyModules": 4,
+    "maxPromptBlocks": 14,
+    "rationale": "Branch PR code work needs code DoD, branch_pr route policy, and evidence checks."
+  },
+  "contextManifest": [],
+  "acceptedRecipeExtensions": [],
+  "rejectedRecipeExtensions": [],
+  "stopReasons": [],
+  "selectionReasons": [
+    "explicit blueprint requested: code.branch_pr",
+    "task intent kind: code",
+    "workflow mode: branch_pr",
+    "task intent mutation scope: code"
+  ],
+  "digest": {
+    "algorithm": "sha256",
+    "value": "502c33075284ce6f9aa46423f98024e5cae094e841cac21d82f799f5898e4d05"
+  }
+}

--- a/.agentplane/tasks/202607281455-147Q75/pr/diffstat.txt
+++ b/.agentplane/tasks/202607281455-147Q75/pr/diffstat.txt
@@ -1,4 +1,4 @@
  .../evaluator-episode.calibration.test.ts          | 59 ++++++++++++++++++----
  .../src/commands/evaluator/evaluator-episode.ts    | 29 ++++++++---
- .../commands/evaluator/evaluator-review-usecase.ts | 23 ++++++++-
- 3 files changed, 93 insertions(+), 18 deletions(-)
+ .../commands/evaluator/evaluator-review-usecase.ts | 25 ++++++++-
+ 3 files changed, 95 insertions(+), 18 deletions(-)

--- a/.agentplane/tasks/202607281455-147Q75/pr/diffstat.txt
+++ b/.agentplane/tasks/202607281455-147Q75/pr/diffstat.txt
@@ -1,0 +1,4 @@
+ .../evaluator-episode.calibration.test.ts          | 59 ++++++++++++++++++----
+ .../src/commands/evaluator/evaluator-episode.ts    | 29 ++++++++---
+ .../commands/evaluator/evaluator-review-usecase.ts | 23 ++++++++-
+ 3 files changed, 93 insertions(+), 18 deletions(-)

--- a/.agentplane/tasks/202607281455-147Q75/pr/github-body.md
+++ b/.agentplane/tasks/202607281455-147Q75/pr/github-body.md
@@ -15,19 +15,28 @@ Release-blocking follow-up: make the evaluator typed-result JSON Schema compatib
 
 ## Verification
 
-- State: pending
-- Note: Not recorded yet.
+- State: ok
+- Note:
+
+```text
+Verified evaluator schema compatibility: all structured-output properties are required with nullable
+optional metadata, nulls normalize before strict SGR validation, and the provider boundary remains
+read-only. Checks passed: focused evaluator suites (14), typecheck, format, routing validation.
+```
 - Canonical workflow state lives in the task README.
 
 <details>
 <summary>Raw evidence</summary>
 
-- Updated: 2026-07-28T14:56:22.735Z
+- Updated: 2026-07-28T14:56:52.349Z
 - Branch: task/202607281455-147Q75/repair-evaluator-response-schema
 - Head: computed live by `agentplane pr check` / `agentplane integrate`
 
 ```text
-No changes detected.
+ .../evaluator-episode.calibration.test.ts          | 59 ++++++++++++++++++----
+ .../src/commands/evaluator/evaluator-episode.ts    | 29 ++++++++---
+ .../commands/evaluator/evaluator-review-usecase.ts | 23 ++++++++-
+ 3 files changed, 93 insertions(+), 18 deletions(-)
 ```
 
 </details>

--- a/.agentplane/tasks/202607281455-147Q75/pr/github-body.md
+++ b/.agentplane/tasks/202607281455-147Q75/pr/github-body.md
@@ -35,8 +35,8 @@ read-only. Checks passed: focused evaluator suites (14), typecheck, format, rout
 ```text
  .../evaluator-episode.calibration.test.ts          | 59 ++++++++++++++++++----
  .../src/commands/evaluator/evaluator-episode.ts    | 29 ++++++++---
- .../commands/evaluator/evaluator-review-usecase.ts | 23 ++++++++-
- 3 files changed, 93 insertions(+), 18 deletions(-)
+ .../commands/evaluator/evaluator-review-usecase.ts | 25 ++++++++-
+ 3 files changed, 95 insertions(+), 18 deletions(-)
 ```
 
 </details>

--- a/.agentplane/tasks/202607281455-147Q75/pr/github-body.md
+++ b/.agentplane/tasks/202607281455-147Q75/pr/github-body.md
@@ -1,0 +1,33 @@
+Task: `202607281455-147Q75`
+Title: Repair evaluator response schema for Codex structured output
+Canonical task record: `.agentplane/tasks/202607281455-147Q75/README.md`
+
+## Summary
+
+Repair evaluator response schema for Codex structured output
+
+Release-blocking follow-up: make the evaluator typed-result JSON Schema compatible with the current Codex structured-output validator, preserve optional evidence fields through explicit nullable values, and add a regression test proving evaluator execution reaches a typed result instead of failing before the provider turn.
+
+## Scope
+
+- In scope: Release-blocking follow-up: make the evaluator typed-result JSON Schema compatible with the current Codex structured-output validator, preserve optional evidence fields through explicit nullable values, and add a regression test proving evaluator execution reaches a typed result instead of failing before the provider turn.
+- Out of scope: unrelated refactors not required for "Repair evaluator response schema for Codex structured output".
+
+## Verification
+
+- State: pending
+- Note: Not recorded yet.
+- Canonical workflow state lives in the task README.
+
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-07-28T14:56:22.735Z
+- Branch: task/202607281455-147Q75/repair-evaluator-response-schema
+- Head: computed live by `agentplane pr check` / `agentplane integrate`
+
+```text
+No changes detected.
+```
+
+</details>

--- a/.agentplane/tasks/202607281455-147Q75/pr/github-title.txt
+++ b/.agentplane/tasks/202607281455-147Q75/pr/github-title.txt
@@ -1,0 +1,1 @@
+🚧 147Q75 task: Repair evaluator response schema for Codex structured output [202607281455-147Q75]

--- a/.agentplane/tasks/202607281455-147Q75/pr/github-title.txt
+++ b/.agentplane/tasks/202607281455-147Q75/pr/github-title.txt
@@ -1,1 +1,1 @@
-🚧 147Q75 task: Repair evaluator response schema for Codex structured output [202607281455-147Q75]
+✅ 147Q75 task: Repair evaluator response schema for Codex structured output [202607281455-147Q75]

--- a/.agentplane/tasks/202607281455-147Q75/pr/meta.json
+++ b/.agentplane/tasks/202607281455-147Q75/pr/meta.json
@@ -2,15 +2,23 @@
   "base": "main",
   "branch": "task/202607281455-147Q75/repair-evaluator-response-schema",
   "created_at": "2026-07-28T14:56:22.735Z",
-  "diffstat_sha256": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-  "last_verified_at": null,
+  "diffstat_sha256": "sha256:7b10d23b67d648d15fa1a62b935c84c12238d695b13a36e5e63bef51ddbb6f6d",
+  "last_verified_at": "2026-07-28T15:03:08.775Z",
+  "last_verified_diffstat_sha256": "sha256:7b10d23b67d648d15fa1a62b935c84c12238d695b13a36e5e63bef51ddbb6f6d",
   "pr_number": 4660,
   "pr_url": "https://github.com/basilisk-labs/agentplane/pull/4660",
+  "pre_merge_closure": {
+    "basis_commit": "2a83376fe1a6b69d98ece871ecd2b0c200a204ba",
+    "branch": "task/202607281455-147Q75/repair-evaluator-response-schema",
+    "pr_number": 4660,
+    "recorded_at": "2026-07-28T15:11:53.714Z",
+    "state": "closed_before_merge"
+  },
   "schema_version": 1,
   "status": "OPEN",
   "task_id": "202607281455-147Q75",
   "updated_at": "2026-07-28T14:56:52.349Z",
   "verify": {
-    "status": "skipped"
+    "status": "pass"
   }
 }

--- a/.agentplane/tasks/202607281455-147Q75/pr/meta.json
+++ b/.agentplane/tasks/202607281455-147Q75/pr/meta.json
@@ -8,10 +8,10 @@
   "pr_number": 4660,
   "pr_url": "https://github.com/basilisk-labs/agentplane/pull/4660",
   "pre_merge_closure": {
-    "basis_commit": "2a83376fe1a6b69d98ece871ecd2b0c200a204ba",
+    "basis_commit": "4166c925343d0ea836bc65297689f4b179382602",
     "branch": "task/202607281455-147Q75/repair-evaluator-response-schema",
     "pr_number": 4660,
-    "recorded_at": "2026-07-28T15:11:53.714Z",
+    "recorded_at": "2026-07-28T15:38:08.751Z",
     "state": "closed_before_merge"
   },
   "schema_version": 1,

--- a/.agentplane/tasks/202607281455-147Q75/pr/meta.json
+++ b/.agentplane/tasks/202607281455-147Q75/pr/meta.json
@@ -1,0 +1,13 @@
+{
+  "base": "main",
+  "branch": "task/202607281455-147Q75/repair-evaluator-response-schema",
+  "created_at": "2026-07-28T14:56:22.735Z",
+  "diffstat_sha256": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "last_verified_at": null,
+  "schema_version": 1,
+  "task_id": "202607281455-147Q75",
+  "updated_at": "2026-07-28T14:56:22.735Z",
+  "verify": {
+    "status": "skipped"
+  }
+}

--- a/.agentplane/tasks/202607281455-147Q75/pr/meta.json
+++ b/.agentplane/tasks/202607281455-147Q75/pr/meta.json
@@ -2,7 +2,7 @@
   "base": "main",
   "branch": "task/202607281455-147Q75/repair-evaluator-response-schema",
   "created_at": "2026-07-28T14:56:22.735Z",
-  "diffstat_sha256": "sha256:7b10d23b67d648d15fa1a62b935c84c12238d695b13a36e5e63bef51ddbb6f6d",
+  "diffstat_sha256": "sha256:4e4d54acd65143b05ecf775a67200dcf67249f52734cebcf9bad435e68b08967",
   "last_verified_at": "2026-07-28T15:03:08.775Z",
   "last_verified_diffstat_sha256": "sha256:7b10d23b67d648d15fa1a62b935c84c12238d695b13a36e5e63bef51ddbb6f6d",
   "pr_number": 4660,

--- a/.agentplane/tasks/202607281455-147Q75/pr/meta.json
+++ b/.agentplane/tasks/202607281455-147Q75/pr/meta.json
@@ -4,9 +4,12 @@
   "created_at": "2026-07-28T14:56:22.735Z",
   "diffstat_sha256": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
   "last_verified_at": null,
+  "pr_number": 4660,
+  "pr_url": "https://github.com/basilisk-labs/agentplane/pull/4660",
   "schema_version": 1,
+  "status": "OPEN",
   "task_id": "202607281455-147Q75",
-  "updated_at": "2026-07-28T14:56:22.735Z",
+  "updated_at": "2026-07-28T14:56:52.349Z",
   "verify": {
     "status": "skipped"
   }

--- a/.agentplane/tasks/202607281455-147Q75/pr/review.md
+++ b/.agentplane/tasks/202607281455-147Q75/pr/review.md
@@ -6,14 +6,14 @@ Created: 2026-07-28T14:56:22.735Z
 
 - Task: `202607281455-147Q75`
 - Title: Repair evaluator response schema for Codex structured output
-- Status: DOING
+- Status: DONE
 - Branch: `task/202607281455-147Q75/repair-evaluator-response-schema`
 - Canonical task record: `.agentplane/tasks/202607281455-147Q75/README.md`
 
 ## Verification
 
-- State: pending
-- Note: Not recorded yet.
+- State: ok
+- Note: Verified evaluator schema compatibility: all structured-output properties are required with nullable optional metadata, nulls normalize before strict SGR validation, and the provider boundary remains read-only. Checks passed: focused evaluator suites (14), typecheck, format, routing validation.
 - Canonical workflow state lives in the task README.
 
 ## Handoff Notes
@@ -24,12 +24,15 @@ Created: 2026-07-28T14:56:22.735Z
 <details>
 <summary>Raw evidence</summary>
 
-- Updated: 2026-07-28T14:56:22.735Z
+- Updated: 2026-07-28T14:56:52.349Z
 - Branch: task/202607281455-147Q75/repair-evaluator-response-schema
 - Head: computed live by `agentplane pr check` / `agentplane integrate`
 
 ```text
-No changes detected.
+ .../evaluator-episode.calibration.test.ts          | 59 ++++++++++++++++++----
+ .../src/commands/evaluator/evaluator-episode.ts    | 29 ++++++++---
+ .../commands/evaluator/evaluator-review-usecase.ts | 23 ++++++++-
+ 3 files changed, 93 insertions(+), 18 deletions(-)
 ```
 
 </details>

--- a/.agentplane/tasks/202607281455-147Q75/pr/review.md
+++ b/.agentplane/tasks/202607281455-147Q75/pr/review.md
@@ -31,8 +31,8 @@ Created: 2026-07-28T14:56:22.735Z
 ```text
  .../evaluator-episode.calibration.test.ts          | 59 ++++++++++++++++++----
  .../src/commands/evaluator/evaluator-episode.ts    | 29 ++++++++---
- .../commands/evaluator/evaluator-review-usecase.ts | 23 ++++++++-
- 3 files changed, 93 insertions(+), 18 deletions(-)
+ .../commands/evaluator/evaluator-review-usecase.ts | 25 ++++++++-
+ 3 files changed, 95 insertions(+), 18 deletions(-)
 ```
 
 </details>

--- a/.agentplane/tasks/202607281455-147Q75/pr/review.md
+++ b/.agentplane/tasks/202607281455-147Q75/pr/review.md
@@ -1,0 +1,36 @@
+# PR Review
+
+Created: 2026-07-28T14:56:22.735Z
+
+## Task
+
+- Task: `202607281455-147Q75`
+- Title: Repair evaluator response schema for Codex structured output
+- Status: DOING
+- Branch: `task/202607281455-147Q75/repair-evaluator-response-schema`
+- Canonical task record: `.agentplane/tasks/202607281455-147Q75/README.md`
+
+## Verification
+
+- State: pending
+- Note: Not recorded yet.
+- Canonical workflow state lives in the task README.
+
+## Handoff Notes
+
+- No handoff notes recorded yet. Use `agentplane pr note ...` to append one.
+
+<!-- BEGIN AUTO SUMMARY -->
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-07-28T14:56:22.735Z
+- Branch: task/202607281455-147Q75/repair-evaluator-response-schema
+- Head: computed live by `agentplane pr check` / `agentplane integrate`
+
+```text
+No changes detected.
+```
+
+</details>
+<!-- END AUTO SUMMARY -->

--- a/.agentplane/tasks/202607281455-147Q75/quality/20260728-150336937-recovery-context/evaluator-blueprint.json
+++ b/.agentplane/tasks/202607281455-147Q75/quality/20260728-150336937-recovery-context/evaluator-blueprint.json
@@ -1,0 +1,582 @@
+{
+  "schemaVersion": 1,
+  "artifactKind": "agentplane.blueprint.resolved_snapshot",
+  "resolverInput": {
+    "taskId": "202607281455-147Q75",
+    "title": "Repair evaluator response schema for Codex structured output",
+    "description": "Release-blocking follow-up: make the evaluator typed-result JSON Schema compatible with the current Codex structured-output validator, preserve optional evidence fields through explicit nullable values, and add a regression test proving evaluator execution reaches a typed result instead of failing before the provider turn.",
+    "tags": [
+      "code",
+      "evaluator",
+      "provider",
+      "regression",
+      "release-blocker",
+      "v0.7"
+    ],
+    "owner": "CODER",
+    "taskKind": "code",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "mutation": "code",
+    "mutationScope": "code",
+    "touchedPaths": [],
+    "recipeHints": [],
+    "riskFlags": [],
+    "blueprintRequest": "code.branch_pr"
+  },
+  "selectedBlueprint": {
+    "id": "code.branch_pr",
+    "version": 1,
+    "title": "Branch PR code change",
+    "taskKinds": [
+      "code"
+    ],
+    "workflowModes": [
+      "branch_pr"
+    ]
+  },
+  "plan": {
+    "schemaVersion": 1,
+    "blueprintId": "code.branch_pr",
+    "blueprintVersion": 1,
+    "title": "Branch PR code change",
+    "taskId": "202607281455-147Q75",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "taskIntent": {
+      "taskKind": "code",
+      "mutationScope": "code",
+      "blueprintRequest": "code.branch_pr"
+    },
+    "whySelected": [
+      "explicit blueprint requested: code.branch_pr",
+      "task intent kind: code",
+      "workflow mode: branch_pr",
+      "task intent mutation scope: code"
+    ],
+    "states": [
+      {
+        "id": "intake",
+        "kind": "intake",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": []
+      },
+      {
+        "id": "scope",
+        "kind": "scope",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "assumptions"
+        ]
+      },
+      {
+        "id": "approval_gate",
+        "kind": "approval_gate",
+        "mode": "approval",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "approval"
+        ]
+      },
+      {
+        "id": "context_resolve",
+        "kind": "context_resolve",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [
+          ".agentplane/policy/security.must.md",
+          ".agentplane/policy/dod.core.md",
+          ".agentplane/policy/dod.code.md",
+          ".agentplane/policy/workflow.branch_pr.md"
+        ],
+        "evidenceKinds": [
+          "context_manifest"
+        ]
+      },
+      {
+        "id": "worktree_start",
+        "kind": "worktree_start",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "work_unit",
+        "kind": "work_unit",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "fast_local_checks",
+        "kind": "fast_local_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane task verify-show <task-id>",
+          "project focused checks"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "pr_artifact",
+        "kind": "pr_artifact",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "artifact",
+          "external_link"
+        ]
+      },
+      {
+        "id": "verify_record",
+        "kind": "verify_record",
+        "mode": "record",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "quality_gate",
+        "kind": "quality_gate",
+        "mode": "agentic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane evaluator run <task-id> --provenance human_supplied|evaluator_supplied --verdict pass|rework|blocked|human_review"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "quality_report"
+        ]
+      },
+      {
+        "id": "hosted_checks",
+        "kind": "hosted_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result",
+          "external_link"
+        ]
+      },
+      {
+        "id": "publish_or_integrate",
+        "kind": "publish_or_integrate",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane integrate <task-id> --branch <branch> --run-verify"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit",
+          "external_link"
+        ]
+      },
+      {
+        "id": "finish",
+        "kind": "finish",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit"
+        ]
+      }
+    ],
+    "requiredEvidence": [
+      {
+        "id": "code_pr.paths",
+        "kind": "changed_paths",
+        "producedBy": "work_unit",
+        "required": true,
+        "description": "Changed source paths."
+      },
+      {
+        "id": "code_pr.fast_checks",
+        "kind": "check_result",
+        "producedBy": "fast_local_checks",
+        "required": true,
+        "description": "Fast local checks."
+      },
+      {
+        "id": "code_pr.pr",
+        "kind": "external_link",
+        "producedBy": "pr_artifact",
+        "required": true,
+        "description": "Pull request artifact."
+      },
+      {
+        "id": "code_pr.verify",
+        "kind": "check_result",
+        "producedBy": "verify_record",
+        "required": true,
+        "description": "Task branch verification."
+      },
+      {
+        "id": "code_pr.quality",
+        "kind": "quality_report",
+        "producedBy": "quality_gate",
+        "required": true,
+        "description": "EVALUATOR quality verdict."
+      },
+      {
+        "id": "code_pr.hosted",
+        "kind": "check_result",
+        "producedBy": "hosted_checks",
+        "required": true,
+        "description": "Hosted check evidence."
+      },
+      {
+        "id": "code_pr.commit",
+        "kind": "commit",
+        "producedBy": "publish_or_integrate",
+        "required": true,
+        "description": "Integration commit."
+      }
+    ],
+    "policyModules": [
+      ".agentplane/policy/dod.code.md",
+      ".agentplane/policy/dod.core.md",
+      ".agentplane/policy/security.must.md",
+      ".agentplane/policy/workflow.branch_pr.md"
+    ],
+    "allowedCommands": [
+      "agentplane evaluator run <task-id> --provenance human_supplied|evaluator_supplied --verdict pass|rework|blocked|human_review",
+      "agentplane integrate <task-id> --branch <branch> --run-verify",
+      "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+      "agentplane task verify-show <task-id>",
+      "agentplane verify <task-id> --ok|--rework",
+      "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+      "project focused checks"
+    ],
+    "contextBudget": {
+      "maxPolicyModules": 4,
+      "maxPromptBlocks": 14,
+      "rationale": "Branch PR code work needs code DoD, branch_pr route policy, and evidence checks."
+    },
+    "contextManifest": [],
+    "acceptedRecipeExtensions": [],
+    "rejectedRecipeExtensions": [],
+    "stopReasons": []
+  },
+  "nodes": [
+    {
+      "id": "intake",
+      "kind": "intake",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": []
+    },
+    {
+      "id": "scope",
+      "kind": "scope",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "assumptions"
+      ]
+    },
+    {
+      "id": "approval_gate",
+      "kind": "approval_gate",
+      "mode": "approval",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "approval"
+      ]
+    },
+    {
+      "id": "context_resolve",
+      "kind": "context_resolve",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [
+        ".agentplane/policy/security.must.md",
+        ".agentplane/policy/dod.core.md",
+        ".agentplane/policy/dod.code.md",
+        ".agentplane/policy/workflow.branch_pr.md"
+      ],
+      "evidenceKinds": [
+        "context_manifest"
+      ]
+    },
+    {
+      "id": "worktree_start",
+      "kind": "worktree_start",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "work_unit",
+      "kind": "work_unit",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "fast_local_checks",
+      "kind": "fast_local_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane task verify-show <task-id>",
+        "project focused checks"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "pr_artifact",
+      "kind": "pr_artifact",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "artifact",
+        "external_link"
+      ]
+    },
+    {
+      "id": "verify_record",
+      "kind": "verify_record",
+      "mode": "record",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "quality_gate",
+      "kind": "quality_gate",
+      "mode": "agentic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane evaluator run <task-id> --provenance human_supplied|evaluator_supplied --verdict pass|rework|blocked|human_review"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "quality_report"
+      ]
+    },
+    {
+      "id": "hosted_checks",
+      "kind": "hosted_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result",
+        "external_link"
+      ]
+    },
+    {
+      "id": "publish_or_integrate",
+      "kind": "publish_or_integrate",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane integrate <task-id> --branch <branch> --run-verify"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit",
+        "external_link"
+      ]
+    },
+    {
+      "id": "finish",
+      "kind": "finish",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit"
+      ]
+    }
+  ],
+  "requiredEvidence": [
+    {
+      "id": "code_pr.paths",
+      "kind": "changed_paths",
+      "producedBy": "work_unit",
+      "required": true,
+      "description": "Changed source paths."
+    },
+    {
+      "id": "code_pr.fast_checks",
+      "kind": "check_result",
+      "producedBy": "fast_local_checks",
+      "required": true,
+      "description": "Fast local checks."
+    },
+    {
+      "id": "code_pr.pr",
+      "kind": "external_link",
+      "producedBy": "pr_artifact",
+      "required": true,
+      "description": "Pull request artifact."
+    },
+    {
+      "id": "code_pr.verify",
+      "kind": "check_result",
+      "producedBy": "verify_record",
+      "required": true,
+      "description": "Task branch verification."
+    },
+    {
+      "id": "code_pr.quality",
+      "kind": "quality_report",
+      "producedBy": "quality_gate",
+      "required": true,
+      "description": "EVALUATOR quality verdict."
+    },
+    {
+      "id": "code_pr.hosted",
+      "kind": "check_result",
+      "producedBy": "hosted_checks",
+      "required": true,
+      "description": "Hosted check evidence."
+    },
+    {
+      "id": "code_pr.commit",
+      "kind": "commit",
+      "producedBy": "publish_or_integrate",
+      "required": true,
+      "description": "Integration commit."
+    }
+  ],
+  "policyModules": [
+    ".agentplane/policy/dod.code.md",
+    ".agentplane/policy/dod.core.md",
+    ".agentplane/policy/security.must.md",
+    ".agentplane/policy/workflow.branch_pr.md"
+  ],
+  "allowedCommands": [
+    "agentplane evaluator run <task-id> --provenance human_supplied|evaluator_supplied --verdict pass|rework|blocked|human_review",
+    "agentplane integrate <task-id> --branch <branch> --run-verify",
+    "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+    "agentplane task verify-show <task-id>",
+    "agentplane verify <task-id> --ok|--rework",
+    "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+    "project focused checks"
+  ],
+  "contextBudget": {
+    "maxPolicyModules": 4,
+    "maxPromptBlocks": 14,
+    "rationale": "Branch PR code work needs code DoD, branch_pr route policy, and evidence checks."
+  },
+  "contextManifest": [],
+  "acceptedRecipeExtensions": [],
+  "rejectedRecipeExtensions": [],
+  "stopReasons": [],
+  "selectionReasons": [
+    "explicit blueprint requested: code.branch_pr",
+    "task intent kind: code",
+    "workflow mode: branch_pr",
+    "task intent mutation scope: code"
+  ],
+  "digest": {
+    "algorithm": "sha256",
+    "value": "502c33075284ce6f9aa46423f98024e5cae094e841cac21d82f799f5898e4d05"
+  }
+}

--- a/.agentplane/tasks/202607281455-147Q75/quality/20260728-150336937-recovery-context/evaluator-diff.patch
+++ b/.agentplane/tasks/202607281455-147Q75/quality/20260728-150336937-recovery-context/evaluator-diff.patch
@@ -1,0 +1,804 @@
+diff --git a/.agentplane/tasks/202607281455-147Q75/blueprint/resolved-snapshot.json b/.agentplane/tasks/202607281455-147Q75/blueprint/resolved-snapshot.json
+new file mode 100644
+index 000000000..5e3d500bd
+--- /dev/null
++++ b/.agentplane/tasks/202607281455-147Q75/blueprint/resolved-snapshot.json
+@@ -0,0 +1,582 @@
++{
++  "schemaVersion": 1,
++  "artifactKind": "agentplane.blueprint.resolved_snapshot",
++  "resolverInput": {
++    "taskId": "202607281455-147Q75",
++    "title": "Repair evaluator response schema for Codex structured output",
++    "description": "Release-blocking follow-up: make the evaluator typed-result JSON Schema compatible with the current Codex structured-output validator, preserve optional evidence fields through explicit nullable values, and add a regression test proving evaluator execution reaches a typed result instead of failing before the provider turn.",
++    "tags": [
++      "code",
++      "evaluator",
++      "provider",
++      "regression",
++      "release-blocker",
++      "v0.7"
++    ],
++    "owner": "CODER",
++    "taskKind": "code",
++    "workflowMode": "branch_pr",
++    "workflowGitCapabilities": {
++      "workflowMode": "branch_pr",
++      "implementationCommitLocation": "task_worktree",
++      "finishCommitSource": "explicit_hash",
++      "closeTailRequired": true,
++      "lifecycleCommentCommitLocation": "task_worktree",
++      "finishCommitFromComment": false
++    },
++    "mutation": "code",
++    "mutationScope": "code",
++    "touchedPaths": [],
++    "recipeHints": [],
++    "riskFlags": [],
++    "blueprintRequest": "code.branch_pr"
++  },
++  "selectedBlueprint": {
++    "id": "code.branch_pr",
++    "version": 1,
++    "title": "Branch PR code change",
++    "taskKinds": [
++      "code"
++    ],
++    "workflowModes": [
++      "branch_pr"
++    ]
++  },
++  "plan": {
++    "schemaVersion": 1,
++    "blueprintId": "code.branch_pr",
++    "blueprintVersion": 1,
++    "title": "Branch PR code change",
++    "taskId": "202607281455-147Q75",
++    "workflowMode": "branch_pr",
++    "workflowGitCapabilities": {
++      "workflowMode": "branch_pr",
++      "implementationCommitLocation": "task_worktree",
++      "finishCommitSource": "explicit_hash",
++      "closeTailRequired": true,
++      "lifecycleCommentCommitLocation": "task_worktree",
++      "finishCommitFromComment": false
++    },
++    "taskIntent": {
++      "taskKind": "code",
++      "mutationScope": "code",
++      "blueprintRequest": "code.branch_pr"
++    },
++    "whySelected": [
++      "explicit blueprint requested: code.branch_pr",
++      "task intent kind: code",
++      "workflow mode: branch_pr",
++      "task intent mutation scope: code"
++    ],
++    "states": [
++      {
++        "id": "intake",
++        "kind": "intake",
++        "mode": "agentic",
++        "required": true,
++        "protected": false,
++        "allowedCommands": [],
++        "policyModules": [],
++        "evidenceKinds": []
++      },
++      {
++        "id": "scope",
++        "kind": "scope",
++        "mode": "deterministic",
++        "required": true,
++        "protected": false,
++        "allowedCommands": [],
++        "policyModules": [],
++        "evidenceKinds": [
++          "assumptions"
++        ]
++      },
++      {
++        "id": "approval_gate",
++        "kind": "approval_gate",
++        "mode": "approval",
++        "required": true,
++        "protected": true,
++        "allowedCommands": [],
++        "policyModules": [],
++        "evidenceKinds": [
++          "approval"
++        ]
++      },
++      {
++        "id": "context_resolve",
++        "kind": "context_resolve",
++        "mode": "deterministic",
++        "required": true,
++        "protected": false,
++        "allowedCommands": [],
++        "policyModules": [
++          ".agentplane/policy/security.must.md",
++          ".agentplane/policy/dod.core.md",
++          ".agentplane/policy/dod.code.md",
++          ".agentplane/policy/workflow.branch_pr.md"
++        ],
++        "evidenceKinds": [
++          "context_manifest"
++        ]
++      },
++      {
++        "id": "worktree_start",
++        "kind": "worktree_start",
++        "mode": "deterministic",
++        "required": true,
++        "protected": true,
++        "allowedCommands": [
++          "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
++        ],
++        "policyModules": [],
++        "evidenceKinds": [
++          "changed_paths"
++        ]
++      },
++      {
++        "id": "work_unit",
++        "kind": "work_unit",
++        "mode": "agentic",
++        "required": true,
++        "protected": false,
++        "allowedCommands": [],
++        "policyModules": [],
++        "evidenceKinds": [
++          "changed_paths"
++        ]
++      },
++      {
++        "id": "fast_local_checks",
++        "kind": "fast_local_checks",
++        "mode": "deterministic",
++        "required": true,
++        "protected": false,
++        "allowedCommands": [
++          "agentplane task verify-show <task-id>",
++          "project focused checks"
++        ],
++        "policyModules": [],
++        "evidenceKinds": [
++          "check_result"
++        ]
++      },
++      {
++        "id": "pr_artifact",
++        "kind": "pr_artifact",
++        "mode": "deterministic",
++        "required": true,
++        "protected": false,
++        "allowedCommands": [
++          "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
++        ],
++        "policyModules": [],
++        "evidenceKinds": [
++          "artifact",
++          "external_link"
++        ]
++      },
++      {
++        "id": "verify_record",
++        "kind": "verify_record",
++        "mode": "record",
++        "required": true,
++        "protected": true,
++        "allowedCommands": [],
++        "policyModules": [],
++        "evidenceKinds": [
++          "check_result"
++        ]
++      },
++      {
++        "id": "quality_gate",
++        "kind": "quality_gate",
++        "mode": "agentic",
++        "required": true,
++        "protected": true,
++        "allowedCommands": [
++          "agentplane evaluator run <task-id> --provenance human_supplied|evaluator_supplied --verdict pass|rework|blocked|human_review"
++        ],
++        "policyModules": [],
++        "evidenceKinds": [
++          "quality_report"
++        ]
++      },
++      {
++        "id": "hosted_checks",
++        "kind": "hosted_checks",
++        "mode": "deterministic",
++        "required": true,
++        "protected": false,
++        "allowedCommands": [],
++        "policyModules": [],
++        "evidenceKinds": [
++          "check_result",
++          "external_link"
++        ]
++      },
++      {
++        "id": "publish_or_integrate",
++        "kind": "publish_or_integrate",
++        "mode": "deterministic",
++        "required": true,
++        "protected": true,
++        "allowedCommands": [
++          "agentplane integrate <task-id> --branch <branch> --run-verify"
++        ],
++        "policyModules": [],
++        "evidenceKinds": [
++          "commit",
++          "external_link"
++        ]
++      },
++      {
++        "id": "finish",
++        "kind": "finish",
++        "mode": "deterministic",
++        "required": true,
++        "protected": true,
++        "allowedCommands": [],
++        "policyModules": [],
++        "evidenceKinds": [
++          "commit"
++        ]
++      }
++    ],
++    "requiredEvidence": [
++      {
++        "id": "code_pr.paths",
++        "kind": "changed_paths",
++        "producedBy": "work_unit",
++        "required": true,
++        "description": "Changed source paths."
++      },
++      {
++        "id": "code_pr.fast_checks",
++        "kind": "check_result",
++        "producedBy": "fast_local_checks",
++        "required": true,
++        "description": "Fast local checks."
++      },
++      {
++        "id": "code_pr.pr",
++        "kind": "external_link",
++        "producedBy": "pr_artifact",
++        "required": true,
++        "description": "Pull request artifact."
++      },
++      {
++        "id": "code_pr.verify",
++        "kind": "check_result",
++        "producedBy": "verify_record",
++        "required": true,
++        "description": "Task branch verification."
++      },
++      {
++        "id": "code_pr.quality",
++        "kind": "quality_report",
++        "producedBy": "quality_gate",
++        "required": true,
++        "description": "EVALUATOR quality verdict."
++      },
++      {
++        "id": "code_pr.hosted",
++        "kind": "check_result",
++        "producedBy": "hosted_checks",
++        "required": true,
++        "description": "Hosted check evidence."
++      },
++      {
++        "id": "code_pr.commit",
++        "kind": "commit",
++        "producedBy": "publish_or_integrate",
++        "required": true,
++        "description": "Integration commit."
++      }
++    ],
++    "policyModules": [
++      ".agentplane/policy/dod.code.md",
++      ".agentplane/policy/dod.core.md",
++      ".agentplane/policy/security.must.md",
++      ".agentplane/policy/workflow.branch_pr.md"
++    ],
++    "allowedCommands": [
++      "agentplane evaluator run <task-id> --provenance human_supplied|evaluator_supplied --verdict pass|rework|blocked|human_review",
++      "agentplane integrate <task-id> --branch <branch> --run-verify",
++      "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
++      "agentplane task verify-show <task-id>",
++      "agentplane verify <task-id> --ok|--rework",
++      "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
++      "project focused checks"
++    ],
++    "contextBudget": {
++      "maxPolicyModules": 4,
++      "maxPromptBlocks": 14,
++      "rationale": "Branch PR code work needs code DoD, branch_pr route policy, and evidence checks."
++    },
++    "contextManifest": [],
++    "acceptedRecipeExtensions": [],
++    "rejectedRecipeExtensions": [],
++    "stopReasons": []
++  },
++  "nodes": [
++    {
++      "id": "intake",
++      "kind": "intake",
++      "mode": "agentic",
++      "required": true,
++      "protected": false,
++      "allowedCommands": [],
++      "policyModules": [],
++      "evidenceKinds": []
++    },
++    {
++      "id": "scope",
++      "kind": "scope",
++      "mode": "deterministic",
++      "required": true,
++      "protected": false,
++      "allowedCommands": [],
++      "policyModules": [],
++      "evidenceKinds": [
++        "assumptions"
++      ]
++    },
++    {
++      "id": "approval_gate",
++      "kind": "approval_gate",
++      "mode": "approval",
++      "required": true,
++      "protected": true,
++      "allowedCommands": [],
++      "policyModules": [],
++      "evidenceKinds": [
++        "approval"
++      ]
++    },
++    {
++      "id": "context_resolve",
++      "kind": "context_resolve",
++      "mode": "deterministic",
++      "required": true,
++      "protected": false,
++      "allowedCommands": [],
++      "policyModules": [
++        ".agentplane/policy/security.must.md",
++        ".agentplane/policy/dod.core.md",
++        ".agentplane/policy/dod.code.md",
++        ".agentplane/policy/workflow.branch_pr.md"
++      ],
++      "evidenceKinds": [
++        "context_manifest"
++      ]
++    },
++    {
++      "id": "worktree_start",
++      "kind": "worktree_start",
++      "mode": "deterministic",
++      "required": true,
++      "protected": true,
++      "allowedCommands": [
++        "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
++      ],
++      "policyModules": [],
++      "evidenceKinds": [
++        "changed_paths"
++      ]
++    },
++    {
++      "id": "work_unit",
++      "kind": "work_unit",
++      "mode": "agentic",
++      "required": true,
++      "protected": false,
++      "allowedCommands": [],
++      "policyModules": [],
++      "evidenceKinds": [
++        "changed_paths"
++      ]
++    },
++    {
++      "id": "fast_local_checks",
++      "kind": "fast_local_checks",
++      "mode": "deterministic",
++      "required": true,
++      "protected": false,
++      "allowedCommands": [
++        "agentplane task verify-show <task-id>",
++        "project focused checks"
++      ],
++      "policyModules": [],
++      "evidenceKinds": [
++        "check_result"
++      ]
++    },
++    {
++      "id": "pr_artifact",
++      "kind": "pr_artifact",
++      "mode": "deterministic",
++      "required": true,
++      "protected": false,
++      "allowedCommands": [
++        "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
++      ],
++      "policyModules": [],
++      "evidenceKinds": [
++        "artifact",
++        "external_link"
++      ]
++    },
++    {
++      "id": "verify_record",
++      "kind": "verify_record",
++      "mode": "record",
++      "required": true,
++      "protected": true,
++      "allowedCommands": [],
++      "policyModules": [],
++      "evidenceKinds": [
++        "check_result"
++      ]
++    },
++    {
++      "id": "quality_gate",
++      "kind": "quality_gate",
++      "mode": "agentic",
++      "required": true,
++      "protected": true,
++      "allowedCommands": [
++        "agentplane evaluator run <task-id> --provenance human_supplied|evaluator_supplied --verdict pass|rework|blocked|human_review"
++      ],
++      "policyModules": [],
++      "evidenceKinds": [
++        "quality_report"
++      ]
++    },
++    {
++      "id": "hosted_checks",
++      "kind": "hosted_checks",
++      "mode": "deterministic",
++      "required": true,
++      "protected": false,
++      "allowedCommands": [],
++      "policyModules": [],
++      "evidenceKinds": [
++        "check_result",
++        "external_link"
++      ]
++    },
++    {
++      "id": "publish_or_integrate",
++      "kind": "publish_or_integrate",
++      "mode": "deterministic",
++      "required": true,
++      "protected": true,
++      "allowedCommands": [
++        "agentplane integrate <task-id> --branch <branch> --run-verify"
++      ],
++      "policyModules": [],
++      "evidenceKinds": [
++        "commit",
++        "external_link"
++      ]
++    },
++    {
++      "id": "finish",
++      "kind": "finish",
++      "mode": "deterministic",
++      "required": true,
++      "protected": true,
++      "allowedCommands": [],
++      "policyModules": [],
++      "evidenceKinds": [
++        "commit"
++      ]
++    }
++  ],
++  "requiredEvidence": [
++    {
++      "id": "code_pr.paths",
++      "kind": "changed_paths",
++      "producedBy": "work_unit",
++      "required": true,
++      "description": "Changed source paths."
++    },
++    {
++      "id": "code_pr.fast_checks",
++      "kind": "check_result",
++      "producedBy": "fast_local_checks",
++      "required": true,
++      "description": "Fast local checks."
++    },
++    {
++      "id": "code_pr.pr",
++      "kind": "external_link",
++      "producedBy": "pr_artifact",
++      "required": true,
++      "description": "Pull request artifact."
++    },
++    {
++      "id": "code_pr.verify",
++      "kind": "check_result",
++      "producedBy": "verify_record",
++      "required": true,
++      "description": "Task branch verification."
++    },
++    {
++      "id": "code_pr.quality",
++      "kind": "quality_report",
++      "producedBy": "quality_gate",
++      "required": true,
++      "description": "EVALUATOR quality verdict."
++    },
++    {
++      "id": "code_pr.hosted",
++      "kind": "check_result",
++      "producedBy": "hosted_checks",
++      "required": true,
++      "description": "Hosted check evidence."
++    },
++    {
++      "id": "code_pr.commit",
++      "kind": "commit",
++      "producedBy": "publish_or_integrate",
++      "required": true,
++      "description": "Integration commit."
++    }
++  ],
++  "policyModules": [
++    ".agentplane/policy/dod.code.md",
++    ".agentplane/policy/dod.core.md",
++    ".agentplane/policy/security.must.md",
++    ".agentplane/policy/workflow.branch_pr.md"
++  ],
++  "allowedCommands": [
++    "agentplane evaluator run <task-id> --provenance human_supplied|evaluator_supplied --verdict pass|rework|blocked|human_review",
++    "agentplane integrate <task-id> --branch <branch> --run-verify",
++    "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
++    "agentplane task verify-show <task-id>",
++    "agentplane verify <task-id> --ok|--rework",
++    "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
++    "project focused checks"
++  ],
++  "contextBudget": {
++    "maxPolicyModules": 4,
++    "maxPromptBlocks": 14,
++    "rationale": "Branch PR code work needs code DoD, branch_pr route policy, and evidence checks."
++  },
++  "contextManifest": [],
++  "acceptedRecipeExtensions": [],
++  "rejectedRecipeExtensions": [],
++  "stopReasons": [],
++  "selectionReasons": [
++    "explicit blueprint requested: code.branch_pr",
++    "task intent kind: code",
++    "workflow mode: branch_pr",
++    "task intent mutation scope: code"
++  ],
++  "digest": {
++    "algorithm": "sha256",
++    "value": "502c33075284ce6f9aa46423f98024e5cae094e841cac21d82f799f5898e4d05"
++  }
++}
+diff --git a/.agentplane/tasks/202607281455-147Q75/pr/meta.json b/.agentplane/tasks/202607281455-147Q75/pr/meta.json
+index 9d8d1b931..492aa18cc 100644
+--- a/.agentplane/tasks/202607281455-147Q75/pr/meta.json
++++ b/.agentplane/tasks/202607281455-147Q75/pr/meta.json
+@@ -4,9 +4,12 @@
+   "created_at": "2026-07-28T14:56:22.735Z",
+   "diffstat_sha256": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+   "last_verified_at": null,
++  "pr_number": 4660,
++  "pr_url": "https://github.com/basilisk-labs/agentplane/pull/4660",
+   "schema_version": 1,
++  "status": "OPEN",
+   "task_id": "202607281455-147Q75",
+-  "updated_at": "2026-07-28T14:56:22.735Z",
++  "updated_at": "2026-07-28T14:56:52.349Z",
+   "verify": {
+     "status": "skipped"
+   }
+diff --git a/packages/agentplane/src/commands/evaluator/evaluator-episode.calibration.test.ts b/packages/agentplane/src/commands/evaluator/evaluator-episode.calibration.test.ts
+index 7d91442dd..83841a573 100644
+--- a/packages/agentplane/src/commands/evaluator/evaluator-episode.calibration.test.ts
++++ b/packages/agentplane/src/commands/evaluator/evaluator-episode.calibration.test.ts
+@@ -96,19 +96,16 @@ function result(
+         severity: nonPassing ? "high" : "low",
+         summary: `${verdict} calibration finding from the frozen evaluator evidence.`,
+         broken_invariant: nonPassing ? "calibration invariant" : "none",
+-        evidence_refs: [{ path: diff.path }],
++        evidence_refs: [{ path: diff.path, sha256: null, line: null, lines: null, section: null }],
+       },
+     ],
+     missing_tests: [],
+     hidden_assumptions: [],
+-    ...(nonPassing
+-      ? {
+-          recovery_context:
+-            verdict === "human_review"
+-              ? "Which of the two mutually incompatible acceptance interpretations should govern this task?"
+-              : `Bounded ${verdict} follow-up required before another evaluator episode.`,
+-        }
+-      : {}),
++    recovery_context: nonPassing
++      ? verdict === "human_review"
++        ? "Which of the two mutually incompatible acceptance interpretations should govern this task?"
++        : `Bounded ${verdict} follow-up required before another evaluator episode.`
++      : null,
+   };
+ }
+ 
+@@ -178,6 +175,14 @@ describe("evaluator episode calibration", () => {
+       output_tokens: 50,
+       total_tokens: 150,
+     });
++    expect(episode.result.recovery_context).toBeUndefined();
++    expect(episode.result.findings[0]?.evidence_refs[0]).toEqual({
++      path: prepared.work_order.evidence.find((entry) => entry.kind === "actual_diff")?.path,
++      sha256: undefined,
++      line: undefined,
++      lines: undefined,
++      section: undefined,
++    });
+     expect(JSON.parse(await readFile(prepared.result_path, "utf8"))).toEqual(episode.result);
+     expect(
+       JSON.parse(
+@@ -210,7 +215,37 @@ describe("evaluator episode calibration", () => {
+     expect(captured?.prompt).toContain(
+       "AgentPlane prepared and froze the authoritative review input",
+     );
+-    expect(await readFile(captured!.output_schema_path, "utf8")).toContain("human_review");
++    const outputSchema = JSON.parse(await readFile(captured!.output_schema_path, "utf8")) as {
++      required: string[];
++      properties: {
++        recovery_context: { type: string[] };
++        findings: {
++          items: {
++            properties: {
++              evidence_refs: {
++                items: {
++                  required: string[];
++                  properties: {
++                    sha256: { type: string[] };
++                    line: { type: string[] };
++                    lines: { type: string[] };
++                    section: { type: string[] };
++                  };
++                };
++              };
++            };
++          };
++        };
++      };
++    };
++    const evidenceSchema = outputSchema.properties.findings.items.properties.evidence_refs.items;
++    expect(outputSchema.required).toContain("recovery_context");
++    expect(outputSchema.properties.recovery_context.type).toEqual(["string", "null"]);
++    expect(evidenceSchema.required).toEqual(["path", "sha256", "line", "lines", "section"]);
++    expect(evidenceSchema.properties.sha256.type).toEqual(["string", "null"]);
++    expect(evidenceSchema.properties.line.type).toEqual(["integer", "null"]);
++    expect(evidenceSchema.properties.lines.type).toEqual(["string", "null"]);
++    expect(evidenceSchema.properties.section.type).toEqual(["string", "null"]);
+   });
+ 
+   it.each([
+@@ -275,7 +310,9 @@ describe("evaluator episode calibration", () => {
+     await commitTarget(root);
+     const { command, prepared } = await prepare(root, taskId);
+     const invalid = result(prepared, "rework");
+-    invalid.findings[0]!.evidence_refs = [{ path: "src/not-frozen.ts" }];
++    invalid.findings[0]!.evidence_refs = [
++      { path: "src/not-frozen.ts", sha256: null, line: null, lines: null, section: null },
++    ];
+ 
+     await expect(
+       executePreparedEvaluatorEpisode({ ctx: command, prepared, executor: provider(invalid) }),
+diff --git a/packages/agentplane/src/commands/evaluator/evaluator-episode.ts b/packages/agentplane/src/commands/evaluator/evaluator-episode.ts
+index aa9d2c767..e5cecf404 100644
+--- a/packages/agentplane/src/commands/evaluator/evaluator-episode.ts
++++ b/packages/agentplane/src/commands/evaluator/evaluator-episode.ts
+@@ -25,6 +25,18 @@ const MAX_PROVIDER_STDERR_BYTES = 1024 * 1024;
+ const CODEX_EVALUATOR_TIMEOUT_MS = 10 * 60 * 1000;
+ 
+ const NON_EMPTY_STRING_SCHEMA = { type: "string", minLength: 1 } as const;
++const NULLABLE_NON_EMPTY_STRING_SCHEMA = {
++  type: ["string", "null"],
++  minLength: 1,
++} as const;
++const NULLABLE_SHA256_SCHEMA = {
++  type: ["string", "null"],
++  pattern: "^sha256:[a-f0-9]{64}$",
++} as const;
++const NULLABLE_POSITIVE_INTEGER_SCHEMA = {
++  type: ["integer", "null"],
++  minimum: 1,
++} as const;
+ 
+ const EVALUATOR_RESULT_OUTPUT_SCHEMA = {
+   $schema: "http://json-schema.org/draft-07/schema#",
+@@ -56,12 +68,16 @@ const EVALUATOR_RESULT_OUTPUT_SCHEMA = {
+               additionalProperties: false,
+               properties: {
+                 path: NON_EMPTY_STRING_SCHEMA,
+-                sha256: { type: "string", pattern: "^sha256:[a-f0-9]{64}$" },
+-                line: { type: "integer", minimum: 1 },
+-                lines: NON_EMPTY_STRING_SCHEMA,
+-                section: NON_EMPTY_STRING_SCHEMA,
++                sha256: NULLABLE_SHA256_SCHEMA,
++                line: NULLABLE_POSITIVE_INTEGER_SCHEMA,
++                lines: NULLABLE_NON_EMPTY_STRING_SCHEMA,
++                section: NULLABLE_NON_EMPTY_STRING_SCHEMA,
+               },
+-              required: ["path"],
++              // Codex structured output requires every declared property to
++              // appear in `required`. Source-reference metadata remains
++              // semantically optional by using null, which is normalized by
++              // the evaluator result validator before its typed SGR handoff.
++              required: ["path", "sha256", "line", "lines", "section"],
+             },
+           },
+         },
+@@ -70,7 +86,7 @@ const EVALUATOR_RESULT_OUTPUT_SCHEMA = {
+     },
+     missing_tests: { type: "array", items: { type: "string" } },
+     hidden_assumptions: { type: "array", items: { type: "string" } },
+-    recovery_context: NON_EMPTY_STRING_SCHEMA,
++    recovery_context: NULLABLE_NON_EMPTY_STRING_SCHEMA,
+   },
+   required: [
+     "schema_version",
+@@ -80,6 +96,7 @@ const EVALUATOR_RESULT_OUTPUT_SCHEMA = {
+     "findings",
+     "missing_tests",
+     "hidden_assumptions",
++    "recovery_context",
+   ],
+ } as const;
+ 
+diff --git a/packages/agentplane/src/commands/evaluator/evaluator-review-usecase.ts b/packages/agentplane/src/commands/evaluator/evaluator-review-usecase.ts
+index 69962b834..7a3f47a8d 100644
+--- a/packages/agentplane/src/commands/evaluator/evaluator-review-usecase.ts
++++ b/packages/agentplane/src/commands/evaluator/evaluator-review-usecase.ts
+@@ -428,6 +428,27 @@ function assertExactKeys(
+   }
+ }
+ 
++function normalizeEvaluatorStructuredNulls(raw: Record<string, unknown>): Record<string, unknown> {
++  const normalized: Record<string, unknown> = { ...raw };
++  if (normalized.recovery_context === null) delete normalized.recovery_context;
++  if (!Array.isArray(normalized.findings)) return normalized;
++  normalized.findings = normalized.findings.map((finding) => {
++    if (!finding || typeof finding !== "object" || Array.isArray(finding)) return finding;
++    const normalizedFinding: Record<string, unknown> = { ...finding };
++    if (!Array.isArray(normalizedFinding.evidence_refs)) return normalizedFinding;
++    normalizedFinding.evidence_refs = normalizedFinding.evidence_refs.map((evidence) => {
++      if (!evidence || typeof evidence !== "object" || Array.isArray(evidence)) return evidence;
++      const normalizedEvidence: Record<string, unknown> = { ...evidence };
++      for (const field of ["sha256", "line", "lines", "section"] as const) {
++        if (normalizedEvidence[field] === null) delete normalizedEvidence[field];
++      }
++      return normalizedEvidence;
++    });
++    return normalizedFinding;
++  });
++  return normalized;
++}
++
+ export function validateStrictEvaluatorResult(raw: unknown): EvaluatorSgrResult {
+   assertExactKeys(
+     raw,
+@@ -468,7 +489,7 @@ export function validateStrictEvaluatorResult(raw: unknown): EvaluatorSgrResult
+       }
+     }
+   }
+-  return validateEvaluatorSgrResult(raw);
++  return validateEvaluatorSgrResult(normalizeEvaluatorStructuredNulls(record));
+ }
+ 
+ export function readWorkOrder(raw: unknown): EvaluatorWorkOrder {

--- a/.agentplane/tasks/202607281455-147Q75/quality/20260728-150336937-recovery-context/evaluator-episode.json
+++ b/.agentplane/tasks/202607281455-147Q75/quality/20260728-150336937-recovery-context/evaluator-episode.json
@@ -1,0 +1,40 @@
+{
+  "schema_version": 1,
+  "kind": "evaluator_episode_receipt",
+  "work_order_id": "evaluator-work-order-202607281455-147Q75-2d54eef78c8e1c2d3cf671c6",
+  "provider": "codex",
+  "authority": {
+    "sandbox": "read-only",
+    "writable_roots": []
+  },
+  "argv": [
+    "codex",
+    "-a",
+    "never",
+    "exec",
+    "--ignore-user-config",
+    "--strict-config",
+    "--disable",
+    "hooks",
+    "--ephemeral",
+    "--json",
+    "-C",
+    "/Users/densmirnov/Github/agentplane/.agentplane/tmp/inc-20260727-main-lane.prxk2f/repo/.agentplane/worktrees/202607281455-147Q75-repair-evaluator-response-schema",
+    "-s",
+    "read-only",
+    "--output-schema",
+    "/Users/densmirnov/Github/agentplane/.agentplane/tmp/inc-20260727-main-lane.prxk2f/repo/.agentplane/worktrees/202607281455-147Q75-repair-evaluator-response-schema/.agentplane/tasks/202607281455-147Q75/quality/20260728-150336937-recovery-context/evaluator-result.schema.json",
+    "-"
+  ],
+  "started_at": "2026-07-28T15:03:37.421Z",
+  "ended_at": "2026-07-28T15:04:43.098Z",
+  "stdout_bytes": 82822,
+  "stderr_bytes": 6229,
+  "provider_usage": {
+    "input_tokens": 203290,
+    "output_tokens": 2093,
+    "total_tokens": 205383
+  },
+  "workspace_state": "unchanged",
+  "result_sha256": "sha256:c0f188fbd15d43ea258d6106dd7406f141aef87957ecc3ddc90f2745c4321c63"
+}

--- a/.agentplane/tasks/202607281455-147Q75/quality/20260728-150336937-recovery-context/evaluator-observed-checks.json
+++ b/.agentplane/tasks/202607281455-147Q75/quality/20260728-150336937-recovery-context/evaluator-observed-checks.json
@@ -1,0 +1,17 @@
+{
+  "task_status": "DOING",
+  "declared_checks": [
+    "bun run format:changed",
+    "bun run typecheck",
+    "bunx vitest run packages/agentplane/src/commands/evaluator/evaluator-episode.calibration.test.ts packages/agentplane/src/commands/evaluator/evaluator-execute.command.test.ts",
+    "node .agentplane/policy/check-routing.mjs"
+  ],
+  "verification": {
+    "state": "ok",
+    "attempts": 0,
+    "updated_at": "2026-07-28T15:03:08.775Z",
+    "updated_by": "TESTER",
+    "note": "Verified evaluator schema compatibility: all structured-output properties are required with nullable optional metadata, nulls normalize before strict SGR validation, and the provider boundary remains read-only. Checks passed: focused evaluator suites (14), typecheck, format, routing validation."
+  },
+  "runner_history": []
+}

--- a/.agentplane/tasks/202607281455-147Q75/quality/20260728-150336937-recovery-context/evaluator-opinion.md
+++ b/.agentplane/tasks/202607281455-147Q75/quality/20260728-150336937-recovery-context/evaluator-opinion.md
@@ -1,0 +1,18 @@
+# Semantic quality review: pass
+
+Provenance: evaluator_supplied
+
+EVALUATOR returned pass with 0 typed finding(s).
+
+## Findings
+
+## Evidence
+
+## Missing Tests
+- none recorded
+
+## Hidden Assumptions
+- none recorded
+
+## Residual Risks
+- none recorded

--- a/.agentplane/tasks/202607281455-147Q75/quality/20260728-150336937-recovery-context/evaluator-prompt.md
+++ b/.agentplane/tasks/202607281455-147Q75/quality/20260728-150336937-recovery-context/evaluator-prompt.md
@@ -1,0 +1,82 @@
+# AgentPlane EVALUATOR episode
+
+AgentPlane prepared and froze the authoritative review input. Perform the semantic evaluation; do not reproduce CLI discovery or lifecycle work.
+This prompt does not execute an evaluator. A caller must run the evaluator in the work-order authority boundary and persist its returned typed result at the declared output path.
+Do not edit implementation, task lifecycle, policy, or evidence files. You may read the frozen evidence and run read-only checks only.
+
+- task_id: 202607281455-147Q75
+- task_readme: .agentplane/tasks/202607281455-147Q75/README.md
+- work_order: .agentplane/tasks/202607281455-147Q75/quality/20260728-150336937-recovery-context/evaluator-work-order.json
+- result_output: .agentplane/tasks/202607281455-147Q75/quality/20260728-150336937-recovery-context/evaluator-result.json
+- report_path: .agentplane/tasks/202607281455-147Q75/quality/20260728-150336937-recovery-context/quality-report.json
+- provenance: evaluator_supplied
+
+## Required result
+
+Return exactly one `sgr.evaluator_result.v1` JSON object through the evaluator result channel. The caller, not the read-only evaluator, persists it at `result_output`. It must contain:
+- schema_version: 1
+- kind: evaluator_result
+- evaluator_id: the evaluator id from the work order
+- verdict: pass | rework | blocked | human_review
+- findings: typed findings with id, severity, summary, broken_invariant, and non-empty evidence_refs
+- missing_tests and hidden_assumptions: string arrays
+- recovery_context: required non-empty string for rework, blocked, or human_review; for human_review it must be the single decision question for the human owner
+
+Every findings[].evidence_refs[].path must be an exact path from work_order.evidence. Do not add fields, commands, patches, lifecycle transitions, or a verdict outside this JSON result.
+The CLI validates the schema, frozen evidence digests, task revision, evaluated SHA, and blueprint before it records quality state.
+
+## Evaluator module
+
+---
+id: recovery-context
+title: Recovery Context Invariant Review
+version: 1
+status: preview
+profile: EVALUATOR
+tags:
+  - recovery
+  - invariants
+  - concurrency
+---
+
+# Recovery Context Invariant Review
+
+Use this evaluator only when the primary implementation path already produced a concrete change or when recovery context is needed after an interruption.
+
+## Inputs
+
+- Task id, task README, approved plan, and Verify Steps.
+- Current diff or PR patch.
+- Relevant comments, review findings, incidents, and recovery/handoff context.
+- Known concurrent-agent activity and task-artifact drift classification, if present.
+
+## Review Procedure
+
+1. Reconstruct the intended contract from the task, not from the implementation summary.
+2. Compare the diff against explicit invariants, stop rules, negative cases, and user constraints.
+3. Check whether recovery context changes the interpretation of the task or exposes stale assumptions.
+4. Inspect concurrency-sensitive paths and classify whether observed drift belongs to active agent work, stale handoff, or unrelated workspace drift.
+5. Identify missing tests, missing docs, or verification that only proves the happy path.
+6. Do not execute fixes. Return review findings only.
+7. When recording the result, use `agentplane evaluator run <task-id> --provenance evaluator_supplied` so the task gets prompt,
+   `quality-report.json`, and opinion artifacts. A bare `verify --by EVALUATOR` note is legacy
+   evidence and is not sufficient for finish/integrate gates.
+
+## Output
+
+Return a concise structured review:
+
+- `verdict`: `pass`, `rework`, `blocked`, or `human_review`.
+- `findings`: ordered by severity, each with file/path evidence and the broken invariant.
+- `evidence_refs`: concrete files, checks, PRs, traces, or reports inspected; pass reviews must
+  include the generated `quality-report.json`.
+- `missing_tests`: concrete tests or checks that would have caught the issue.
+- `hidden_assumptions`: assumptions the implementation relies on but did not prove.
+- `residual_risks`: known risks after the review.
+- `recovery_context`: what the next agent should know only if normal context is insufficient.
+
+## Stop Rules
+
+- Use `blocked` when required task context, diff, or recovery context is missing.
+- Use `rework` when behavior diverges from the approved contract even if local checks pass.
+- Use `pass` only when the implementation and verification evidence cover positive, negative, and concurrency-sensitive paths relevant to the task.

--- a/.agentplane/tasks/202607281455-147Q75/quality/20260728-150336937-recovery-context/evaluator-result.json
+++ b/.agentplane/tasks/202607281455-147Q75/quality/20260728-150336937-recovery-context/evaluator-result.json
@@ -1,0 +1,9 @@
+{
+  "schema_version": 1,
+  "kind": "evaluator_result",
+  "evaluator_id": "recovery-context",
+  "verdict": "pass",
+  "findings": [],
+  "missing_tests": [],
+  "hidden_assumptions": []
+}

--- a/.agentplane/tasks/202607281455-147Q75/quality/20260728-150336937-recovery-context/evaluator-result.schema.json
+++ b/.agentplane/tasks/202607281455-147Q75/quality/20260728-150336937-recovery-context/evaluator-result.schema.json
@@ -1,0 +1,148 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "AgentPlane EvaluatorSgrResult",
+  "description": "Read-only EVALUATOR output. AgentPlane validates frozen evidence and owns all persistence.",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "schema_version": {
+      "type": "integer",
+      "enum": [
+        1
+      ]
+    },
+    "kind": {
+      "type": "string",
+      "enum": [
+        "evaluator_result"
+      ]
+    },
+    "evaluator_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "verdict": {
+      "type": "string",
+      "enum": [
+        "pass",
+        "rework",
+        "blocked",
+        "human_review"
+      ]
+    },
+    "findings": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "id": {
+            "type": "string",
+            "minLength": 1
+          },
+          "severity": {
+            "type": "string",
+            "enum": [
+              "low",
+              "medium",
+              "high"
+            ]
+          },
+          "summary": {
+            "type": "string",
+            "minLength": 1
+          },
+          "broken_invariant": {
+            "type": "string",
+            "minLength": 1
+          },
+          "evidence_refs": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "path": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "sha256": {
+                  "type": [
+                    "string",
+                    "null"
+                  ],
+                  "pattern": "^sha256:[a-f0-9]{64}$"
+                },
+                "line": {
+                  "type": [
+                    "integer",
+                    "null"
+                  ],
+                  "minimum": 1
+                },
+                "lines": {
+                  "type": [
+                    "string",
+                    "null"
+                  ],
+                  "minLength": 1
+                },
+                "section": {
+                  "type": [
+                    "string",
+                    "null"
+                  ],
+                  "minLength": 1
+                }
+              },
+              "required": [
+                "path",
+                "sha256",
+                "line",
+                "lines",
+                "section"
+              ]
+            }
+          }
+        },
+        "required": [
+          "id",
+          "severity",
+          "summary",
+          "broken_invariant",
+          "evidence_refs"
+        ]
+      }
+    },
+    "missing_tests": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "hidden_assumptions": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "recovery_context": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "minLength": 1
+    }
+  },
+  "required": [
+    "schema_version",
+    "kind",
+    "evaluator_id",
+    "verdict",
+    "findings",
+    "missing_tests",
+    "hidden_assumptions",
+    "recovery_context"
+  ]
+}

--- a/.agentplane/tasks/202607281455-147Q75/quality/20260728-150336937-recovery-context/evaluator-work-order.json
+++ b/.agentplane/tasks/202607281455-147Q75/quality/20260728-150336937-recovery-context/evaluator-work-order.json
@@ -1,0 +1,97 @@
+{
+  "schema_version": 1,
+  "kind": "evaluator_work_order",
+  "work_order_id": "evaluator-work-order-202607281455-147Q75-2d54eef78c8e1c2d3cf671c6",
+  "prepared_at": "2026-07-28T15:03:36.937Z",
+  "task": {
+    "id": "202607281455-147Q75",
+    "revision": 6,
+    "objective": "Repair evaluator response schema for Codex structured output\n\nRelease-blocking follow-up: make the evaluator typed-result JSON Schema compatible with the current Codex structured-output validator, preserve optional evidence fields through explicit nullable values, and add a regression test proving evaluator execution reaches a typed result instead of failing before the provider turn.",
+    "acceptance_criteria": [
+      "bun run format:changed",
+      "bun run typecheck",
+      "bunx vitest run packages/agentplane/src/commands/evaluator/evaluator-episode.calibration.test.ts packages/agentplane/src/commands/evaluator/evaluator-execute.command.test.ts",
+      "node .agentplane/policy/check-routing.mjs",
+      "- In scope: Release-blocking follow-up: make the evaluator typed-result JSON Schema compatible with the current Codex structured-output validator, preserve optional evidence fields through explicit nullable values, and add a regression test proving evaluator execution reaches a typed result instead of failing before the provider turn.\n- Out of scope: unrelated refactors not required for \"Repair evaluator response schema for Codex structured output\".",
+      "1. Change only the evaluator structured-output schema and its focused tests so Codex accepts the response format while the existing strict result validator keeps evidence fields semantically optional. 2. Add a regression that asserts the nested evidence reference schema is OpenAI-compatible and preserves nullable optional fields. 3. Run the declared evaluator tests, typecheck, format:changed, and routing validation. 4. Publish the task branch PR; record TESTER verification, EVALUATOR review, hosted checks, and integration before resuming task 202607221850-8HBF4J.",
+      "PLANNER fallback scaffold. Replace with task-specific acceptance checks when PLANNER context is available.\n\n1. Run `bunx vitest run packages/agentplane/src/commands/evaluator/evaluator-episode.calibration.test.ts packages/agentplane/src/commands/evaluator/evaluator-execute.command.test.ts`. Expected: it succeeds and confirms the requested outcome for this task.\n2. Run `bun run typecheck`. Expected: it succeeds and confirms the requested outcome for this task.\n3. Run `bun run format:changed`. Expected: it succeeds and confirms the requested outcome for this task.\n4. Run `node .agentplane/policy/check-routing.mjs`. Expected: it succeeds and confirms the requested outcome for this task.\n5. Review the changed artifact or behavior for the `code` task. Expected: the requested outcome is visible and matches the approved scope.\n6. Compare the final result against the task summary and touched scope. Expected: remaining follow-up is either resolved or explicit in ## Findings."
+    ]
+  },
+  "evaluated_sha": "b5cad73384df973a4a0845521c97723347af56f8",
+  "blueprint_digest": "502c33075284ce6f9aa46423f98024e5cae094e841cac21d82f799f5898e4d05",
+  "evaluator": {
+    "id": "recovery-context",
+    "profile": "EVALUATOR",
+    "prompt_module_path": ".agentplane/evaluators/recovery-context.md"
+  },
+  "authority": {
+    "sandbox": "read-only",
+    "writable_roots": [],
+    "allowed_tool_classes": [
+      "repository_read",
+      "git_read",
+      "run_checks",
+      "report_result"
+    ],
+    "external_side_effects": []
+  },
+  "result_contract": "sgr.evaluator_result.v1",
+  "evidence": [
+    {
+      "id": "task-document",
+      "kind": "task_document",
+      "path": ".agentplane/tasks/202607281455-147Q75/README.md",
+      "sha256": "sha256:e2072f69385bcff71f3a62ae602f5928cc5b6fe0221097a64a6ec974bfce95d0",
+      "required": true
+    },
+    {
+      "id": "actual-diff",
+      "kind": "actual_diff",
+      "path": ".agentplane/tasks/202607281455-147Q75/quality/20260728-150336937-recovery-context/evaluator-diff.patch",
+      "sha256": "sha256:d5c09236535d08ceb9cfdad76f7b2eff93d15957cee5bb6f27f3d54f705df132",
+      "required": true
+    },
+    {
+      "id": "observed-checks",
+      "kind": "observed_checks",
+      "path": ".agentplane/tasks/202607281455-147Q75/quality/20260728-150336937-recovery-context/evaluator-observed-checks.json",
+      "sha256": "sha256:d9766091f8d5baf547f3b5b4b40562dcd4eda3acecc6649e17b9dff509c0d8b7",
+      "required": true
+    },
+    {
+      "id": "blueprint",
+      "kind": "blueprint",
+      "path": ".agentplane/tasks/202607281455-147Q75/quality/20260728-150336937-recovery-context/evaluator-blueprint.json",
+      "sha256": "sha256:72fcb8c3a11cb7c24c9725eecd7af30106e482c804c6a32f1f535662a2283f44",
+      "required": true
+    },
+    {
+      "id": "policy-1",
+      "kind": "policy_module",
+      "path": ".agentplane/policy/dod.code.md",
+      "sha256": "sha256:3fec50dfe0db2f9495a3fa96f36d95fb34262033299d57f6f3775af4b7cc1486",
+      "required": true
+    },
+    {
+      "id": "policy-2",
+      "kind": "policy_module",
+      "path": ".agentplane/policy/dod.core.md",
+      "sha256": "sha256:f6c11b8a2c55760c17af15f79fe13791b3e7bba4852fc7d311fc0657e490b0c7",
+      "required": true
+    },
+    {
+      "id": "policy-3",
+      "kind": "policy_module",
+      "path": ".agentplane/policy/security.must.md",
+      "sha256": "sha256:96d01012e7ab67873bcb7a2cdd3818efa2c1fa500ee2eaf0e316f67e15bbcab2",
+      "required": true
+    },
+    {
+      "id": "policy-4",
+      "kind": "policy_module",
+      "path": ".agentplane/policy/workflow.branch_pr.md",
+      "sha256": "sha256:12d3b942042c276d30593803ddcfe12b20dc794e3e8bfbd97b6ce59df13ba82b",
+      "required": true
+    }
+  ]
+}

--- a/.agentplane/tasks/202607281455-147Q75/quality/20260728-150336937-recovery-context/quality-report.json
+++ b/.agentplane/tasks/202607281455-147Q75/quality/20260728-150336937-recovery-context/quality-report.json
@@ -1,0 +1,17 @@
+{
+  "schema_version": 1,
+  "task_id": "202607281455-147Q75",
+  "evaluator_id": "recovery-context",
+  "evaluator_profile": "EVALUATOR",
+  "generated_at": "2026-07-28T15:04:43.610Z",
+  "provenance": "evaluator_supplied",
+  "verdict": "pass",
+  "summary": "EVALUATOR returned pass with 0 typed finding(s).",
+  "evaluated_sha": "b5cad73384df973a4a0845521c97723347af56f8",
+  "blueprint_digest": "502c33075284ce6f9aa46423f98024e5cae094e841cac21d82f799f5898e4d05",
+  "findings": [],
+  "evidence_refs": [],
+  "missing_tests": [],
+  "hidden_assumptions": [],
+  "residual_risks": []
+}

--- a/.agentplane/tasks/202607281455-147Q75/quality/20260728-151123390-recovery-context/evaluator-blueprint.json
+++ b/.agentplane/tasks/202607281455-147Q75/quality/20260728-151123390-recovery-context/evaluator-blueprint.json
@@ -1,0 +1,582 @@
+{
+  "schemaVersion": 1,
+  "artifactKind": "agentplane.blueprint.resolved_snapshot",
+  "resolverInput": {
+    "taskId": "202607281455-147Q75",
+    "title": "Repair evaluator response schema for Codex structured output",
+    "description": "Release-blocking follow-up: make the evaluator typed-result JSON Schema compatible with the current Codex structured-output validator, preserve optional evidence fields through explicit nullable values, and add a regression test proving evaluator execution reaches a typed result instead of failing before the provider turn.",
+    "tags": [
+      "code",
+      "evaluator",
+      "provider",
+      "regression",
+      "release-blocker",
+      "v0.7"
+    ],
+    "owner": "CODER",
+    "taskKind": "code",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "mutation": "code",
+    "mutationScope": "code",
+    "touchedPaths": [],
+    "recipeHints": [],
+    "riskFlags": [],
+    "blueprintRequest": "code.branch_pr"
+  },
+  "selectedBlueprint": {
+    "id": "code.branch_pr",
+    "version": 1,
+    "title": "Branch PR code change",
+    "taskKinds": [
+      "code"
+    ],
+    "workflowModes": [
+      "branch_pr"
+    ]
+  },
+  "plan": {
+    "schemaVersion": 1,
+    "blueprintId": "code.branch_pr",
+    "blueprintVersion": 1,
+    "title": "Branch PR code change",
+    "taskId": "202607281455-147Q75",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "taskIntent": {
+      "taskKind": "code",
+      "mutationScope": "code",
+      "blueprintRequest": "code.branch_pr"
+    },
+    "whySelected": [
+      "explicit blueprint requested: code.branch_pr",
+      "task intent kind: code",
+      "workflow mode: branch_pr",
+      "task intent mutation scope: code"
+    ],
+    "states": [
+      {
+        "id": "intake",
+        "kind": "intake",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": []
+      },
+      {
+        "id": "scope",
+        "kind": "scope",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "assumptions"
+        ]
+      },
+      {
+        "id": "approval_gate",
+        "kind": "approval_gate",
+        "mode": "approval",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "approval"
+        ]
+      },
+      {
+        "id": "context_resolve",
+        "kind": "context_resolve",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [
+          ".agentplane/policy/security.must.md",
+          ".agentplane/policy/dod.core.md",
+          ".agentplane/policy/dod.code.md",
+          ".agentplane/policy/workflow.branch_pr.md"
+        ],
+        "evidenceKinds": [
+          "context_manifest"
+        ]
+      },
+      {
+        "id": "worktree_start",
+        "kind": "worktree_start",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "work_unit",
+        "kind": "work_unit",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "fast_local_checks",
+        "kind": "fast_local_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane task verify-show <task-id>",
+          "project focused checks"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "pr_artifact",
+        "kind": "pr_artifact",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "artifact",
+          "external_link"
+        ]
+      },
+      {
+        "id": "verify_record",
+        "kind": "verify_record",
+        "mode": "record",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "quality_gate",
+        "kind": "quality_gate",
+        "mode": "agentic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane evaluator run <task-id> --provenance human_supplied|evaluator_supplied --verdict pass|rework|blocked|human_review"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "quality_report"
+        ]
+      },
+      {
+        "id": "hosted_checks",
+        "kind": "hosted_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result",
+          "external_link"
+        ]
+      },
+      {
+        "id": "publish_or_integrate",
+        "kind": "publish_or_integrate",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane integrate <task-id> --branch <branch> --run-verify"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit",
+          "external_link"
+        ]
+      },
+      {
+        "id": "finish",
+        "kind": "finish",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit"
+        ]
+      }
+    ],
+    "requiredEvidence": [
+      {
+        "id": "code_pr.paths",
+        "kind": "changed_paths",
+        "producedBy": "work_unit",
+        "required": true,
+        "description": "Changed source paths."
+      },
+      {
+        "id": "code_pr.fast_checks",
+        "kind": "check_result",
+        "producedBy": "fast_local_checks",
+        "required": true,
+        "description": "Fast local checks."
+      },
+      {
+        "id": "code_pr.pr",
+        "kind": "external_link",
+        "producedBy": "pr_artifact",
+        "required": true,
+        "description": "Pull request artifact."
+      },
+      {
+        "id": "code_pr.verify",
+        "kind": "check_result",
+        "producedBy": "verify_record",
+        "required": true,
+        "description": "Task branch verification."
+      },
+      {
+        "id": "code_pr.quality",
+        "kind": "quality_report",
+        "producedBy": "quality_gate",
+        "required": true,
+        "description": "EVALUATOR quality verdict."
+      },
+      {
+        "id": "code_pr.hosted",
+        "kind": "check_result",
+        "producedBy": "hosted_checks",
+        "required": true,
+        "description": "Hosted check evidence."
+      },
+      {
+        "id": "code_pr.commit",
+        "kind": "commit",
+        "producedBy": "publish_or_integrate",
+        "required": true,
+        "description": "Integration commit."
+      }
+    ],
+    "policyModules": [
+      ".agentplane/policy/dod.code.md",
+      ".agentplane/policy/dod.core.md",
+      ".agentplane/policy/security.must.md",
+      ".agentplane/policy/workflow.branch_pr.md"
+    ],
+    "allowedCommands": [
+      "agentplane evaluator run <task-id> --provenance human_supplied|evaluator_supplied --verdict pass|rework|blocked|human_review",
+      "agentplane integrate <task-id> --branch <branch> --run-verify",
+      "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+      "agentplane task verify-show <task-id>",
+      "agentplane verify <task-id> --ok|--rework",
+      "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+      "project focused checks"
+    ],
+    "contextBudget": {
+      "maxPolicyModules": 4,
+      "maxPromptBlocks": 14,
+      "rationale": "Branch PR code work needs code DoD, branch_pr route policy, and evidence checks."
+    },
+    "contextManifest": [],
+    "acceptedRecipeExtensions": [],
+    "rejectedRecipeExtensions": [],
+    "stopReasons": []
+  },
+  "nodes": [
+    {
+      "id": "intake",
+      "kind": "intake",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": []
+    },
+    {
+      "id": "scope",
+      "kind": "scope",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "assumptions"
+      ]
+    },
+    {
+      "id": "approval_gate",
+      "kind": "approval_gate",
+      "mode": "approval",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "approval"
+      ]
+    },
+    {
+      "id": "context_resolve",
+      "kind": "context_resolve",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [
+        ".agentplane/policy/security.must.md",
+        ".agentplane/policy/dod.core.md",
+        ".agentplane/policy/dod.code.md",
+        ".agentplane/policy/workflow.branch_pr.md"
+      ],
+      "evidenceKinds": [
+        "context_manifest"
+      ]
+    },
+    {
+      "id": "worktree_start",
+      "kind": "worktree_start",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "work_unit",
+      "kind": "work_unit",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "fast_local_checks",
+      "kind": "fast_local_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane task verify-show <task-id>",
+        "project focused checks"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "pr_artifact",
+      "kind": "pr_artifact",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "artifact",
+        "external_link"
+      ]
+    },
+    {
+      "id": "verify_record",
+      "kind": "verify_record",
+      "mode": "record",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "quality_gate",
+      "kind": "quality_gate",
+      "mode": "agentic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane evaluator run <task-id> --provenance human_supplied|evaluator_supplied --verdict pass|rework|blocked|human_review"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "quality_report"
+      ]
+    },
+    {
+      "id": "hosted_checks",
+      "kind": "hosted_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result",
+        "external_link"
+      ]
+    },
+    {
+      "id": "publish_or_integrate",
+      "kind": "publish_or_integrate",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane integrate <task-id> --branch <branch> --run-verify"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit",
+        "external_link"
+      ]
+    },
+    {
+      "id": "finish",
+      "kind": "finish",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit"
+      ]
+    }
+  ],
+  "requiredEvidence": [
+    {
+      "id": "code_pr.paths",
+      "kind": "changed_paths",
+      "producedBy": "work_unit",
+      "required": true,
+      "description": "Changed source paths."
+    },
+    {
+      "id": "code_pr.fast_checks",
+      "kind": "check_result",
+      "producedBy": "fast_local_checks",
+      "required": true,
+      "description": "Fast local checks."
+    },
+    {
+      "id": "code_pr.pr",
+      "kind": "external_link",
+      "producedBy": "pr_artifact",
+      "required": true,
+      "description": "Pull request artifact."
+    },
+    {
+      "id": "code_pr.verify",
+      "kind": "check_result",
+      "producedBy": "verify_record",
+      "required": true,
+      "description": "Task branch verification."
+    },
+    {
+      "id": "code_pr.quality",
+      "kind": "quality_report",
+      "producedBy": "quality_gate",
+      "required": true,
+      "description": "EVALUATOR quality verdict."
+    },
+    {
+      "id": "code_pr.hosted",
+      "kind": "check_result",
+      "producedBy": "hosted_checks",
+      "required": true,
+      "description": "Hosted check evidence."
+    },
+    {
+      "id": "code_pr.commit",
+      "kind": "commit",
+      "producedBy": "publish_or_integrate",
+      "required": true,
+      "description": "Integration commit."
+    }
+  ],
+  "policyModules": [
+    ".agentplane/policy/dod.code.md",
+    ".agentplane/policy/dod.core.md",
+    ".agentplane/policy/security.must.md",
+    ".agentplane/policy/workflow.branch_pr.md"
+  ],
+  "allowedCommands": [
+    "agentplane evaluator run <task-id> --provenance human_supplied|evaluator_supplied --verdict pass|rework|blocked|human_review",
+    "agentplane integrate <task-id> --branch <branch> --run-verify",
+    "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+    "agentplane task verify-show <task-id>",
+    "agentplane verify <task-id> --ok|--rework",
+    "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+    "project focused checks"
+  ],
+  "contextBudget": {
+    "maxPolicyModules": 4,
+    "maxPromptBlocks": 14,
+    "rationale": "Branch PR code work needs code DoD, branch_pr route policy, and evidence checks."
+  },
+  "contextManifest": [],
+  "acceptedRecipeExtensions": [],
+  "rejectedRecipeExtensions": [],
+  "stopReasons": [],
+  "selectionReasons": [
+    "explicit blueprint requested: code.branch_pr",
+    "task intent kind: code",
+    "workflow mode: branch_pr",
+    "task intent mutation scope: code"
+  ],
+  "digest": {
+    "algorithm": "sha256",
+    "value": "502c33075284ce6f9aa46423f98024e5cae094e841cac21d82f799f5898e4d05"
+  }
+}

--- a/.agentplane/tasks/202607281455-147Q75/quality/20260728-151123390-recovery-context/evaluator-diff.patch
+++ b/.agentplane/tasks/202607281455-147Q75/quality/20260728-151123390-recovery-context/evaluator-diff.patch
@@ -1,0 +1,48 @@
+diff --git a/.agentplane/tasks/202607281455-147Q75/README.md b/.agentplane/tasks/202607281455-147Q75/README.md
+index cd7d916a3..6050db114 100644
+--- a/.agentplane/tasks/202607281455-147Q75/README.md
++++ b/.agentplane/tasks/202607281455-147Q75/README.md
+@@ -4,7 +4,7 @@ title: "Repair evaluator response schema for Codex structured output"
+ status: "DOING"
+ priority: "high"
+ owner: "CODER"
+-revision: 4
++revision: 5
+ origin:
+   system: "manual"
+ depends_on: []
+@@ -34,11 +34,16 @@ verification:
+   updated_by: null
+   note: null
+   attempts: 0
+-commit: null
++commit:
++  hash: "b5cad73384df973a4a0845521c97723347af56f8"
++  message: "Repair evaluator structured-output schema"
+ comments:
+   -
+     author: "CODER"
+     body: "Start: repair the evaluator structured-output schema compatibility defect and add a focused provider-schema regression without changing evaluator review semantics."
++  -
++    author: "CODER"
++    body: "Implemented: Codex-compatible evaluator output schema now requires nullable optional fields, the strict handoff normalizes nulls, and regression coverage proves the provider contract."
+ events:
+   -
+     type: "status"
+@@ -47,8 +52,15 @@ events:
+     from: "TODO"
+     to: "DOING"
+     note: "Start: repair the evaluator structured-output schema compatibility defect and add a focused provider-schema regression without changing evaluator review semantics."
++  -
++    type: "status"
++    at: "2026-07-28T15:02:06.041Z"
++    author: "CODER"
++    from: "DOING"
++    to: "DOING"
++    note: "Implemented: Codex-compatible evaluator output schema now requires nullable optional fields, the strict handoff normalizes nulls, and regression coverage proves the provider contract."
+ doc_version: 3
+-doc_updated_at: "2026-07-28T14:56:22.566Z"
++doc_updated_at: "2026-07-28T15:02:06.041Z"
+ doc_updated_by: "CODER"
+ description: "Release-blocking follow-up: make the evaluator typed-result JSON Schema compatible with the current Codex structured-output validator, preserve optional evidence fields through explicit nullable values, and add a regression test proving evaluator execution reaches a typed result instead of failing before the provider turn."
+ sections:

--- a/.agentplane/tasks/202607281455-147Q75/quality/20260728-151123390-recovery-context/evaluator-observed-checks.json
+++ b/.agentplane/tasks/202607281455-147Q75/quality/20260728-151123390-recovery-context/evaluator-observed-checks.json
@@ -1,0 +1,17 @@
+{
+  "task_status": "DOING",
+  "declared_checks": [
+    "bun run format:changed",
+    "bun run typecheck",
+    "bunx vitest run packages/agentplane/src/commands/evaluator/evaluator-episode.calibration.test.ts packages/agentplane/src/commands/evaluator/evaluator-execute.command.test.ts",
+    "node .agentplane/policy/check-routing.mjs"
+  ],
+  "verification": {
+    "state": "ok",
+    "attempts": 0,
+    "updated_at": "2026-07-28T15:03:08.775Z",
+    "updated_by": "TESTER",
+    "note": "Verified evaluator schema compatibility: all structured-output properties are required with nullable optional metadata, nulls normalize before strict SGR validation, and the provider boundary remains read-only. Checks passed: focused evaluator suites (14), typecheck, format, routing validation."
+  },
+  "runner_history": []
+}

--- a/.agentplane/tasks/202607281455-147Q75/quality/20260728-151123390-recovery-context/evaluator-opinion.md
+++ b/.agentplane/tasks/202607281455-147Q75/quality/20260728-151123390-recovery-context/evaluator-opinion.md
@@ -1,0 +1,20 @@
+# Semantic quality review: pass
+
+Provenance: evaluator_supplied
+
+EVALUATOR returned pass with 1 typed finding(s).
+
+## Findings
+- The response schema requires every declared key and represents optional source metadata and recovery context as null-capable fields; strict validation removes null placeholders before frozen-evidence checks.
+
+## Evidence
+- .agentplane/tasks/202607281455-147Q75/quality/20260728-151123390-recovery-context/evaluator-diff.patch
+
+## Missing Tests
+- none recorded
+
+## Hidden Assumptions
+- none recorded
+
+## Residual Risks
+- none recorded

--- a/.agentplane/tasks/202607281455-147Q75/quality/20260728-151123390-recovery-context/evaluator-prompt.md
+++ b/.agentplane/tasks/202607281455-147Q75/quality/20260728-151123390-recovery-context/evaluator-prompt.md
@@ -1,0 +1,82 @@
+# AgentPlane EVALUATOR episode
+
+AgentPlane prepared and froze the authoritative review input. Perform the semantic evaluation; do not reproduce CLI discovery or lifecycle work.
+This prompt does not execute an evaluator. A caller must run the evaluator in the work-order authority boundary and persist its returned typed result at the declared output path.
+Do not edit implementation, task lifecycle, policy, or evidence files. You may read the frozen evidence and run read-only checks only.
+
+- task_id: 202607281455-147Q75
+- task_readme: .agentplane/tasks/202607281455-147Q75/README.md
+- work_order: .agentplane/tasks/202607281455-147Q75/quality/20260728-151123390-recovery-context/evaluator-work-order.json
+- result_output: .agentplane/tasks/202607281455-147Q75/quality/20260728-151123390-recovery-context/evaluator-result.json
+- report_path: .agentplane/tasks/202607281455-147Q75/quality/20260728-151123390-recovery-context/quality-report.json
+- provenance: evaluator_supplied
+
+## Required result
+
+Return exactly one `sgr.evaluator_result.v1` JSON object through the evaluator result channel. The caller, not the read-only evaluator, persists it at `result_output`. It must contain:
+- schema_version: 1
+- kind: evaluator_result
+- evaluator_id: the evaluator id from the work order
+- verdict: pass | rework | blocked | human_review
+- findings: typed findings with id, severity, summary, broken_invariant, and non-empty evidence_refs
+- missing_tests and hidden_assumptions: string arrays
+- recovery_context: required non-empty string for rework, blocked, or human_review; for human_review it must be the single decision question for the human owner
+
+Every findings[].evidence_refs[].path must be an exact path from work_order.evidence. Do not add fields, commands, patches, lifecycle transitions, or a verdict outside this JSON result.
+The CLI validates the schema, frozen evidence digests, task revision, evaluated SHA, and blueprint before it records quality state.
+
+## Evaluator module
+
+---
+id: recovery-context
+title: Recovery Context Invariant Review
+version: 1
+status: preview
+profile: EVALUATOR
+tags:
+  - recovery
+  - invariants
+  - concurrency
+---
+
+# Recovery Context Invariant Review
+
+Use this evaluator only when the primary implementation path already produced a concrete change or when recovery context is needed after an interruption.
+
+## Inputs
+
+- Task id, task README, approved plan, and Verify Steps.
+- Current diff or PR patch.
+- Relevant comments, review findings, incidents, and recovery/handoff context.
+- Known concurrent-agent activity and task-artifact drift classification, if present.
+
+## Review Procedure
+
+1. Reconstruct the intended contract from the task, not from the implementation summary.
+2. Compare the diff against explicit invariants, stop rules, negative cases, and user constraints.
+3. Check whether recovery context changes the interpretation of the task or exposes stale assumptions.
+4. Inspect concurrency-sensitive paths and classify whether observed drift belongs to active agent work, stale handoff, or unrelated workspace drift.
+5. Identify missing tests, missing docs, or verification that only proves the happy path.
+6. Do not execute fixes. Return review findings only.
+7. When recording the result, use `agentplane evaluator run <task-id> --provenance evaluator_supplied` so the task gets prompt,
+   `quality-report.json`, and opinion artifacts. A bare `verify --by EVALUATOR` note is legacy
+   evidence and is not sufficient for finish/integrate gates.
+
+## Output
+
+Return a concise structured review:
+
+- `verdict`: `pass`, `rework`, `blocked`, or `human_review`.
+- `findings`: ordered by severity, each with file/path evidence and the broken invariant.
+- `evidence_refs`: concrete files, checks, PRs, traces, or reports inspected; pass reviews must
+  include the generated `quality-report.json`.
+- `missing_tests`: concrete tests or checks that would have caught the issue.
+- `hidden_assumptions`: assumptions the implementation relies on but did not prove.
+- `residual_risks`: known risks after the review.
+- `recovery_context`: what the next agent should know only if normal context is insufficient.
+
+## Stop Rules
+
+- Use `blocked` when required task context, diff, or recovery context is missing.
+- Use `rework` when behavior diverges from the approved contract even if local checks pass.
+- Use `pass` only when the implementation and verification evidence cover positive, negative, and concurrency-sensitive paths relevant to the task.

--- a/.agentplane/tasks/202607281455-147Q75/quality/20260728-151123390-recovery-context/evaluator-result.json
+++ b/.agentplane/tasks/202607281455-147Q75/quality/20260728-151123390-recovery-context/evaluator-result.json
@@ -1,0 +1,21 @@
+{
+  "schema_version": 1,
+  "kind": "evaluator_result",
+  "evaluator_id": "recovery-context",
+  "verdict": "pass",
+  "findings": [
+    {
+      "id": "compatibility-finding-1",
+      "severity": "medium",
+      "summary": "The response schema requires every declared key and represents optional source metadata and recovery context as null-capable fields; strict validation removes null placeholders before frozen-evidence checks.",
+      "broken_invariant": "Compatibility evaluator facade requires independent review evidence.",
+      "evidence_refs": [
+        {
+          "path": ".agentplane/tasks/202607281455-147Q75/quality/20260728-151123390-recovery-context/evaluator-diff.patch"
+        }
+      ]
+    }
+  ],
+  "missing_tests": [],
+  "hidden_assumptions": []
+}

--- a/.agentplane/tasks/202607281455-147Q75/quality/20260728-151123390-recovery-context/evaluator-work-order.json
+++ b/.agentplane/tasks/202607281455-147Q75/quality/20260728-151123390-recovery-context/evaluator-work-order.json
@@ -1,0 +1,97 @@
+{
+  "schema_version": 1,
+  "kind": "evaluator_work_order",
+  "work_order_id": "evaluator-work-order-202607281455-147Q75-2966261129135dd793e4aa5e",
+  "prepared_at": "2026-07-28T15:11:23.390Z",
+  "task": {
+    "id": "202607281455-147Q75",
+    "revision": 7,
+    "objective": "Repair evaluator response schema for Codex structured output\n\nRelease-blocking follow-up: make the evaluator typed-result JSON Schema compatible with the current Codex structured-output validator, preserve optional evidence fields through explicit nullable values, and add a regression test proving evaluator execution reaches a typed result instead of failing before the provider turn.",
+    "acceptance_criteria": [
+      "bun run format:changed",
+      "bun run typecheck",
+      "bunx vitest run packages/agentplane/src/commands/evaluator/evaluator-episode.calibration.test.ts packages/agentplane/src/commands/evaluator/evaluator-execute.command.test.ts",
+      "node .agentplane/policy/check-routing.mjs",
+      "- In scope: Release-blocking follow-up: make the evaluator typed-result JSON Schema compatible with the current Codex structured-output validator, preserve optional evidence fields through explicit nullable values, and add a regression test proving evaluator execution reaches a typed result instead of failing before the provider turn.\n- Out of scope: unrelated refactors not required for \"Repair evaluator response schema for Codex structured output\".",
+      "1. Change only the evaluator structured-output schema and its focused tests so Codex accepts the response format while the existing strict result validator keeps evidence fields semantically optional. 2. Add a regression that asserts the nested evidence reference schema is OpenAI-compatible and preserves nullable optional fields. 3. Run the declared evaluator tests, typecheck, format:changed, and routing validation. 4. Publish the task branch PR; record TESTER verification, EVALUATOR review, hosted checks, and integration before resuming task 202607221850-8HBF4J.",
+      "PLANNER fallback scaffold. Replace with task-specific acceptance checks when PLANNER context is available.\n\n1. Run `bunx vitest run packages/agentplane/src/commands/evaluator/evaluator-episode.calibration.test.ts packages/agentplane/src/commands/evaluator/evaluator-execute.command.test.ts`. Expected: it succeeds and confirms the requested outcome for this task.\n2. Run `bun run typecheck`. Expected: it succeeds and confirms the requested outcome for this task.\n3. Run `bun run format:changed`. Expected: it succeeds and confirms the requested outcome for this task.\n4. Run `node .agentplane/policy/check-routing.mjs`. Expected: it succeeds and confirms the requested outcome for this task.\n5. Review the changed artifact or behavior for the `code` task. Expected: the requested outcome is visible and matches the approved scope.\n6. Compare the final result against the task summary and touched scope. Expected: remaining follow-up is either resolved or explicit in ## Findings."
+    ]
+  },
+  "evaluated_sha": "2a83376fe1a6b69d98ece871ecd2b0c200a204ba",
+  "blueprint_digest": "502c33075284ce6f9aa46423f98024e5cae094e841cac21d82f799f5898e4d05",
+  "evaluator": {
+    "id": "recovery-context",
+    "profile": "EVALUATOR",
+    "prompt_module_path": ".agentplane/evaluators/recovery-context.md"
+  },
+  "authority": {
+    "sandbox": "read-only",
+    "writable_roots": [],
+    "allowed_tool_classes": [
+      "repository_read",
+      "git_read",
+      "run_checks",
+      "report_result"
+    ],
+    "external_side_effects": []
+  },
+  "result_contract": "sgr.evaluator_result.v1",
+  "evidence": [
+    {
+      "id": "task-document",
+      "kind": "task_document",
+      "path": ".agentplane/tasks/202607281455-147Q75/README.md",
+      "sha256": "sha256:63750faa0d62855195d23679be4738de022cecec00f039b1bddf3f68958fc09d",
+      "required": true
+    },
+    {
+      "id": "actual-diff",
+      "kind": "actual_diff",
+      "path": ".agentplane/tasks/202607281455-147Q75/quality/20260728-151123390-recovery-context/evaluator-diff.patch",
+      "sha256": "sha256:94ffab8074f08e522ff3b893552ce156c0f55735a38e8bf0c143794c9e652d47",
+      "required": true
+    },
+    {
+      "id": "observed-checks",
+      "kind": "observed_checks",
+      "path": ".agentplane/tasks/202607281455-147Q75/quality/20260728-151123390-recovery-context/evaluator-observed-checks.json",
+      "sha256": "sha256:d9766091f8d5baf547f3b5b4b40562dcd4eda3acecc6649e17b9dff509c0d8b7",
+      "required": true
+    },
+    {
+      "id": "blueprint",
+      "kind": "blueprint",
+      "path": ".agentplane/tasks/202607281455-147Q75/quality/20260728-151123390-recovery-context/evaluator-blueprint.json",
+      "sha256": "sha256:72fcb8c3a11cb7c24c9725eecd7af30106e482c804c6a32f1f535662a2283f44",
+      "required": true
+    },
+    {
+      "id": "policy-1",
+      "kind": "policy_module",
+      "path": ".agentplane/policy/dod.code.md",
+      "sha256": "sha256:3fec50dfe0db2f9495a3fa96f36d95fb34262033299d57f6f3775af4b7cc1486",
+      "required": true
+    },
+    {
+      "id": "policy-2",
+      "kind": "policy_module",
+      "path": ".agentplane/policy/dod.core.md",
+      "sha256": "sha256:f6c11b8a2c55760c17af15f79fe13791b3e7bba4852fc7d311fc0657e490b0c7",
+      "required": true
+    },
+    {
+      "id": "policy-3",
+      "kind": "policy_module",
+      "path": ".agentplane/policy/security.must.md",
+      "sha256": "sha256:96d01012e7ab67873bcb7a2cdd3818efa2c1fa500ee2eaf0e316f67e15bbcab2",
+      "required": true
+    },
+    {
+      "id": "policy-4",
+      "kind": "policy_module",
+      "path": ".agentplane/policy/workflow.branch_pr.md",
+      "sha256": "sha256:12d3b942042c276d30593803ddcfe12b20dc794e3e8bfbd97b6ce59df13ba82b",
+      "required": true
+    }
+  ]
+}

--- a/.agentplane/tasks/202607281455-147Q75/quality/20260728-151123390-recovery-context/quality-report.json
+++ b/.agentplane/tasks/202607281455-147Q75/quality/20260728-151123390-recovery-context/quality-report.json
@@ -1,0 +1,21 @@
+{
+  "schema_version": 1,
+  "task_id": "202607281455-147Q75",
+  "evaluator_id": "recovery-context",
+  "evaluator_profile": "EVALUATOR",
+  "generated_at": "2026-07-28T15:11:23.716Z",
+  "provenance": "evaluator_supplied",
+  "verdict": "pass",
+  "summary": "EVALUATOR returned pass with 1 typed finding(s).",
+  "evaluated_sha": "2a83376fe1a6b69d98ece871ecd2b0c200a204ba",
+  "blueprint_digest": "502c33075284ce6f9aa46423f98024e5cae094e841cac21d82f799f5898e4d05",
+  "findings": [
+    "The response schema requires every declared key and represents optional source metadata and recovery context as null-capable fields; strict validation removes null placeholders before frozen-evidence checks."
+  ],
+  "evidence_refs": [
+    ".agentplane/tasks/202607281455-147Q75/quality/20260728-151123390-recovery-context/evaluator-diff.patch"
+  ],
+  "missing_tests": [],
+  "hidden_assumptions": [],
+  "residual_risks": []
+}

--- a/.agentplane/tasks/202607281455-147Q75/quality/20260728-153249845-recovery-context/evaluator-blueprint.json
+++ b/.agentplane/tasks/202607281455-147Q75/quality/20260728-153249845-recovery-context/evaluator-blueprint.json
@@ -1,0 +1,582 @@
+{
+  "schemaVersion": 1,
+  "artifactKind": "agentplane.blueprint.resolved_snapshot",
+  "resolverInput": {
+    "taskId": "202607281455-147Q75",
+    "title": "Repair evaluator response schema for Codex structured output",
+    "description": "Release-blocking follow-up: make the evaluator typed-result JSON Schema compatible with the current Codex structured-output validator, preserve optional evidence fields through explicit nullable values, and add a regression test proving evaluator execution reaches a typed result instead of failing before the provider turn.",
+    "tags": [
+      "code",
+      "evaluator",
+      "provider",
+      "regression",
+      "release-blocker",
+      "v0.7"
+    ],
+    "owner": "CODER",
+    "taskKind": "code",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "mutation": "code",
+    "mutationScope": "code",
+    "touchedPaths": [],
+    "recipeHints": [],
+    "riskFlags": [],
+    "blueprintRequest": "code.branch_pr"
+  },
+  "selectedBlueprint": {
+    "id": "code.branch_pr",
+    "version": 1,
+    "title": "Branch PR code change",
+    "taskKinds": [
+      "code"
+    ],
+    "workflowModes": [
+      "branch_pr"
+    ]
+  },
+  "plan": {
+    "schemaVersion": 1,
+    "blueprintId": "code.branch_pr",
+    "blueprintVersion": 1,
+    "title": "Branch PR code change",
+    "taskId": "202607281455-147Q75",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "taskIntent": {
+      "taskKind": "code",
+      "mutationScope": "code",
+      "blueprintRequest": "code.branch_pr"
+    },
+    "whySelected": [
+      "explicit blueprint requested: code.branch_pr",
+      "task intent kind: code",
+      "workflow mode: branch_pr",
+      "task intent mutation scope: code"
+    ],
+    "states": [
+      {
+        "id": "intake",
+        "kind": "intake",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": []
+      },
+      {
+        "id": "scope",
+        "kind": "scope",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "assumptions"
+        ]
+      },
+      {
+        "id": "approval_gate",
+        "kind": "approval_gate",
+        "mode": "approval",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "approval"
+        ]
+      },
+      {
+        "id": "context_resolve",
+        "kind": "context_resolve",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [
+          ".agentplane/policy/security.must.md",
+          ".agentplane/policy/dod.core.md",
+          ".agentplane/policy/dod.code.md",
+          ".agentplane/policy/workflow.branch_pr.md"
+        ],
+        "evidenceKinds": [
+          "context_manifest"
+        ]
+      },
+      {
+        "id": "worktree_start",
+        "kind": "worktree_start",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "work_unit",
+        "kind": "work_unit",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "fast_local_checks",
+        "kind": "fast_local_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane task verify-show <task-id>",
+          "project focused checks"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "pr_artifact",
+        "kind": "pr_artifact",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "artifact",
+          "external_link"
+        ]
+      },
+      {
+        "id": "verify_record",
+        "kind": "verify_record",
+        "mode": "record",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "quality_gate",
+        "kind": "quality_gate",
+        "mode": "agentic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane evaluator run <task-id> --provenance human_supplied|evaluator_supplied --verdict pass|rework|blocked|human_review"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "quality_report"
+        ]
+      },
+      {
+        "id": "hosted_checks",
+        "kind": "hosted_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result",
+          "external_link"
+        ]
+      },
+      {
+        "id": "publish_or_integrate",
+        "kind": "publish_or_integrate",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane integrate <task-id> --branch <branch> --run-verify"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit",
+          "external_link"
+        ]
+      },
+      {
+        "id": "finish",
+        "kind": "finish",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit"
+        ]
+      }
+    ],
+    "requiredEvidence": [
+      {
+        "id": "code_pr.paths",
+        "kind": "changed_paths",
+        "producedBy": "work_unit",
+        "required": true,
+        "description": "Changed source paths."
+      },
+      {
+        "id": "code_pr.fast_checks",
+        "kind": "check_result",
+        "producedBy": "fast_local_checks",
+        "required": true,
+        "description": "Fast local checks."
+      },
+      {
+        "id": "code_pr.pr",
+        "kind": "external_link",
+        "producedBy": "pr_artifact",
+        "required": true,
+        "description": "Pull request artifact."
+      },
+      {
+        "id": "code_pr.verify",
+        "kind": "check_result",
+        "producedBy": "verify_record",
+        "required": true,
+        "description": "Task branch verification."
+      },
+      {
+        "id": "code_pr.quality",
+        "kind": "quality_report",
+        "producedBy": "quality_gate",
+        "required": true,
+        "description": "EVALUATOR quality verdict."
+      },
+      {
+        "id": "code_pr.hosted",
+        "kind": "check_result",
+        "producedBy": "hosted_checks",
+        "required": true,
+        "description": "Hosted check evidence."
+      },
+      {
+        "id": "code_pr.commit",
+        "kind": "commit",
+        "producedBy": "publish_or_integrate",
+        "required": true,
+        "description": "Integration commit."
+      }
+    ],
+    "policyModules": [
+      ".agentplane/policy/dod.code.md",
+      ".agentplane/policy/dod.core.md",
+      ".agentplane/policy/security.must.md",
+      ".agentplane/policy/workflow.branch_pr.md"
+    ],
+    "allowedCommands": [
+      "agentplane evaluator run <task-id> --provenance human_supplied|evaluator_supplied --verdict pass|rework|blocked|human_review",
+      "agentplane integrate <task-id> --branch <branch> --run-verify",
+      "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+      "agentplane task verify-show <task-id>",
+      "agentplane verify <task-id> --ok|--rework",
+      "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+      "project focused checks"
+    ],
+    "contextBudget": {
+      "maxPolicyModules": 4,
+      "maxPromptBlocks": 14,
+      "rationale": "Branch PR code work needs code DoD, branch_pr route policy, and evidence checks."
+    },
+    "contextManifest": [],
+    "acceptedRecipeExtensions": [],
+    "rejectedRecipeExtensions": [],
+    "stopReasons": []
+  },
+  "nodes": [
+    {
+      "id": "intake",
+      "kind": "intake",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": []
+    },
+    {
+      "id": "scope",
+      "kind": "scope",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "assumptions"
+      ]
+    },
+    {
+      "id": "approval_gate",
+      "kind": "approval_gate",
+      "mode": "approval",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "approval"
+      ]
+    },
+    {
+      "id": "context_resolve",
+      "kind": "context_resolve",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [
+        ".agentplane/policy/security.must.md",
+        ".agentplane/policy/dod.core.md",
+        ".agentplane/policy/dod.code.md",
+        ".agentplane/policy/workflow.branch_pr.md"
+      ],
+      "evidenceKinds": [
+        "context_manifest"
+      ]
+    },
+    {
+      "id": "worktree_start",
+      "kind": "worktree_start",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "work_unit",
+      "kind": "work_unit",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "fast_local_checks",
+      "kind": "fast_local_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane task verify-show <task-id>",
+        "project focused checks"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "pr_artifact",
+      "kind": "pr_artifact",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "artifact",
+        "external_link"
+      ]
+    },
+    {
+      "id": "verify_record",
+      "kind": "verify_record",
+      "mode": "record",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "quality_gate",
+      "kind": "quality_gate",
+      "mode": "agentic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane evaluator run <task-id> --provenance human_supplied|evaluator_supplied --verdict pass|rework|blocked|human_review"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "quality_report"
+      ]
+    },
+    {
+      "id": "hosted_checks",
+      "kind": "hosted_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result",
+        "external_link"
+      ]
+    },
+    {
+      "id": "publish_or_integrate",
+      "kind": "publish_or_integrate",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane integrate <task-id> --branch <branch> --run-verify"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit",
+        "external_link"
+      ]
+    },
+    {
+      "id": "finish",
+      "kind": "finish",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit"
+      ]
+    }
+  ],
+  "requiredEvidence": [
+    {
+      "id": "code_pr.paths",
+      "kind": "changed_paths",
+      "producedBy": "work_unit",
+      "required": true,
+      "description": "Changed source paths."
+    },
+    {
+      "id": "code_pr.fast_checks",
+      "kind": "check_result",
+      "producedBy": "fast_local_checks",
+      "required": true,
+      "description": "Fast local checks."
+    },
+    {
+      "id": "code_pr.pr",
+      "kind": "external_link",
+      "producedBy": "pr_artifact",
+      "required": true,
+      "description": "Pull request artifact."
+    },
+    {
+      "id": "code_pr.verify",
+      "kind": "check_result",
+      "producedBy": "verify_record",
+      "required": true,
+      "description": "Task branch verification."
+    },
+    {
+      "id": "code_pr.quality",
+      "kind": "quality_report",
+      "producedBy": "quality_gate",
+      "required": true,
+      "description": "EVALUATOR quality verdict."
+    },
+    {
+      "id": "code_pr.hosted",
+      "kind": "check_result",
+      "producedBy": "hosted_checks",
+      "required": true,
+      "description": "Hosted check evidence."
+    },
+    {
+      "id": "code_pr.commit",
+      "kind": "commit",
+      "producedBy": "publish_or_integrate",
+      "required": true,
+      "description": "Integration commit."
+    }
+  ],
+  "policyModules": [
+    ".agentplane/policy/dod.code.md",
+    ".agentplane/policy/dod.core.md",
+    ".agentplane/policy/security.must.md",
+    ".agentplane/policy/workflow.branch_pr.md"
+  ],
+  "allowedCommands": [
+    "agentplane evaluator run <task-id> --provenance human_supplied|evaluator_supplied --verdict pass|rework|blocked|human_review",
+    "agentplane integrate <task-id> --branch <branch> --run-verify",
+    "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+    "agentplane task verify-show <task-id>",
+    "agentplane verify <task-id> --ok|--rework",
+    "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+    "project focused checks"
+  ],
+  "contextBudget": {
+    "maxPolicyModules": 4,
+    "maxPromptBlocks": 14,
+    "rationale": "Branch PR code work needs code DoD, branch_pr route policy, and evidence checks."
+  },
+  "contextManifest": [],
+  "acceptedRecipeExtensions": [],
+  "rejectedRecipeExtensions": [],
+  "stopReasons": [],
+  "selectionReasons": [
+    "explicit blueprint requested: code.branch_pr",
+    "task intent kind: code",
+    "workflow mode: branch_pr",
+    "task intent mutation scope: code"
+  ],
+  "digest": {
+    "algorithm": "sha256",
+    "value": "502c33075284ce6f9aa46423f98024e5cae094e841cac21d82f799f5898e4d05"
+  }
+}

--- a/.agentplane/tasks/202607281455-147Q75/quality/20260728-153249845-recovery-context/evaluator-diff.patch
+++ b/.agentplane/tasks/202607281455-147Q75/quality/20260728-153249845-recovery-context/evaluator-diff.patch
@@ -1,0 +1,34 @@
+diff --git a/packages/agentplane/src/commands/evaluator/evaluator-review-usecase.ts b/packages/agentplane/src/commands/evaluator/evaluator-review-usecase.ts
+index 7a3f47a8d..57c8cecb9 100644
+--- a/packages/agentplane/src/commands/evaluator/evaluator-review-usecase.ts
++++ b/packages/agentplane/src/commands/evaluator/evaluator-review-usecase.ts
+@@ -432,18 +432,20 @@ function normalizeEvaluatorStructuredNulls(raw: Record<string, unknown>): Record
+   const normalized: Record<string, unknown> = { ...raw };
+   if (normalized.recovery_context === null) delete normalized.recovery_context;
+   if (!Array.isArray(normalized.findings)) return normalized;
+-  normalized.findings = normalized.findings.map((finding) => {
++  normalized.findings = (normalized.findings as unknown[]).map((finding: unknown): unknown => {
+     if (!finding || typeof finding !== "object" || Array.isArray(finding)) return finding;
+     const normalizedFinding: Record<string, unknown> = { ...finding };
+     if (!Array.isArray(normalizedFinding.evidence_refs)) return normalizedFinding;
+-    normalizedFinding.evidence_refs = normalizedFinding.evidence_refs.map((evidence) => {
+-      if (!evidence || typeof evidence !== "object" || Array.isArray(evidence)) return evidence;
+-      const normalizedEvidence: Record<string, unknown> = { ...evidence };
+-      for (const field of ["sha256", "line", "lines", "section"] as const) {
+-        if (normalizedEvidence[field] === null) delete normalizedEvidence[field];
+-      }
+-      return normalizedEvidence;
+-    });
++    normalizedFinding.evidence_refs = (normalizedFinding.evidence_refs as unknown[]).map(
++      (evidence: unknown): unknown => {
++        if (!evidence || typeof evidence !== "object" || Array.isArray(evidence)) return evidence;
++        const normalizedEvidence: Record<string, unknown> = { ...evidence };
++        for (const field of ["sha256", "line", "lines", "section"] as const) {
++          if (normalizedEvidence[field] === null) delete normalizedEvidence[field];
++        }
++        return normalizedEvidence;
++      },
++    );
+     return normalizedFinding;
+   });
+   return normalized;

--- a/.agentplane/tasks/202607281455-147Q75/quality/20260728-153249845-recovery-context/evaluator-observed-checks.json
+++ b/.agentplane/tasks/202607281455-147Q75/quality/20260728-153249845-recovery-context/evaluator-observed-checks.json
@@ -1,0 +1,17 @@
+{
+  "task_status": "DONE",
+  "declared_checks": [
+    "bun run format:changed",
+    "bun run typecheck",
+    "bunx vitest run packages/agentplane/src/commands/evaluator/evaluator-episode.calibration.test.ts packages/agentplane/src/commands/evaluator/evaluator-execute.command.test.ts",
+    "node .agentplane/policy/check-routing.mjs"
+  ],
+  "verification": {
+    "state": "ok",
+    "attempts": 0,
+    "updated_at": "2026-07-28T15:03:08.775Z",
+    "updated_by": "TESTER",
+    "note": "Verified evaluator schema compatibility: all structured-output properties are required with nullable optional metadata, nulls normalize before strict SGR validation, and the provider boundary remains read-only. Checks passed: focused evaluator suites (14), typecheck, format, routing validation."
+  },
+  "runner_history": []
+}

--- a/.agentplane/tasks/202607281455-147Q75/quality/20260728-153249845-recovery-context/evaluator-prompt.md
+++ b/.agentplane/tasks/202607281455-147Q75/quality/20260728-153249845-recovery-context/evaluator-prompt.md
@@ -1,0 +1,82 @@
+# AgentPlane EVALUATOR episode
+
+AgentPlane prepared and froze the authoritative review input. Perform the semantic evaluation; do not reproduce CLI discovery or lifecycle work.
+This prompt does not execute an evaluator. A caller must run the evaluator in the work-order authority boundary and persist its returned typed result at the declared output path.
+Do not edit implementation, task lifecycle, policy, or evidence files. You may read the frozen evidence and run read-only checks only.
+
+- task_id: 202607281455-147Q75
+- task_readme: .agentplane/tasks/202607281455-147Q75/README.md
+- work_order: .agentplane/tasks/202607281455-147Q75/quality/20260728-153249845-recovery-context/evaluator-work-order.json
+- result_output: .agentplane/tasks/202607281455-147Q75/quality/20260728-153249845-recovery-context/evaluator-result.json
+- report_path: .agentplane/tasks/202607281455-147Q75/quality/20260728-153249845-recovery-context/quality-report.json
+- provenance: evaluator_supplied
+
+## Required result
+
+Return exactly one `sgr.evaluator_result.v1` JSON object through the evaluator result channel. The caller, not the read-only evaluator, persists it at `result_output`. It must contain:
+- schema_version: 1
+- kind: evaluator_result
+- evaluator_id: the evaluator id from the work order
+- verdict: pass | rework | blocked | human_review
+- findings: typed findings with id, severity, summary, broken_invariant, and non-empty evidence_refs
+- missing_tests and hidden_assumptions: string arrays
+- recovery_context: required non-empty string for rework, blocked, or human_review; for human_review it must be the single decision question for the human owner
+
+Every findings[].evidence_refs[].path must be an exact path from work_order.evidence. Do not add fields, commands, patches, lifecycle transitions, or a verdict outside this JSON result.
+The CLI validates the schema, frozen evidence digests, task revision, evaluated SHA, and blueprint before it records quality state.
+
+## Evaluator module
+
+---
+id: recovery-context
+title: Recovery Context Invariant Review
+version: 1
+status: preview
+profile: EVALUATOR
+tags:
+  - recovery
+  - invariants
+  - concurrency
+---
+
+# Recovery Context Invariant Review
+
+Use this evaluator only when the primary implementation path already produced a concrete change or when recovery context is needed after an interruption.
+
+## Inputs
+
+- Task id, task README, approved plan, and Verify Steps.
+- Current diff or PR patch.
+- Relevant comments, review findings, incidents, and recovery/handoff context.
+- Known concurrent-agent activity and task-artifact drift classification, if present.
+
+## Review Procedure
+
+1. Reconstruct the intended contract from the task, not from the implementation summary.
+2. Compare the diff against explicit invariants, stop rules, negative cases, and user constraints.
+3. Check whether recovery context changes the interpretation of the task or exposes stale assumptions.
+4. Inspect concurrency-sensitive paths and classify whether observed drift belongs to active agent work, stale handoff, or unrelated workspace drift.
+5. Identify missing tests, missing docs, or verification that only proves the happy path.
+6. Do not execute fixes. Return review findings only.
+7. When recording the result, use `agentplane evaluator run <task-id> --provenance evaluator_supplied` so the task gets prompt,
+   `quality-report.json`, and opinion artifacts. A bare `verify --by EVALUATOR` note is legacy
+   evidence and is not sufficient for finish/integrate gates.
+
+## Output
+
+Return a concise structured review:
+
+- `verdict`: `pass`, `rework`, `blocked`, or `human_review`.
+- `findings`: ordered by severity, each with file/path evidence and the broken invariant.
+- `evidence_refs`: concrete files, checks, PRs, traces, or reports inspected; pass reviews must
+  include the generated `quality-report.json`.
+- `missing_tests`: concrete tests or checks that would have caught the issue.
+- `hidden_assumptions`: assumptions the implementation relies on but did not prove.
+- `residual_risks`: known risks after the review.
+- `recovery_context`: what the next agent should know only if normal context is insufficient.
+
+## Stop Rules
+
+- Use `blocked` when required task context, diff, or recovery context is missing.
+- Use `rework` when behavior diverges from the approved contract even if local checks pass.
+- Use `pass` only when the implementation and verification evidence cover positive, negative, and concurrency-sensitive paths relevant to the task.

--- a/.agentplane/tasks/202607281455-147Q75/quality/20260728-153249845-recovery-context/evaluator-work-order.json
+++ b/.agentplane/tasks/202607281455-147Q75/quality/20260728-153249845-recovery-context/evaluator-work-order.json
@@ -1,0 +1,97 @@
+{
+  "schema_version": 1,
+  "kind": "evaluator_work_order",
+  "work_order_id": "evaluator-work-order-202607281455-147Q75-72c3ea947b0c397a2fccfc63",
+  "prepared_at": "2026-07-28T15:32:49.845Z",
+  "task": {
+    "id": "202607281455-147Q75",
+    "revision": 9,
+    "objective": "Repair evaluator response schema for Codex structured output\n\nRelease-blocking follow-up: make the evaluator typed-result JSON Schema compatible with the current Codex structured-output validator, preserve optional evidence fields through explicit nullable values, and add a regression test proving evaluator execution reaches a typed result instead of failing before the provider turn.",
+    "acceptance_criteria": [
+      "bun run format:changed",
+      "bun run typecheck",
+      "bunx vitest run packages/agentplane/src/commands/evaluator/evaluator-episode.calibration.test.ts packages/agentplane/src/commands/evaluator/evaluator-execute.command.test.ts",
+      "node .agentplane/policy/check-routing.mjs",
+      "- In scope: Release-blocking follow-up: make the evaluator typed-result JSON Schema compatible with the current Codex structured-output validator, preserve optional evidence fields through explicit nullable values, and add a regression test proving evaluator execution reaches a typed result instead of failing before the provider turn.\n- Out of scope: unrelated refactors not required for \"Repair evaluator response schema for Codex structured output\".",
+      "1. Change only the evaluator structured-output schema and its focused tests so Codex accepts the response format while the existing strict result validator keeps evidence fields semantically optional. 2. Add a regression that asserts the nested evidence reference schema is OpenAI-compatible and preserves nullable optional fields. 3. Run the declared evaluator tests, typecheck, format:changed, and routing validation. 4. Publish the task branch PR; record TESTER verification, EVALUATOR review, hosted checks, and integration before resuming task 202607221850-8HBF4J.",
+      "PLANNER fallback scaffold. Replace with task-specific acceptance checks when PLANNER context is available.\n\n1. Run `bunx vitest run packages/agentplane/src/commands/evaluator/evaluator-episode.calibration.test.ts packages/agentplane/src/commands/evaluator/evaluator-execute.command.test.ts`. Expected: it succeeds and confirms the requested outcome for this task.\n2. Run `bun run typecheck`. Expected: it succeeds and confirms the requested outcome for this task.\n3. Run `bun run format:changed`. Expected: it succeeds and confirms the requested outcome for this task.\n4. Run `node .agentplane/policy/check-routing.mjs`. Expected: it succeeds and confirms the requested outcome for this task.\n5. Review the changed artifact or behavior for the `code` task. Expected: the requested outcome is visible and matches the approved scope.\n6. Compare the final result against the task summary and touched scope. Expected: remaining follow-up is either resolved or explicit in ## Findings."
+    ]
+  },
+  "evaluated_sha": "5fe3f261279c62fbcda629d4ee6cb539fdc956e1",
+  "blueprint_digest": "502c33075284ce6f9aa46423f98024e5cae094e841cac21d82f799f5898e4d05",
+  "evaluator": {
+    "id": "recovery-context",
+    "profile": "EVALUATOR",
+    "prompt_module_path": ".agentplane/evaluators/recovery-context.md"
+  },
+  "authority": {
+    "sandbox": "read-only",
+    "writable_roots": [],
+    "allowed_tool_classes": [
+      "repository_read",
+      "git_read",
+      "run_checks",
+      "report_result"
+    ],
+    "external_side_effects": []
+  },
+  "result_contract": "sgr.evaluator_result.v1",
+  "evidence": [
+    {
+      "id": "task-document",
+      "kind": "task_document",
+      "path": ".agentplane/tasks/202607281455-147Q75/README.md",
+      "sha256": "sha256:01a9f11a9ea7f1c09709eefaf420a147ad7126ce521a18d24921193bff00a7aa",
+      "required": true
+    },
+    {
+      "id": "actual-diff",
+      "kind": "actual_diff",
+      "path": ".agentplane/tasks/202607281455-147Q75/quality/20260728-153249845-recovery-context/evaluator-diff.patch",
+      "sha256": "sha256:574fd7dd4e69fc01ae0f1d3a2e75bb5603ce7e01725e7d0f0b12d86e26423d7c",
+      "required": true
+    },
+    {
+      "id": "observed-checks",
+      "kind": "observed_checks",
+      "path": ".agentplane/tasks/202607281455-147Q75/quality/20260728-153249845-recovery-context/evaluator-observed-checks.json",
+      "sha256": "sha256:bdbdb67b2fb320ea64438d2cc89480c53c6635f0b5d7ce3ed2767019094af1d5",
+      "required": true
+    },
+    {
+      "id": "blueprint",
+      "kind": "blueprint",
+      "path": ".agentplane/tasks/202607281455-147Q75/quality/20260728-153249845-recovery-context/evaluator-blueprint.json",
+      "sha256": "sha256:72fcb8c3a11cb7c24c9725eecd7af30106e482c804c6a32f1f535662a2283f44",
+      "required": true
+    },
+    {
+      "id": "policy-1",
+      "kind": "policy_module",
+      "path": ".agentplane/policy/dod.code.md",
+      "sha256": "sha256:3fec50dfe0db2f9495a3fa96f36d95fb34262033299d57f6f3775af4b7cc1486",
+      "required": true
+    },
+    {
+      "id": "policy-2",
+      "kind": "policy_module",
+      "path": ".agentplane/policy/dod.core.md",
+      "sha256": "sha256:f6c11b8a2c55760c17af15f79fe13791b3e7bba4852fc7d311fc0657e490b0c7",
+      "required": true
+    },
+    {
+      "id": "policy-3",
+      "kind": "policy_module",
+      "path": ".agentplane/policy/security.must.md",
+      "sha256": "sha256:96d01012e7ab67873bcb7a2cdd3818efa2c1fa500ee2eaf0e316f67e15bbcab2",
+      "required": true
+    },
+    {
+      "id": "policy-4",
+      "kind": "policy_module",
+      "path": ".agentplane/policy/workflow.branch_pr.md",
+      "sha256": "sha256:12d3b942042c276d30593803ddcfe12b20dc794e3e8bfbd97b6ce59df13ba82b",
+      "required": true
+    }
+  ]
+}

--- a/.agentplane/tasks/202607281455-147Q75/quality/20260728-153650388-recovery-context/evaluator-blueprint.json
+++ b/.agentplane/tasks/202607281455-147Q75/quality/20260728-153650388-recovery-context/evaluator-blueprint.json
@@ -1,0 +1,582 @@
+{
+  "schemaVersion": 1,
+  "artifactKind": "agentplane.blueprint.resolved_snapshot",
+  "resolverInput": {
+    "taskId": "202607281455-147Q75",
+    "title": "Repair evaluator response schema for Codex structured output",
+    "description": "Release-blocking follow-up: make the evaluator typed-result JSON Schema compatible with the current Codex structured-output validator, preserve optional evidence fields through explicit nullable values, and add a regression test proving evaluator execution reaches a typed result instead of failing before the provider turn.",
+    "tags": [
+      "code",
+      "evaluator",
+      "provider",
+      "regression",
+      "release-blocker",
+      "v0.7"
+    ],
+    "owner": "CODER",
+    "taskKind": "code",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "mutation": "code",
+    "mutationScope": "code",
+    "touchedPaths": [],
+    "recipeHints": [],
+    "riskFlags": [],
+    "blueprintRequest": "code.branch_pr"
+  },
+  "selectedBlueprint": {
+    "id": "code.branch_pr",
+    "version": 1,
+    "title": "Branch PR code change",
+    "taskKinds": [
+      "code"
+    ],
+    "workflowModes": [
+      "branch_pr"
+    ]
+  },
+  "plan": {
+    "schemaVersion": 1,
+    "blueprintId": "code.branch_pr",
+    "blueprintVersion": 1,
+    "title": "Branch PR code change",
+    "taskId": "202607281455-147Q75",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "taskIntent": {
+      "taskKind": "code",
+      "mutationScope": "code",
+      "blueprintRequest": "code.branch_pr"
+    },
+    "whySelected": [
+      "explicit blueprint requested: code.branch_pr",
+      "task intent kind: code",
+      "workflow mode: branch_pr",
+      "task intent mutation scope: code"
+    ],
+    "states": [
+      {
+        "id": "intake",
+        "kind": "intake",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": []
+      },
+      {
+        "id": "scope",
+        "kind": "scope",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "assumptions"
+        ]
+      },
+      {
+        "id": "approval_gate",
+        "kind": "approval_gate",
+        "mode": "approval",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "approval"
+        ]
+      },
+      {
+        "id": "context_resolve",
+        "kind": "context_resolve",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [
+          ".agentplane/policy/security.must.md",
+          ".agentplane/policy/dod.core.md",
+          ".agentplane/policy/dod.code.md",
+          ".agentplane/policy/workflow.branch_pr.md"
+        ],
+        "evidenceKinds": [
+          "context_manifest"
+        ]
+      },
+      {
+        "id": "worktree_start",
+        "kind": "worktree_start",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "work_unit",
+        "kind": "work_unit",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "fast_local_checks",
+        "kind": "fast_local_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane task verify-show <task-id>",
+          "project focused checks"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "pr_artifact",
+        "kind": "pr_artifact",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "artifact",
+          "external_link"
+        ]
+      },
+      {
+        "id": "verify_record",
+        "kind": "verify_record",
+        "mode": "record",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "quality_gate",
+        "kind": "quality_gate",
+        "mode": "agentic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane evaluator run <task-id> --provenance human_supplied|evaluator_supplied --verdict pass|rework|blocked|human_review"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "quality_report"
+        ]
+      },
+      {
+        "id": "hosted_checks",
+        "kind": "hosted_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result",
+          "external_link"
+        ]
+      },
+      {
+        "id": "publish_or_integrate",
+        "kind": "publish_or_integrate",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane integrate <task-id> --branch <branch> --run-verify"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit",
+          "external_link"
+        ]
+      },
+      {
+        "id": "finish",
+        "kind": "finish",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit"
+        ]
+      }
+    ],
+    "requiredEvidence": [
+      {
+        "id": "code_pr.paths",
+        "kind": "changed_paths",
+        "producedBy": "work_unit",
+        "required": true,
+        "description": "Changed source paths."
+      },
+      {
+        "id": "code_pr.fast_checks",
+        "kind": "check_result",
+        "producedBy": "fast_local_checks",
+        "required": true,
+        "description": "Fast local checks."
+      },
+      {
+        "id": "code_pr.pr",
+        "kind": "external_link",
+        "producedBy": "pr_artifact",
+        "required": true,
+        "description": "Pull request artifact."
+      },
+      {
+        "id": "code_pr.verify",
+        "kind": "check_result",
+        "producedBy": "verify_record",
+        "required": true,
+        "description": "Task branch verification."
+      },
+      {
+        "id": "code_pr.quality",
+        "kind": "quality_report",
+        "producedBy": "quality_gate",
+        "required": true,
+        "description": "EVALUATOR quality verdict."
+      },
+      {
+        "id": "code_pr.hosted",
+        "kind": "check_result",
+        "producedBy": "hosted_checks",
+        "required": true,
+        "description": "Hosted check evidence."
+      },
+      {
+        "id": "code_pr.commit",
+        "kind": "commit",
+        "producedBy": "publish_or_integrate",
+        "required": true,
+        "description": "Integration commit."
+      }
+    ],
+    "policyModules": [
+      ".agentplane/policy/dod.code.md",
+      ".agentplane/policy/dod.core.md",
+      ".agentplane/policy/security.must.md",
+      ".agentplane/policy/workflow.branch_pr.md"
+    ],
+    "allowedCommands": [
+      "agentplane evaluator run <task-id> --provenance human_supplied|evaluator_supplied --verdict pass|rework|blocked|human_review",
+      "agentplane integrate <task-id> --branch <branch> --run-verify",
+      "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+      "agentplane task verify-show <task-id>",
+      "agentplane verify <task-id> --ok|--rework",
+      "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+      "project focused checks"
+    ],
+    "contextBudget": {
+      "maxPolicyModules": 4,
+      "maxPromptBlocks": 14,
+      "rationale": "Branch PR code work needs code DoD, branch_pr route policy, and evidence checks."
+    },
+    "contextManifest": [],
+    "acceptedRecipeExtensions": [],
+    "rejectedRecipeExtensions": [],
+    "stopReasons": []
+  },
+  "nodes": [
+    {
+      "id": "intake",
+      "kind": "intake",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": []
+    },
+    {
+      "id": "scope",
+      "kind": "scope",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "assumptions"
+      ]
+    },
+    {
+      "id": "approval_gate",
+      "kind": "approval_gate",
+      "mode": "approval",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "approval"
+      ]
+    },
+    {
+      "id": "context_resolve",
+      "kind": "context_resolve",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [
+        ".agentplane/policy/security.must.md",
+        ".agentplane/policy/dod.core.md",
+        ".agentplane/policy/dod.code.md",
+        ".agentplane/policy/workflow.branch_pr.md"
+      ],
+      "evidenceKinds": [
+        "context_manifest"
+      ]
+    },
+    {
+      "id": "worktree_start",
+      "kind": "worktree_start",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "work_unit",
+      "kind": "work_unit",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "fast_local_checks",
+      "kind": "fast_local_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane task verify-show <task-id>",
+        "project focused checks"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "pr_artifact",
+      "kind": "pr_artifact",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "artifact",
+        "external_link"
+      ]
+    },
+    {
+      "id": "verify_record",
+      "kind": "verify_record",
+      "mode": "record",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "quality_gate",
+      "kind": "quality_gate",
+      "mode": "agentic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane evaluator run <task-id> --provenance human_supplied|evaluator_supplied --verdict pass|rework|blocked|human_review"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "quality_report"
+      ]
+    },
+    {
+      "id": "hosted_checks",
+      "kind": "hosted_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result",
+        "external_link"
+      ]
+    },
+    {
+      "id": "publish_or_integrate",
+      "kind": "publish_or_integrate",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane integrate <task-id> --branch <branch> --run-verify"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit",
+        "external_link"
+      ]
+    },
+    {
+      "id": "finish",
+      "kind": "finish",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit"
+      ]
+    }
+  ],
+  "requiredEvidence": [
+    {
+      "id": "code_pr.paths",
+      "kind": "changed_paths",
+      "producedBy": "work_unit",
+      "required": true,
+      "description": "Changed source paths."
+    },
+    {
+      "id": "code_pr.fast_checks",
+      "kind": "check_result",
+      "producedBy": "fast_local_checks",
+      "required": true,
+      "description": "Fast local checks."
+    },
+    {
+      "id": "code_pr.pr",
+      "kind": "external_link",
+      "producedBy": "pr_artifact",
+      "required": true,
+      "description": "Pull request artifact."
+    },
+    {
+      "id": "code_pr.verify",
+      "kind": "check_result",
+      "producedBy": "verify_record",
+      "required": true,
+      "description": "Task branch verification."
+    },
+    {
+      "id": "code_pr.quality",
+      "kind": "quality_report",
+      "producedBy": "quality_gate",
+      "required": true,
+      "description": "EVALUATOR quality verdict."
+    },
+    {
+      "id": "code_pr.hosted",
+      "kind": "check_result",
+      "producedBy": "hosted_checks",
+      "required": true,
+      "description": "Hosted check evidence."
+    },
+    {
+      "id": "code_pr.commit",
+      "kind": "commit",
+      "producedBy": "publish_or_integrate",
+      "required": true,
+      "description": "Integration commit."
+    }
+  ],
+  "policyModules": [
+    ".agentplane/policy/dod.code.md",
+    ".agentplane/policy/dod.core.md",
+    ".agentplane/policy/security.must.md",
+    ".agentplane/policy/workflow.branch_pr.md"
+  ],
+  "allowedCommands": [
+    "agentplane evaluator run <task-id> --provenance human_supplied|evaluator_supplied --verdict pass|rework|blocked|human_review",
+    "agentplane integrate <task-id> --branch <branch> --run-verify",
+    "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+    "agentplane task verify-show <task-id>",
+    "agentplane verify <task-id> --ok|--rework",
+    "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+    "project focused checks"
+  ],
+  "contextBudget": {
+    "maxPolicyModules": 4,
+    "maxPromptBlocks": 14,
+    "rationale": "Branch PR code work needs code DoD, branch_pr route policy, and evidence checks."
+  },
+  "contextManifest": [],
+  "acceptedRecipeExtensions": [],
+  "rejectedRecipeExtensions": [],
+  "stopReasons": [],
+  "selectionReasons": [
+    "explicit blueprint requested: code.branch_pr",
+    "task intent kind: code",
+    "workflow mode: branch_pr",
+    "task intent mutation scope: code"
+  ],
+  "digest": {
+    "algorithm": "sha256",
+    "value": "502c33075284ce6f9aa46423f98024e5cae094e841cac21d82f799f5898e4d05"
+  }
+}

--- a/.agentplane/tasks/202607281455-147Q75/quality/20260728-153650388-recovery-context/evaluator-diff.patch
+++ b/.agentplane/tasks/202607281455-147Q75/quality/20260728-153650388-recovery-context/evaluator-diff.patch
@@ -1,0 +1,34 @@
+diff --git a/packages/agentplane/src/commands/evaluator/evaluator-review-usecase.ts b/packages/agentplane/src/commands/evaluator/evaluator-review-usecase.ts
+index 7a3f47a8d..57c8cecb9 100644
+--- a/packages/agentplane/src/commands/evaluator/evaluator-review-usecase.ts
++++ b/packages/agentplane/src/commands/evaluator/evaluator-review-usecase.ts
+@@ -432,18 +432,20 @@ function normalizeEvaluatorStructuredNulls(raw: Record<string, unknown>): Record
+   const normalized: Record<string, unknown> = { ...raw };
+   if (normalized.recovery_context === null) delete normalized.recovery_context;
+   if (!Array.isArray(normalized.findings)) return normalized;
+-  normalized.findings = normalized.findings.map((finding) => {
++  normalized.findings = (normalized.findings as unknown[]).map((finding: unknown): unknown => {
+     if (!finding || typeof finding !== "object" || Array.isArray(finding)) return finding;
+     const normalizedFinding: Record<string, unknown> = { ...finding };
+     if (!Array.isArray(normalizedFinding.evidence_refs)) return normalizedFinding;
+-    normalizedFinding.evidence_refs = normalizedFinding.evidence_refs.map((evidence) => {
+-      if (!evidence || typeof evidence !== "object" || Array.isArray(evidence)) return evidence;
+-      const normalizedEvidence: Record<string, unknown> = { ...evidence };
+-      for (const field of ["sha256", "line", "lines", "section"] as const) {
+-        if (normalizedEvidence[field] === null) delete normalizedEvidence[field];
+-      }
+-      return normalizedEvidence;
+-    });
++    normalizedFinding.evidence_refs = (normalizedFinding.evidence_refs as unknown[]).map(
++      (evidence: unknown): unknown => {
++        if (!evidence || typeof evidence !== "object" || Array.isArray(evidence)) return evidence;
++        const normalizedEvidence: Record<string, unknown> = { ...evidence };
++        for (const field of ["sha256", "line", "lines", "section"] as const) {
++          if (normalizedEvidence[field] === null) delete normalizedEvidence[field];
++        }
++        return normalizedEvidence;
++      },
++    );
+     return normalizedFinding;
+   });
+   return normalized;

--- a/.agentplane/tasks/202607281455-147Q75/quality/20260728-153650388-recovery-context/evaluator-observed-checks.json
+++ b/.agentplane/tasks/202607281455-147Q75/quality/20260728-153650388-recovery-context/evaluator-observed-checks.json
@@ -1,0 +1,17 @@
+{
+  "task_status": "DONE",
+  "declared_checks": [
+    "bun run format:changed",
+    "bun run typecheck",
+    "bunx vitest run packages/agentplane/src/commands/evaluator/evaluator-episode.calibration.test.ts packages/agentplane/src/commands/evaluator/evaluator-execute.command.test.ts",
+    "node .agentplane/policy/check-routing.mjs"
+  ],
+  "verification": {
+    "state": "ok",
+    "attempts": 0,
+    "updated_at": "2026-07-28T15:03:08.775Z",
+    "updated_by": "TESTER",
+    "note": "Verified evaluator schema compatibility: all structured-output properties are required with nullable optional metadata, nulls normalize before strict SGR validation, and the provider boundary remains read-only. Checks passed: focused evaluator suites (14), typecheck, format, routing validation."
+  },
+  "runner_history": []
+}

--- a/.agentplane/tasks/202607281455-147Q75/quality/20260728-153650388-recovery-context/evaluator-opinion.md
+++ b/.agentplane/tasks/202607281455-147Q75/quality/20260728-153650388-recovery-context/evaluator-opinion.md
@@ -1,0 +1,21 @@
+# Semantic quality review: pass
+
+Provenance: human_supplied
+
+Independent review of the CI recovery patch: the null-normalization traversal now treats external arrays as unknown values before record narrowing, preserving the schema compatibility behavior while satisfying strict TypeScript safety.
+
+## Findings
+- The normalization path preserves its read-only semantics: only null placeholders are removed from copied records, while non-record and array values remain opaque unknown values.
+
+## Evidence
+- packages/agentplane/src/commands/evaluator/evaluator-review-usecase.ts
+- 5fe3f261279c62fbcda629d4ee6cb539fdc956e1
+
+## Missing Tests
+- none recorded
+
+## Hidden Assumptions
+- none recorded
+
+## Residual Risks
+- none recorded

--- a/.agentplane/tasks/202607281455-147Q75/quality/20260728-153650388-recovery-context/evaluator-prompt.md
+++ b/.agentplane/tasks/202607281455-147Q75/quality/20260728-153650388-recovery-context/evaluator-prompt.md
@@ -1,0 +1,82 @@
+# AgentPlane EVALUATOR episode
+
+AgentPlane prepared and froze the authoritative review input. Perform the semantic evaluation; do not reproduce CLI discovery or lifecycle work.
+This prompt does not execute an evaluator. A caller must run the evaluator in the work-order authority boundary and persist its returned typed result at the declared output path.
+Do not edit implementation, task lifecycle, policy, or evidence files. You may read the frozen evidence and run read-only checks only.
+
+- task_id: 202607281455-147Q75
+- task_readme: .agentplane/tasks/202607281455-147Q75/README.md
+- work_order: .agentplane/tasks/202607281455-147Q75/quality/20260728-153650388-recovery-context/evaluator-work-order.json
+- result_output: .agentplane/tasks/202607281455-147Q75/quality/20260728-153650388-recovery-context/evaluator-result.json
+- report_path: .agentplane/tasks/202607281455-147Q75/quality/20260728-153650388-recovery-context/quality-report.json
+- provenance: human_supplied
+
+## Required result
+
+Return exactly one `sgr.evaluator_result.v1` JSON object through the evaluator result channel. The caller, not the read-only evaluator, persists it at `result_output`. It must contain:
+- schema_version: 1
+- kind: evaluator_result
+- evaluator_id: the evaluator id from the work order
+- verdict: pass | rework | blocked | human_review
+- findings: typed findings with id, severity, summary, broken_invariant, and non-empty evidence_refs
+- missing_tests and hidden_assumptions: string arrays
+- recovery_context: required non-empty string for rework, blocked, or human_review; for human_review it must be the single decision question for the human owner
+
+Every findings[].evidence_refs[].path must be an exact path from work_order.evidence. Do not add fields, commands, patches, lifecycle transitions, or a verdict outside this JSON result.
+The CLI validates the schema, frozen evidence digests, task revision, evaluated SHA, and blueprint before it records quality state.
+
+## Evaluator module
+
+---
+id: recovery-context
+title: Recovery Context Invariant Review
+version: 1
+status: preview
+profile: EVALUATOR
+tags:
+  - recovery
+  - invariants
+  - concurrency
+---
+
+# Recovery Context Invariant Review
+
+Use this evaluator only when the primary implementation path already produced a concrete change or when recovery context is needed after an interruption.
+
+## Inputs
+
+- Task id, task README, approved plan, and Verify Steps.
+- Current diff or PR patch.
+- Relevant comments, review findings, incidents, and recovery/handoff context.
+- Known concurrent-agent activity and task-artifact drift classification, if present.
+
+## Review Procedure
+
+1. Reconstruct the intended contract from the task, not from the implementation summary.
+2. Compare the diff against explicit invariants, stop rules, negative cases, and user constraints.
+3. Check whether recovery context changes the interpretation of the task or exposes stale assumptions.
+4. Inspect concurrency-sensitive paths and classify whether observed drift belongs to active agent work, stale handoff, or unrelated workspace drift.
+5. Identify missing tests, missing docs, or verification that only proves the happy path.
+6. Do not execute fixes. Return review findings only.
+7. When recording the result, use `agentplane evaluator run <task-id> --provenance evaluator_supplied` so the task gets prompt,
+   `quality-report.json`, and opinion artifacts. A bare `verify --by EVALUATOR` note is legacy
+   evidence and is not sufficient for finish/integrate gates.
+
+## Output
+
+Return a concise structured review:
+
+- `verdict`: `pass`, `rework`, `blocked`, or `human_review`.
+- `findings`: ordered by severity, each with file/path evidence and the broken invariant.
+- `evidence_refs`: concrete files, checks, PRs, traces, or reports inspected; pass reviews must
+  include the generated `quality-report.json`.
+- `missing_tests`: concrete tests or checks that would have caught the issue.
+- `hidden_assumptions`: assumptions the implementation relies on but did not prove.
+- `residual_risks`: known risks after the review.
+- `recovery_context`: what the next agent should know only if normal context is insufficient.
+
+## Stop Rules
+
+- Use `blocked` when required task context, diff, or recovery context is missing.
+- Use `rework` when behavior diverges from the approved contract even if local checks pass.
+- Use `pass` only when the implementation and verification evidence cover positive, negative, and concurrency-sensitive paths relevant to the task.

--- a/.agentplane/tasks/202607281455-147Q75/quality/20260728-153650388-recovery-context/evaluator-work-order.json
+++ b/.agentplane/tasks/202607281455-147Q75/quality/20260728-153650388-recovery-context/evaluator-work-order.json
@@ -1,0 +1,97 @@
+{
+  "schema_version": 1,
+  "kind": "evaluator_work_order",
+  "work_order_id": "evaluator-work-order-202607281455-147Q75-72c3ea947b0c397a2fccfc63",
+  "prepared_at": "2026-07-28T15:36:50.388Z",
+  "task": {
+    "id": "202607281455-147Q75",
+    "revision": 9,
+    "objective": "Repair evaluator response schema for Codex structured output\n\nRelease-blocking follow-up: make the evaluator typed-result JSON Schema compatible with the current Codex structured-output validator, preserve optional evidence fields through explicit nullable values, and add a regression test proving evaluator execution reaches a typed result instead of failing before the provider turn.",
+    "acceptance_criteria": [
+      "bun run format:changed",
+      "bun run typecheck",
+      "bunx vitest run packages/agentplane/src/commands/evaluator/evaluator-episode.calibration.test.ts packages/agentplane/src/commands/evaluator/evaluator-execute.command.test.ts",
+      "node .agentplane/policy/check-routing.mjs",
+      "- In scope: Release-blocking follow-up: make the evaluator typed-result JSON Schema compatible with the current Codex structured-output validator, preserve optional evidence fields through explicit nullable values, and add a regression test proving evaluator execution reaches a typed result instead of failing before the provider turn.\n- Out of scope: unrelated refactors not required for \"Repair evaluator response schema for Codex structured output\".",
+      "1. Change only the evaluator structured-output schema and its focused tests so Codex accepts the response format while the existing strict result validator keeps evidence fields semantically optional. 2. Add a regression that asserts the nested evidence reference schema is OpenAI-compatible and preserves nullable optional fields. 3. Run the declared evaluator tests, typecheck, format:changed, and routing validation. 4. Publish the task branch PR; record TESTER verification, EVALUATOR review, hosted checks, and integration before resuming task 202607221850-8HBF4J.",
+      "PLANNER fallback scaffold. Replace with task-specific acceptance checks when PLANNER context is available.\n\n1. Run `bunx vitest run packages/agentplane/src/commands/evaluator/evaluator-episode.calibration.test.ts packages/agentplane/src/commands/evaluator/evaluator-execute.command.test.ts`. Expected: it succeeds and confirms the requested outcome for this task.\n2. Run `bun run typecheck`. Expected: it succeeds and confirms the requested outcome for this task.\n3. Run `bun run format:changed`. Expected: it succeeds and confirms the requested outcome for this task.\n4. Run `node .agentplane/policy/check-routing.mjs`. Expected: it succeeds and confirms the requested outcome for this task.\n5. Review the changed artifact or behavior for the `code` task. Expected: the requested outcome is visible and matches the approved scope.\n6. Compare the final result against the task summary and touched scope. Expected: remaining follow-up is either resolved or explicit in ## Findings."
+    ]
+  },
+  "evaluated_sha": "5fe3f261279c62fbcda629d4ee6cb539fdc956e1",
+  "blueprint_digest": "502c33075284ce6f9aa46423f98024e5cae094e841cac21d82f799f5898e4d05",
+  "evaluator": {
+    "id": "recovery-context",
+    "profile": "EVALUATOR",
+    "prompt_module_path": ".agentplane/evaluators/recovery-context.md"
+  },
+  "authority": {
+    "sandbox": "read-only",
+    "writable_roots": [],
+    "allowed_tool_classes": [
+      "repository_read",
+      "git_read",
+      "run_checks",
+      "report_result"
+    ],
+    "external_side_effects": []
+  },
+  "result_contract": "sgr.evaluator_result.v1",
+  "evidence": [
+    {
+      "id": "task-document",
+      "kind": "task_document",
+      "path": ".agentplane/tasks/202607281455-147Q75/README.md",
+      "sha256": "sha256:01a9f11a9ea7f1c09709eefaf420a147ad7126ce521a18d24921193bff00a7aa",
+      "required": true
+    },
+    {
+      "id": "actual-diff",
+      "kind": "actual_diff",
+      "path": ".agentplane/tasks/202607281455-147Q75/quality/20260728-153650388-recovery-context/evaluator-diff.patch",
+      "sha256": "sha256:574fd7dd4e69fc01ae0f1d3a2e75bb5603ce7e01725e7d0f0b12d86e26423d7c",
+      "required": true
+    },
+    {
+      "id": "observed-checks",
+      "kind": "observed_checks",
+      "path": ".agentplane/tasks/202607281455-147Q75/quality/20260728-153650388-recovery-context/evaluator-observed-checks.json",
+      "sha256": "sha256:bdbdb67b2fb320ea64438d2cc89480c53c6635f0b5d7ce3ed2767019094af1d5",
+      "required": true
+    },
+    {
+      "id": "blueprint",
+      "kind": "blueprint",
+      "path": ".agentplane/tasks/202607281455-147Q75/quality/20260728-153650388-recovery-context/evaluator-blueprint.json",
+      "sha256": "sha256:72fcb8c3a11cb7c24c9725eecd7af30106e482c804c6a32f1f535662a2283f44",
+      "required": true
+    },
+    {
+      "id": "policy-1",
+      "kind": "policy_module",
+      "path": ".agentplane/policy/dod.code.md",
+      "sha256": "sha256:3fec50dfe0db2f9495a3fa96f36d95fb34262033299d57f6f3775af4b7cc1486",
+      "required": true
+    },
+    {
+      "id": "policy-2",
+      "kind": "policy_module",
+      "path": ".agentplane/policy/dod.core.md",
+      "sha256": "sha256:f6c11b8a2c55760c17af15f79fe13791b3e7bba4852fc7d311fc0657e490b0c7",
+      "required": true
+    },
+    {
+      "id": "policy-3",
+      "kind": "policy_module",
+      "path": ".agentplane/policy/security.must.md",
+      "sha256": "sha256:96d01012e7ab67873bcb7a2cdd3818efa2c1fa500ee2eaf0e316f67e15bbcab2",
+      "required": true
+    },
+    {
+      "id": "policy-4",
+      "kind": "policy_module",
+      "path": ".agentplane/policy/workflow.branch_pr.md",
+      "sha256": "sha256:12d3b942042c276d30593803ddcfe12b20dc794e3e8bfbd97b6ce59df13ba82b",
+      "required": true
+    }
+  ]
+}

--- a/.agentplane/tasks/202607281455-147Q75/quality/20260728-153650388-recovery-context/quality-report.json
+++ b/.agentplane/tasks/202607281455-147Q75/quality/20260728-153650388-recovery-context/quality-report.json
@@ -1,0 +1,22 @@
+{
+  "schema_version": 1,
+  "task_id": "202607281455-147Q75",
+  "evaluator_id": "recovery-context",
+  "evaluator_profile": "EVALUATOR",
+  "generated_at": "2026-07-28T15:36:51.396Z",
+  "provenance": "human_supplied",
+  "verdict": "pass",
+  "summary": "Independent review of the CI recovery patch: the null-normalization traversal now treats external arrays as unknown values before record narrowing, preserving the schema compatibility behavior while satisfying strict TypeScript safety.",
+  "evaluated_sha": "5fe3f261279c62fbcda629d4ee6cb539fdc956e1",
+  "blueprint_digest": "502c33075284ce6f9aa46423f98024e5cae094e841cac21d82f799f5898e4d05",
+  "findings": [
+    "The normalization path preserves its read-only semantics: only null placeholders are removed from copied records, while non-record and array values remain opaque unknown values."
+  ],
+  "evidence_refs": [
+    "packages/agentplane/src/commands/evaluator/evaluator-review-usecase.ts",
+    "5fe3f261279c62fbcda629d4ee6cb539fdc956e1"
+  ],
+  "missing_tests": [],
+  "hidden_assumptions": [],
+  "residual_risks": []
+}

--- a/packages/agentplane/src/commands/evaluator/evaluator-episode.calibration.test.ts
+++ b/packages/agentplane/src/commands/evaluator/evaluator-episode.calibration.test.ts
@@ -96,19 +96,16 @@ function result(
         severity: nonPassing ? "high" : "low",
         summary: `${verdict} calibration finding from the frozen evaluator evidence.`,
         broken_invariant: nonPassing ? "calibration invariant" : "none",
-        evidence_refs: [{ path: diff.path }],
+        evidence_refs: [{ path: diff.path, sha256: null, line: null, lines: null, section: null }],
       },
     ],
     missing_tests: [],
     hidden_assumptions: [],
-    ...(nonPassing
-      ? {
-          recovery_context:
-            verdict === "human_review"
-              ? "Which of the two mutually incompatible acceptance interpretations should govern this task?"
-              : `Bounded ${verdict} follow-up required before another evaluator episode.`,
-        }
-      : {}),
+    recovery_context: nonPassing
+      ? verdict === "human_review"
+        ? "Which of the two mutually incompatible acceptance interpretations should govern this task?"
+        : `Bounded ${verdict} follow-up required before another evaluator episode.`
+      : null,
   };
 }
 
@@ -178,6 +175,14 @@ describe("evaluator episode calibration", () => {
       output_tokens: 50,
       total_tokens: 150,
     });
+    expect(episode.result.recovery_context).toBeUndefined();
+    expect(episode.result.findings[0]?.evidence_refs[0]).toEqual({
+      path: prepared.work_order.evidence.find((entry) => entry.kind === "actual_diff")?.path,
+      sha256: undefined,
+      line: undefined,
+      lines: undefined,
+      section: undefined,
+    });
     expect(JSON.parse(await readFile(prepared.result_path, "utf8"))).toEqual(episode.result);
     expect(
       JSON.parse(
@@ -210,7 +215,37 @@ describe("evaluator episode calibration", () => {
     expect(captured?.prompt).toContain(
       "AgentPlane prepared and froze the authoritative review input",
     );
-    expect(await readFile(captured!.output_schema_path, "utf8")).toContain("human_review");
+    const outputSchema = JSON.parse(await readFile(captured!.output_schema_path, "utf8")) as {
+      required: string[];
+      properties: {
+        recovery_context: { type: string[] };
+        findings: {
+          items: {
+            properties: {
+              evidence_refs: {
+                items: {
+                  required: string[];
+                  properties: {
+                    sha256: { type: string[] };
+                    line: { type: string[] };
+                    lines: { type: string[] };
+                    section: { type: string[] };
+                  };
+                };
+              };
+            };
+          };
+        };
+      };
+    };
+    const evidenceSchema = outputSchema.properties.findings.items.properties.evidence_refs.items;
+    expect(outputSchema.required).toContain("recovery_context");
+    expect(outputSchema.properties.recovery_context.type).toEqual(["string", "null"]);
+    expect(evidenceSchema.required).toEqual(["path", "sha256", "line", "lines", "section"]);
+    expect(evidenceSchema.properties.sha256.type).toEqual(["string", "null"]);
+    expect(evidenceSchema.properties.line.type).toEqual(["integer", "null"]);
+    expect(evidenceSchema.properties.lines.type).toEqual(["string", "null"]);
+    expect(evidenceSchema.properties.section.type).toEqual(["string", "null"]);
   });
 
   it.each([
@@ -275,7 +310,9 @@ describe("evaluator episode calibration", () => {
     await commitTarget(root);
     const { command, prepared } = await prepare(root, taskId);
     const invalid = result(prepared, "rework");
-    invalid.findings[0]!.evidence_refs = [{ path: "src/not-frozen.ts" }];
+    invalid.findings[0]!.evidence_refs = [
+      { path: "src/not-frozen.ts", sha256: null, line: null, lines: null, section: null },
+    ];
 
     await expect(
       executePreparedEvaluatorEpisode({ ctx: command, prepared, executor: provider(invalid) }),

--- a/packages/agentplane/src/commands/evaluator/evaluator-episode.ts
+++ b/packages/agentplane/src/commands/evaluator/evaluator-episode.ts
@@ -25,6 +25,18 @@ const MAX_PROVIDER_STDERR_BYTES = 1024 * 1024;
 const CODEX_EVALUATOR_TIMEOUT_MS = 10 * 60 * 1000;
 
 const NON_EMPTY_STRING_SCHEMA = { type: "string", minLength: 1 } as const;
+const NULLABLE_NON_EMPTY_STRING_SCHEMA = {
+  type: ["string", "null"],
+  minLength: 1,
+} as const;
+const NULLABLE_SHA256_SCHEMA = {
+  type: ["string", "null"],
+  pattern: "^sha256:[a-f0-9]{64}$",
+} as const;
+const NULLABLE_POSITIVE_INTEGER_SCHEMA = {
+  type: ["integer", "null"],
+  minimum: 1,
+} as const;
 
 const EVALUATOR_RESULT_OUTPUT_SCHEMA = {
   $schema: "http://json-schema.org/draft-07/schema#",
@@ -56,12 +68,16 @@ const EVALUATOR_RESULT_OUTPUT_SCHEMA = {
               additionalProperties: false,
               properties: {
                 path: NON_EMPTY_STRING_SCHEMA,
-                sha256: { type: "string", pattern: "^sha256:[a-f0-9]{64}$" },
-                line: { type: "integer", minimum: 1 },
-                lines: NON_EMPTY_STRING_SCHEMA,
-                section: NON_EMPTY_STRING_SCHEMA,
+                sha256: NULLABLE_SHA256_SCHEMA,
+                line: NULLABLE_POSITIVE_INTEGER_SCHEMA,
+                lines: NULLABLE_NON_EMPTY_STRING_SCHEMA,
+                section: NULLABLE_NON_EMPTY_STRING_SCHEMA,
               },
-              required: ["path"],
+              // Codex structured output requires every declared property to
+              // appear in `required`. Source-reference metadata remains
+              // semantically optional by using null, which is normalized by
+              // the evaluator result validator before its typed SGR handoff.
+              required: ["path", "sha256", "line", "lines", "section"],
             },
           },
         },
@@ -70,7 +86,7 @@ const EVALUATOR_RESULT_OUTPUT_SCHEMA = {
     },
     missing_tests: { type: "array", items: { type: "string" } },
     hidden_assumptions: { type: "array", items: { type: "string" } },
-    recovery_context: NON_EMPTY_STRING_SCHEMA,
+    recovery_context: NULLABLE_NON_EMPTY_STRING_SCHEMA,
   },
   required: [
     "schema_version",
@@ -80,6 +96,7 @@ const EVALUATOR_RESULT_OUTPUT_SCHEMA = {
     "findings",
     "missing_tests",
     "hidden_assumptions",
+    "recovery_context",
   ],
 } as const;
 

--- a/packages/agentplane/src/commands/evaluator/evaluator-review-usecase.ts
+++ b/packages/agentplane/src/commands/evaluator/evaluator-review-usecase.ts
@@ -428,6 +428,27 @@ function assertExactKeys(
   }
 }
 
+function normalizeEvaluatorStructuredNulls(raw: Record<string, unknown>): Record<string, unknown> {
+  const normalized: Record<string, unknown> = { ...raw };
+  if (normalized.recovery_context === null) delete normalized.recovery_context;
+  if (!Array.isArray(normalized.findings)) return normalized;
+  normalized.findings = normalized.findings.map((finding) => {
+    if (!finding || typeof finding !== "object" || Array.isArray(finding)) return finding;
+    const normalizedFinding: Record<string, unknown> = { ...finding };
+    if (!Array.isArray(normalizedFinding.evidence_refs)) return normalizedFinding;
+    normalizedFinding.evidence_refs = normalizedFinding.evidence_refs.map((evidence) => {
+      if (!evidence || typeof evidence !== "object" || Array.isArray(evidence)) return evidence;
+      const normalizedEvidence: Record<string, unknown> = { ...evidence };
+      for (const field of ["sha256", "line", "lines", "section"] as const) {
+        if (normalizedEvidence[field] === null) delete normalizedEvidence[field];
+      }
+      return normalizedEvidence;
+    });
+    return normalizedFinding;
+  });
+  return normalized;
+}
+
 export function validateStrictEvaluatorResult(raw: unknown): EvaluatorSgrResult {
   assertExactKeys(
     raw,
@@ -468,7 +489,7 @@ export function validateStrictEvaluatorResult(raw: unknown): EvaluatorSgrResult 
       }
     }
   }
-  return validateEvaluatorSgrResult(raw);
+  return validateEvaluatorSgrResult(normalizeEvaluatorStructuredNulls(record));
 }
 
 export function readWorkOrder(raw: unknown): EvaluatorWorkOrder {

--- a/packages/agentplane/src/commands/evaluator/evaluator-review-usecase.ts
+++ b/packages/agentplane/src/commands/evaluator/evaluator-review-usecase.ts
@@ -432,18 +432,20 @@ function normalizeEvaluatorStructuredNulls(raw: Record<string, unknown>): Record
   const normalized: Record<string, unknown> = { ...raw };
   if (normalized.recovery_context === null) delete normalized.recovery_context;
   if (!Array.isArray(normalized.findings)) return normalized;
-  normalized.findings = normalized.findings.map((finding) => {
+  normalized.findings = (normalized.findings as unknown[]).map((finding: unknown): unknown => {
     if (!finding || typeof finding !== "object" || Array.isArray(finding)) return finding;
     const normalizedFinding: Record<string, unknown> = { ...finding };
     if (!Array.isArray(normalizedFinding.evidence_refs)) return normalizedFinding;
-    normalizedFinding.evidence_refs = normalizedFinding.evidence_refs.map((evidence) => {
-      if (!evidence || typeof evidence !== "object" || Array.isArray(evidence)) return evidence;
-      const normalizedEvidence: Record<string, unknown> = { ...evidence };
-      for (const field of ["sha256", "line", "lines", "section"] as const) {
-        if (normalizedEvidence[field] === null) delete normalizedEvidence[field];
-      }
-      return normalizedEvidence;
-    });
+    normalizedFinding.evidence_refs = (normalizedFinding.evidence_refs as unknown[]).map(
+      (evidence: unknown): unknown => {
+        if (!evidence || typeof evidence !== "object" || Array.isArray(evidence)) return evidence;
+        const normalizedEvidence: Record<string, unknown> = { ...evidence };
+        for (const field of ["sha256", "line", "lines", "section"] as const) {
+          if (normalizedEvidence[field] === null) delete normalizedEvidence[field];
+        }
+        return normalizedEvidence;
+      },
+    );
     return normalizedFinding;
   });
   return normalized;


### PR DESCRIPTION
Task: `202607281455-147Q75`
Title: Repair evaluator response schema for Codex structured output
Canonical task record: `.agentplane/tasks/202607281455-147Q75/README.md`

## Summary

Repair evaluator response schema for Codex structured output

Release-blocking follow-up: make the evaluator typed-result JSON Schema compatible with the current Codex structured-output validator, preserve optional evidence fields through explicit nullable values, and add a regression test proving evaluator execution reaches a typed result instead of failing before the provider turn.

## Scope

- In scope: Release-blocking follow-up: make the evaluator typed-result JSON Schema compatible with the current Codex structured-output validator, preserve optional evidence fields through explicit nullable values, and add a regression test proving evaluator execution reaches a typed result instead of failing before the provider turn.
- Out of scope: unrelated refactors not required for "Repair evaluator response schema for Codex structured output".

## Verification

- State: pending
- Note: Not recorded yet.
- Canonical workflow state lives in the task README.

<details>
<summary>Raw evidence</summary>

- Updated: 2026-07-28T14:56:22.735Z
- Branch: task/202607281455-147Q75/repair-evaluator-response-schema
- Head: computed live by `agentplane pr check` / `agentplane integrate`

```text
No changes detected.
```

</details>
