### PR TITLE
🚧 R1N8C5 task: Restore PR head tracking after constrained refspec publication [202607291650-R1N8C5]

### DIFF
--- a/.agentplane/tasks/202607291650-R1N8C5/README.md
+++ b/.agentplane/tasks/202607291650-R1N8C5/README.md
@@ -1,0 +1,105 @@
+---
+id: "202607291650-R1N8C5"
+title: "Restore PR head tracking after constrained refspec publication"
+status: "DOING"
+priority: "high"
+owner: "CODER"
+revision: 6
+origin:
+  system: "manual"
+depends_on: []
+tags:
+  - "code"
+verify: []
+plan_approval:
+  state: "approved"
+  updated_at: "2026-07-29T16:51:11.520Z"
+  updated_by: "ORCHESTRATOR"
+  note: null
+verification:
+  state: "pending"
+  updated_at: null
+  updated_by: null
+  note: null
+  attempts: 0
+commit: null
+comments:
+  -
+    author: "CODER"
+    body: "Start: continue branch_pr task in the dedicated task worktree."
+events:
+  -
+    type: "status"
+    at: "2026-07-29T16:51:35.134Z"
+    author: "CODER"
+    from: "TODO"
+    to: "DOING"
+    note: "Start: continue branch_pr task in the dedicated task worktree."
+doc_version: 3
+doc_updated_at: "2026-07-29T16:51:35.134Z"
+doc_updated_by: "CODER"
+description: "Fix branch_pr publication when origin fetches only main: after a task branch is successfully published and remote/head SHA match, ensure its local remote-tracking reference is available so pr flow and integrate classify the hosted SHA as published. Add a regression test for the constrained-refspec repository shape. Preserve unrelated deletion of the stale beta task README in the base checkout."
+sections:
+  Summary: |-
+    Restore PR head tracking after constrained refspec publication
+
+    Fix branch_pr publication when origin fetches only main: after a task branch is successfully published and remote/head SHA match, ensure its local remote-tracking reference is available so pr flow and integrate classify the hosted SHA as published. Add a regression test for the constrained-refspec repository shape. Preserve unrelated deletion of the stale beta task README in the base checkout.
+  Scope: |-
+    - In scope: Fix branch_pr publication when origin fetches only main: after a task branch is successfully published and remote/head SHA match, ensure its local remote-tracking reference is available so pr flow and integrate classify the hosted SHA as published. Add a regression test for the constrained-refspec repository shape. Preserve unrelated deletion of the stale beta task README in the base checkout.
+    - Out of scope: unrelated refactors not required for "Restore PR head tracking after constrained refspec publication".
+  Plan: "1. Reproduce the constrained-refspec shape where origin tracks only main while the task branch is already present remotely. 2. Update the CLI publication helper so a successful publication also materializes the matching local remote-tracking ref needed by pr flow and integrate. 3. Add a regression test that proves branch@{upstream} resolves to the published task SHA under that refspec. 4. Run focused publication tests, static/type checks, and declared structural checks. 5. Publish one isolated PR, wait for hosted checks, record task verification, and return the blocked FTH PR to the serialized integration lane."
+  Verify Steps: |-
+    1. Reproduce the constrained-refspec repository shape in packages/agentplane/src/commands/pr/branch-publication.test.ts. Expected: after publication, branch@{upstream} resolves to origin/<task-branch> and its SHA equals the local branch SHA.
+    2. Run: bun test packages/agentplane/src/commands/pr/branch-publication.test.ts. Expected: all branch-publication cases, including the constrained-refspec regression, pass.
+    3. Run: bun run typecheck. Expected: TypeScript typecheck passes.
+    4. Run: bunx eslint packages/agentplane/src/commands/pr/branch-publication.ts packages/agentplane/src/commands/pr/branch-publication.test.ts. Expected: no lint errors in changed scope.
+    5. Run: bun run hotspots:check and node .agentplane/policy/check-routing.mjs. Expected: structural and policy gates pass.
+    6. On the task PR, wait for the hosted checks to settle. Expected: no failing required check, then pr flow status classifies the published head as aligned rather than missing_upstream.
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: ""
+extensions:
+  workflow_route_baseline:
+    start_head_sha: "d0b9d694451714a0cbd5a01cdfb8db1faffee6aa"
+    version: 1
+id_source: "generated"
+---
+## Summary
+
+Restore PR head tracking after constrained refspec publication
+
+Fix branch_pr publication when origin fetches only main: after a task branch is successfully published and remote/head SHA match, ensure its local remote-tracking reference is available so pr flow and integrate classify the hosted SHA as published. Add a regression test for the constrained-refspec repository shape. Preserve unrelated deletion of the stale beta task README in the base checkout.
+
+## Scope
+
+- In scope: Fix branch_pr publication when origin fetches only main: after a task branch is successfully published and remote/head SHA match, ensure its local remote-tracking reference is available so pr flow and integrate classify the hosted SHA as published. Add a regression test for the constrained-refspec repository shape. Preserve unrelated deletion of the stale beta task README in the base checkout.
+- Out of scope: unrelated refactors not required for "Restore PR head tracking after constrained refspec publication".
+
+## Plan
+
+1. Reproduce the constrained-refspec shape where origin tracks only main while the task branch is already present remotely. 2. Update the CLI publication helper so a successful publication also materializes the matching local remote-tracking ref needed by pr flow and integrate. 3. Add a regression test that proves branch@{upstream} resolves to the published task SHA under that refspec. 4. Run focused publication tests, static/type checks, and declared structural checks. 5. Publish one isolated PR, wait for hosted checks, record task verification, and return the blocked FTH PR to the serialized integration lane.
+
+## Verify Steps
+
+1. Reproduce the constrained-refspec repository shape in packages/agentplane/src/commands/pr/branch-publication.test.ts. Expected: after publication, branch@{upstream} resolves to origin/<task-branch> and its SHA equals the local branch SHA.
+2. Run: bun test packages/agentplane/src/commands/pr/branch-publication.test.ts. Expected: all branch-publication cases, including the constrained-refspec regression, pass.
+3. Run: bun run typecheck. Expected: TypeScript typecheck passes.
+4. Run: bunx eslint packages/agentplane/src/commands/pr/branch-publication.ts packages/agentplane/src/commands/pr/branch-publication.test.ts. Expected: no lint errors in changed scope.
+5. Run: bun run hotspots:check and node .agentplane/policy/check-routing.mjs. Expected: structural and policy gates pass.
+6. On the task PR, wait for the hosted checks to settle. Expected: no failing required check, then pr flow status classifies the published head as aligned rather than missing_upstream.
+
+## Verification
+
+<!-- BEGIN VERIFICATION RESULTS -->
+<!-- END VERIFICATION RESULTS -->
+
+## Rollback Plan
+
+- Revert task-related commit(s).
+- Re-run required checks to confirm rollback safety.
+
+## Findings

--- a/.agentplane/tasks/202607291650-R1N8C5/README.md
+++ b/.agentplane/tasks/202607291650-R1N8C5/README.md
@@ -4,7 +4,7 @@ title: "Restore PR head tracking after constrained refspec publication"
 status: "DOING"
 priority: "high"
 owner: "CODER"
-revision: 6
+revision: 10
 origin:
   system: "manual"
 depends_on: []
@@ -22,11 +22,19 @@ verification:
   updated_by: null
   note: null
   attempts: 0
-commit: null
+commit:
+  hash: "c4bda47aa4ae0a6aa4b4b3c41d7fb2d09f352102"
+  message: "♻️ R1N8C5 pr: restore constrained-refspec head tracking"
 comments:
   -
     author: "CODER"
     body: "Start: continue branch_pr task in the dedicated task worktree."
+  -
+    author: "CODER"
+    body: "Implementation: committed constrained-refspec publication tracking repair with focused regression coverage."
+  -
+    author: "CODER"
+    body: "Implementation: committed constrained-refspec publication tracking repair with focused regression coverage."
 events:
   -
     type: "status"
@@ -35,8 +43,22 @@ events:
     from: "TODO"
     to: "DOING"
     note: "Start: continue branch_pr task in the dedicated task worktree."
+  -
+    type: "status"
+    at: "2026-07-29T16:59:25.116Z"
+    author: "CODER"
+    from: "DOING"
+    to: "DOING"
+    note: "Implementation: committed constrained-refspec publication tracking repair with focused regression coverage."
+  -
+    type: "status"
+    at: "2026-07-29T17:00:10.800Z"
+    author: "CODER"
+    from: "DOING"
+    to: "DOING"
+    note: "Implementation: committed constrained-refspec publication tracking repair with focused regression coverage."
 doc_version: 3
-doc_updated_at: "2026-07-29T16:51:35.134Z"
+doc_updated_at: "2026-07-29T17:00:10.800Z"
 doc_updated_by: "CODER"
 description: "Fix branch_pr publication when origin fetches only main: after a task branch is successfully published and remote/head SHA match, ensure its local remote-tracking reference is available so pr flow and integrate classify the hosted SHA as published. Add a regression test for the constrained-refspec repository shape. Preserve unrelated deletion of the stale beta task README in the base checkout."
 sections:
@@ -49,19 +71,25 @@ sections:
     - Out of scope: unrelated refactors not required for "Restore PR head tracking after constrained refspec publication".
   Plan: "1. Reproduce the constrained-refspec shape where origin tracks only main while the task branch is already present remotely. 2. Update the CLI publication helper so a successful publication also materializes the matching local remote-tracking ref needed by pr flow and integrate. 3. Add a regression test that proves branch@{upstream} resolves to the published task SHA under that refspec. 4. Run focused publication tests, static/type checks, and declared structural checks. 5. Publish one isolated PR, wait for hosted checks, record task verification, and return the blocked FTH PR to the serialized integration lane."
   Verify Steps: |-
-    1. Reproduce the constrained-refspec repository shape in packages/agentplane/src/commands/pr/branch-publication.test.ts. Expected: after publication, branch@{upstream} resolves to origin/<task-branch> and its SHA equals the local branch SHA.
-    2. Run: bun test packages/agentplane/src/commands/pr/branch-publication.test.ts. Expected: all branch-publication cases, including the constrained-refspec regression, pass.
+    1. Reproduce the constrained-refspec repository shape in packages/agentplane/src/commands/pr/branch-publication.test.ts and packages/core/src/git/git-client.test.ts. Expected: publication creates refs/remotes/origin/<task-branch>, and AgentPlane resolves the configured upstream even when Git's fetch refspec lists only main.
+    2. Run: bun test packages/core/src/git/git-client.test.ts packages/agentplane/src/commands/pr/branch-publication.test.ts. Expected: all focused cases pass.
     3. Run: bun run typecheck. Expected: TypeScript typecheck passes.
-    4. Run: bunx eslint packages/agentplane/src/commands/pr/branch-publication.ts packages/agentplane/src/commands/pr/branch-publication.test.ts. Expected: no lint errors in changed scope.
+    4. Run: bunx eslint packages/core/src/git/git-client.ts packages/core/src/git/git-client.test.ts packages/agentplane/src/commands/pr/branch-publication.ts packages/agentplane/src/commands/pr/branch-publication.test.ts. Expected: no lint errors in changed scope.
     5. Run: bun run hotspots:check and node .agentplane/policy/check-routing.mjs. Expected: structural and policy gates pass.
-    6. On the task PR, wait for the hosted checks to settle. Expected: no failing required check, then pr flow status classifies the published head as aligned rather than missing_upstream.
+    6. Build the repository CLI, republish the task PR through agentplane pr open, then run agentplane pr flow status <task-id> --json. Expected: the local and hosted PR heads are aligned; publication is not missing_upstream.
+    7. On the task PR, wait for hosted checks to settle. Expected: no failing required check.
   Verification: |-
     <!-- BEGIN VERIFICATION RESULTS -->
     <!-- END VERIFICATION RESULTS -->
   Rollback Plan: |-
     - Revert task-related commit(s).
     - Re-run required checks to confirm rollback safety.
-  Findings: ""
+  Findings: |-
+    - Observation: With remote.origin.fetch restricted to main, git push -u records branch remote/merge configuration but Git's %(upstream:short) remains empty even after an explicit remote-tracking fetch.
+      Impact: pr flow and integrate misclassified a hosted task head at the exact same SHA as unpublished, blocking the merge lane.
+      Resolution: Refresh the branch tracking ref from the publication target and make gitBranchUpstream fall back to configured remote/merge only when the matching local tracking ref resolves.
+      Promotion: incident-candidate
+      Fixability: repo-fixable
 extensions:
   workflow_route_baseline:
     start_head_sha: "d0b9d694451714a0cbd5a01cdfb8db1faffee6aa"
@@ -85,12 +113,13 @@ Fix branch_pr publication when origin fetches only main: after a task branch is 
 
 ## Verify Steps
 
-1. Reproduce the constrained-refspec repository shape in packages/agentplane/src/commands/pr/branch-publication.test.ts. Expected: after publication, branch@{upstream} resolves to origin/<task-branch> and its SHA equals the local branch SHA.
-2. Run: bun test packages/agentplane/src/commands/pr/branch-publication.test.ts. Expected: all branch-publication cases, including the constrained-refspec regression, pass.
+1. Reproduce the constrained-refspec repository shape in packages/agentplane/src/commands/pr/branch-publication.test.ts and packages/core/src/git/git-client.test.ts. Expected: publication creates refs/remotes/origin/<task-branch>, and AgentPlane resolves the configured upstream even when Git's fetch refspec lists only main.
+2. Run: bun test packages/core/src/git/git-client.test.ts packages/agentplane/src/commands/pr/branch-publication.test.ts. Expected: all focused cases pass.
 3. Run: bun run typecheck. Expected: TypeScript typecheck passes.
-4. Run: bunx eslint packages/agentplane/src/commands/pr/branch-publication.ts packages/agentplane/src/commands/pr/branch-publication.test.ts. Expected: no lint errors in changed scope.
+4. Run: bunx eslint packages/core/src/git/git-client.ts packages/core/src/git/git-client.test.ts packages/agentplane/src/commands/pr/branch-publication.ts packages/agentplane/src/commands/pr/branch-publication.test.ts. Expected: no lint errors in changed scope.
 5. Run: bun run hotspots:check and node .agentplane/policy/check-routing.mjs. Expected: structural and policy gates pass.
-6. On the task PR, wait for the hosted checks to settle. Expected: no failing required check, then pr flow status classifies the published head as aligned rather than missing_upstream.
+6. Build the repository CLI, republish the task PR through agentplane pr open, then run agentplane pr flow status <task-id> --json. Expected: the local and hosted PR heads are aligned; publication is not missing_upstream.
+7. On the task PR, wait for hosted checks to settle. Expected: no failing required check.
 
 ## Verification
 
@@ -103,3 +132,9 @@ Fix branch_pr publication when origin fetches only main: after a task branch is 
 - Re-run required checks to confirm rollback safety.
 
 ## Findings
+
+- Observation: With remote.origin.fetch restricted to main, git push -u records branch remote/merge configuration but Git's %(upstream:short) remains empty even after an explicit remote-tracking fetch.
+  Impact: pr flow and integrate misclassified a hosted task head at the exact same SHA as unpublished, blocking the merge lane.
+  Resolution: Refresh the branch tracking ref from the publication target and make gitBranchUpstream fall back to configured remote/merge only when the matching local tracking ref resolves.
+  Promotion: incident-candidate
+  Fixability: repo-fixable

--- a/.agentplane/tasks/202607291650-R1N8C5/blueprint/resolved-snapshot.json
+++ b/.agentplane/tasks/202607291650-R1N8C5/blueprint/resolved-snapshot.json
@@ -1,0 +1,596 @@
+{
+  "schemaVersion": 1,
+  "artifactKind": "agentplane.blueprint.resolved_snapshot",
+  "resolverInput": {
+    "taskId": "202607291650-R1N8C5",
+    "title": "Restore PR head tracking after constrained refspec publication",
+    "description": "Fix branch_pr publication when origin fetches only main: after a task branch is successfully published and remote/head SHA match, ensure its local remote-tracking reference is available so pr flow and integrate classify the hosted SHA as published. Add a regression test for the constrained-refspec repository shape. Preserve unrelated deletion of the stale beta task README in the base checkout.",
+    "tags": [
+      "code"
+    ],
+    "owner": "CODER",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "mutation": "code",
+    "touchedPaths": [],
+    "recipeHints": [],
+    "riskFlags": []
+  },
+  "selectedBlueprint": {
+    "id": "quality.regression",
+    "version": 1,
+    "title": "Quality regression",
+    "taskKinds": [
+      "code"
+    ],
+    "workflowModes": [
+      "branch_pr"
+    ]
+  },
+  "plan": {
+    "schemaVersion": 1,
+    "blueprintId": "quality.regression",
+    "blueprintVersion": 1,
+    "title": "Quality regression",
+    "taskId": "202607291650-R1N8C5",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "taskIntent": {
+      "mutationScope": "code"
+    },
+    "whySelected": [
+      "specialized code domain resolved to quality.regression",
+      "workflow mode: branch_pr",
+      "mutation scope: code"
+    ],
+    "states": [
+      {
+        "id": "intake",
+        "kind": "intake",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": []
+      },
+      {
+        "id": "scope",
+        "kind": "scope",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "assumptions"
+        ]
+      },
+      {
+        "id": "approval_gate",
+        "kind": "approval_gate",
+        "mode": "approval",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "approval"
+        ]
+      },
+      {
+        "id": "context_resolve",
+        "kind": "context_resolve",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [
+          ".agentplane/policy/security.must.md",
+          ".agentplane/policy/dod.core.md",
+          ".agentplane/policy/dod.code.md",
+          ".agentplane/policy/workflow.branch_pr.md"
+        ],
+        "evidenceKinds": [
+          "context_manifest",
+          "artifact"
+        ]
+      },
+      {
+        "id": "worktree_start",
+        "kind": "worktree_start",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "work_unit",
+        "kind": "work_unit",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths",
+          "check_result"
+        ]
+      },
+      {
+        "id": "fast_local_checks",
+        "kind": "fast_local_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane task verify-show <task-id>",
+          "project focused checks"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "pr_artifact",
+        "kind": "pr_artifact",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "artifact",
+          "external_link"
+        ]
+      },
+      {
+        "id": "verify_record",
+        "kind": "verify_record",
+        "mode": "record",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result",
+          "weak_links"
+        ]
+      },
+      {
+        "id": "quality_gate",
+        "kind": "quality_gate",
+        "mode": "agentic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane evaluator run <task-id> --provenance human_supplied|evaluator_supplied --verdict pass|rework|blocked|human_review"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "quality_report"
+        ]
+      },
+      {
+        "id": "hosted_checks",
+        "kind": "hosted_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result",
+          "external_link"
+        ]
+      },
+      {
+        "id": "publish_or_integrate",
+        "kind": "publish_or_integrate",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane integrate <task-id> --branch <branch> --run-verify"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit",
+          "external_link"
+        ]
+      },
+      {
+        "id": "finish",
+        "kind": "finish",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit"
+        ]
+      }
+    ],
+    "requiredEvidence": [
+      {
+        "id": "regression.original_failure",
+        "kind": "artifact",
+        "producedBy": "context_resolve",
+        "required": true,
+        "description": "Original failure log or check output."
+      },
+      {
+        "id": "regression.reproduction",
+        "kind": "check_result",
+        "producedBy": "work_unit",
+        "required": true,
+        "description": "Local reproduction or explicit non-reproduction result."
+      },
+      {
+        "id": "regression.focused_check",
+        "kind": "check_result",
+        "producedBy": "fast_local_checks",
+        "required": true,
+        "description": "Focused regression check."
+      },
+      {
+        "id": "regression.matrix_or_scope",
+        "kind": "assumptions",
+        "producedBy": "scope",
+        "required": true,
+        "description": "Affected test/check matrix or bounded scope."
+      },
+      {
+        "id": "regression.full_gate",
+        "kind": "check_result",
+        "producedBy": "hosted_checks",
+        "required": true,
+        "description": "Full relevant gate or hosted check evidence."
+      },
+      {
+        "id": "regression.flake_classification",
+        "kind": "weak_links",
+        "producedBy": "verify_record",
+        "required": true,
+        "description": "Flake classification or residual risk."
+      },
+      {
+        "id": "regression.quality",
+        "kind": "quality_report",
+        "producedBy": "quality_gate",
+        "required": true,
+        "description": "EVALUATOR quality verdict."
+      },
+      {
+        "id": "regression.commit",
+        "kind": "commit",
+        "producedBy": "publish_or_integrate",
+        "required": true,
+        "description": "Integration commit."
+      }
+    ],
+    "policyModules": [
+      ".agentplane/policy/dod.code.md",
+      ".agentplane/policy/dod.core.md",
+      ".agentplane/policy/security.must.md",
+      ".agentplane/policy/workflow.branch_pr.md"
+    ],
+    "allowedCommands": [
+      "affected matrix or full relevant gate",
+      "agentplane evaluator run <task-id> --provenance human_supplied|evaluator_supplied --verdict pass|rework|blocked|human_review",
+      "agentplane integrate <task-id> --branch <branch> --run-verify",
+      "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+      "agentplane task verify-show <task-id>",
+      "agentplane verify <task-id> --ok|--rework",
+      "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+      "failure reproduction command",
+      "focused regression check",
+      "project focused checks"
+    ],
+    "contextBudget": {
+      "maxPolicyModules": 4,
+      "maxPromptBlocks": 16,
+      "rationale": "Regression work needs failure evidence, focused reproduction, and the relevant quality gate."
+    },
+    "contextManifest": [],
+    "acceptedRecipeExtensions": [],
+    "rejectedRecipeExtensions": [],
+    "stopReasons": []
+  },
+  "nodes": [
+    {
+      "id": "intake",
+      "kind": "intake",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": []
+    },
+    {
+      "id": "scope",
+      "kind": "scope",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "assumptions"
+      ]
+    },
+    {
+      "id": "approval_gate",
+      "kind": "approval_gate",
+      "mode": "approval",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "approval"
+      ]
+    },
+    {
+      "id": "context_resolve",
+      "kind": "context_resolve",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [
+        ".agentplane/policy/security.must.md",
+        ".agentplane/policy/dod.core.md",
+        ".agentplane/policy/dod.code.md",
+        ".agentplane/policy/workflow.branch_pr.md"
+      ],
+      "evidenceKinds": [
+        "context_manifest",
+        "artifact"
+      ]
+    },
+    {
+      "id": "worktree_start",
+      "kind": "worktree_start",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "work_unit",
+      "kind": "work_unit",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths",
+        "check_result"
+      ]
+    },
+    {
+      "id": "fast_local_checks",
+      "kind": "fast_local_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane task verify-show <task-id>",
+        "project focused checks"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "pr_artifact",
+      "kind": "pr_artifact",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "artifact",
+        "external_link"
+      ]
+    },
+    {
+      "id": "verify_record",
+      "kind": "verify_record",
+      "mode": "record",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result",
+        "weak_links"
+      ]
+    },
+    {
+      "id": "quality_gate",
+      "kind": "quality_gate",
+      "mode": "agentic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane evaluator run <task-id> --provenance human_supplied|evaluator_supplied --verdict pass|rework|blocked|human_review"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "quality_report"
+      ]
+    },
+    {
+      "id": "hosted_checks",
+      "kind": "hosted_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result",
+        "external_link"
+      ]
+    },
+    {
+      "id": "publish_or_integrate",
+      "kind": "publish_or_integrate",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane integrate <task-id> --branch <branch> --run-verify"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit",
+        "external_link"
+      ]
+    },
+    {
+      "id": "finish",
+      "kind": "finish",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit"
+      ]
+    }
+  ],
+  "requiredEvidence": [
+    {
+      "id": "regression.original_failure",
+      "kind": "artifact",
+      "producedBy": "context_resolve",
+      "required": true,
+      "description": "Original failure log or check output."
+    },
+    {
+      "id": "regression.reproduction",
+      "kind": "check_result",
+      "producedBy": "work_unit",
+      "required": true,
+      "description": "Local reproduction or explicit non-reproduction result."
+    },
+    {
+      "id": "regression.focused_check",
+      "kind": "check_result",
+      "producedBy": "fast_local_checks",
+      "required": true,
+      "description": "Focused regression check."
+    },
+    {
+      "id": "regression.matrix_or_scope",
+      "kind": "assumptions",
+      "producedBy": "scope",
+      "required": true,
+      "description": "Affected test/check matrix or bounded scope."
+    },
+    {
+      "id": "regression.full_gate",
+      "kind": "check_result",
+      "producedBy": "hosted_checks",
+      "required": true,
+      "description": "Full relevant gate or hosted check evidence."
+    },
+    {
+      "id": "regression.flake_classification",
+      "kind": "weak_links",
+      "producedBy": "verify_record",
+      "required": true,
+      "description": "Flake classification or residual risk."
+    },
+    {
+      "id": "regression.quality",
+      "kind": "quality_report",
+      "producedBy": "quality_gate",
+      "required": true,
+      "description": "EVALUATOR quality verdict."
+    },
+    {
+      "id": "regression.commit",
+      "kind": "commit",
+      "producedBy": "publish_or_integrate",
+      "required": true,
+      "description": "Integration commit."
+    }
+  ],
+  "policyModules": [
+    ".agentplane/policy/dod.code.md",
+    ".agentplane/policy/dod.core.md",
+    ".agentplane/policy/security.must.md",
+    ".agentplane/policy/workflow.branch_pr.md"
+  ],
+  "allowedCommands": [
+    "affected matrix or full relevant gate",
+    "agentplane evaluator run <task-id> --provenance human_supplied|evaluator_supplied --verdict pass|rework|blocked|human_review",
+    "agentplane integrate <task-id> --branch <branch> --run-verify",
+    "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+    "agentplane task verify-show <task-id>",
+    "agentplane verify <task-id> --ok|--rework",
+    "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+    "failure reproduction command",
+    "focused regression check",
+    "project focused checks"
+  ],
+  "contextBudget": {
+    "maxPolicyModules": 4,
+    "maxPromptBlocks": 16,
+    "rationale": "Regression work needs failure evidence, focused reproduction, and the relevant quality gate."
+  },
+  "contextManifest": [],
+  "acceptedRecipeExtensions": [],
+  "rejectedRecipeExtensions": [],
+  "stopReasons": [],
+  "selectionReasons": [
+    "specialized code domain resolved to quality.regression",
+    "workflow mode: branch_pr",
+    "mutation scope: code"
+  ],
+  "digest": {
+    "algorithm": "sha256",
+    "value": "31d12b96656f95ab0f97fb753d8286250f6545819ffc7e4d09786b34d54b295a"
+  }
+}

--- a/.agentplane/tasks/202607291650-R1N8C5/pr/diffstat.txt
+++ b/.agentplane/tasks/202607291650-R1N8C5/pr/diffstat.txt
@@ -1,0 +1,5 @@
+ .../src/commands/pr/branch-publication.test.ts     | 63 ++++++++++++++++++++++
+ .../src/commands/pr/branch-publication.ts          | 27 ++++++++++
+ packages/core/src/git/git-client.test.ts           | 27 +++++++++-
+ packages/core/src/git/git-client.ts                | 21 +++++++-
+ 4 files changed, 135 insertions(+), 3 deletions(-)

--- a/.agentplane/tasks/202607291650-R1N8C5/pr/github-body.md
+++ b/.agentplane/tasks/202607291650-R1N8C5/pr/github-body.md
@@ -22,12 +22,16 @@ Fix branch_pr publication when origin fetches only main: after a task branch is 
 <details>
 <summary>Raw evidence</summary>
 
-- Updated: 2026-07-29T16:51:35.238Z
+- Updated: 2026-07-29T16:52:05.113Z
 - Branch: task/202607291650-R1N8C5/restore-pr-head-tracking-after-constrained-refsp
 - Head: computed live by `agentplane pr check` / `agentplane integrate`
 
 ```text
-No changes detected.
+ .../src/commands/pr/branch-publication.test.ts     | 63 ++++++++++++++++++++++
+ .../src/commands/pr/branch-publication.ts          | 27 ++++++++++
+ packages/core/src/git/git-client.test.ts           | 27 +++++++++-
+ packages/core/src/git/git-client.ts                | 21 +++++++-
+ 4 files changed, 135 insertions(+), 3 deletions(-)
 ```
 
 </details>

--- a/.agentplane/tasks/202607291650-R1N8C5/pr/github-body.md
+++ b/.agentplane/tasks/202607291650-R1N8C5/pr/github-body.md
@@ -1,0 +1,33 @@
+Task: `202607291650-R1N8C5`
+Title: Restore PR head tracking after constrained refspec publication
+Canonical task record: `.agentplane/tasks/202607291650-R1N8C5/README.md`
+
+## Summary
+
+Restore PR head tracking after constrained refspec publication
+
+Fix branch_pr publication when origin fetches only main: after a task branch is successfully published and remote/head SHA match, ensure its local remote-tracking reference is available so pr flow and integrate classify the hosted SHA as published. Add a regression test for the constrained-refspec repository shape. Preserve unrelated deletion of the stale beta task README in the base checkout.
+
+## Scope
+
+- In scope: Fix branch_pr publication when origin fetches only main: after a task branch is successfully published and remote/head SHA match, ensure its local remote-tracking reference is available so pr flow and integrate classify the hosted SHA as published. Add a regression test for the constrained-refspec repository shape. Preserve unrelated deletion of the stale beta task README in the base checkout.
+- Out of scope: unrelated refactors not required for "Restore PR head tracking after constrained refspec publication".
+
+## Verification
+
+- State: pending
+- Note: Not recorded yet.
+- Canonical workflow state lives in the task README.
+
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-07-29T16:51:35.238Z
+- Branch: task/202607291650-R1N8C5/restore-pr-head-tracking-after-constrained-refsp
+- Head: computed live by `agentplane pr check` / `agentplane integrate`
+
+```text
+No changes detected.
+```
+
+</details>

--- a/.agentplane/tasks/202607291650-R1N8C5/pr/github-title.txt
+++ b/.agentplane/tasks/202607291650-R1N8C5/pr/github-title.txt
@@ -1,0 +1,1 @@
+🚧 R1N8C5 task: Restore PR head tracking after constrained refspec publication [202607291650-R1N8C5]

--- a/.agentplane/tasks/202607291650-R1N8C5/pr/meta.json
+++ b/.agentplane/tasks/202607291650-R1N8C5/pr/meta.json
@@ -2,11 +2,14 @@
   "base": "main",
   "branch": "task/202607291650-R1N8C5/restore-pr-head-tracking-after-constrained-refsp",
   "created_at": "2026-07-29T16:51:35.238Z",
-  "diffstat_sha256": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "diffstat_sha256": "sha256:92fe7547e5a88de410c641a22b9a00e8c28cc544b2ea69118ddb979af97a0654",
   "last_verified_at": null,
+  "pr_number": 4673,
+  "pr_url": "https://github.com/basilisk-labs/agentplane/pull/4673",
   "schema_version": 1,
+  "status": "OPEN",
   "task_id": "202607291650-R1N8C5",
-  "updated_at": "2026-07-29T16:51:35.238Z",
+  "updated_at": "2026-07-29T16:52:05.113Z",
   "verify": {
     "status": "skipped"
   }

--- a/.agentplane/tasks/202607291650-R1N8C5/pr/meta.json
+++ b/.agentplane/tasks/202607291650-R1N8C5/pr/meta.json
@@ -1,0 +1,13 @@
+{
+  "base": "main",
+  "branch": "task/202607291650-R1N8C5/restore-pr-head-tracking-after-constrained-refsp",
+  "created_at": "2026-07-29T16:51:35.238Z",
+  "diffstat_sha256": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "last_verified_at": null,
+  "schema_version": 1,
+  "task_id": "202607291650-R1N8C5",
+  "updated_at": "2026-07-29T16:51:35.238Z",
+  "verify": {
+    "status": "skipped"
+  }
+}

--- a/.agentplane/tasks/202607291650-R1N8C5/pr/review.md
+++ b/.agentplane/tasks/202607291650-R1N8C5/pr/review.md
@@ -24,12 +24,16 @@ Created: 2026-07-29T16:51:35.238Z
 <details>
 <summary>Raw evidence</summary>
 
-- Updated: 2026-07-29T16:51:35.238Z
+- Updated: 2026-07-29T16:52:05.113Z
 - Branch: task/202607291650-R1N8C5/restore-pr-head-tracking-after-constrained-refsp
 - Head: computed live by `agentplane pr check` / `agentplane integrate`
 
 ```text
-No changes detected.
+ .../src/commands/pr/branch-publication.test.ts     | 63 ++++++++++++++++++++++
+ .../src/commands/pr/branch-publication.ts          | 27 ++++++++++
+ packages/core/src/git/git-client.test.ts           | 27 +++++++++-
+ packages/core/src/git/git-client.ts                | 21 +++++++-
+ 4 files changed, 135 insertions(+), 3 deletions(-)
 ```
 
 </details>

--- a/.agentplane/tasks/202607291650-R1N8C5/pr/review.md
+++ b/.agentplane/tasks/202607291650-R1N8C5/pr/review.md
@@ -1,0 +1,36 @@
+# PR Review
+
+Created: 2026-07-29T16:51:35.238Z
+
+## Task
+
+- Task: `202607291650-R1N8C5`
+- Title: Restore PR head tracking after constrained refspec publication
+- Status: DOING
+- Branch: `task/202607291650-R1N8C5/restore-pr-head-tracking-after-constrained-refsp`
+- Canonical task record: `.agentplane/tasks/202607291650-R1N8C5/README.md`
+
+## Verification
+
+- State: pending
+- Note: Not recorded yet.
+- Canonical workflow state lives in the task README.
+
+## Handoff Notes
+
+- No handoff notes recorded yet. Use `agentplane pr note ...` to append one.
+
+<!-- BEGIN AUTO SUMMARY -->
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-07-29T16:51:35.238Z
+- Branch: task/202607291650-R1N8C5/restore-pr-head-tracking-after-constrained-refsp
+- Head: computed live by `agentplane pr check` / `agentplane integrate`
+
+```text
+No changes detected.
+```
+
+</details>
+<!-- END AUTO SUMMARY -->

--- a/packages/agentplane/src/commands/pr/branch-publication.test.ts
+++ b/packages/agentplane/src/commands/pr/branch-publication.test.ts
@@ -188,7 +188,70 @@ async function setupRewrittenOpenPrBranch(scenarioName: string): Promise<{
   };
 }
 
+async function setupConstrainedRefspecBranch(): Promise<{
+  branch: string;
+  root: string;
+}> {
+  const root = await mkGitRepoRootWithBranch("main");
+  const execFileAsync = promisify(execFile);
+  await configureGitUser(root);
+  const remotePath = await mkdtemp(path.join(os.tmpdir(), "agentplane-pr-publication-origin-"));
+  await execFileAsync("git", ["init", "--bare", remotePath], {
+    cwd: root,
+    env: cleanGitEnv(),
+  });
+  await execFileAsync("git", ["remote", "add", "origin", remotePath], {
+    cwd: root,
+    env: cleanGitEnv(),
+  });
+  await execFileAsync(
+    "git",
+    ["config", "remote.origin.fetch", "+refs/heads/main:refs/remotes/origin/main"],
+    { cwd: root, env: cleanGitEnv() },
+  );
+  await execFileAsync("git", ["commit", "--allow-empty", "-m", "chore initial main"], {
+    cwd: root,
+    env: cleanGitEnv(),
+  });
+
+  const branch = "task/T-TRACK/constrained-refspec";
+  await execFileAsync("git", ["checkout", "-b", branch], {
+    cwd: root,
+    env: cleanGitEnv(),
+  });
+  await execFileAsync("git", ["commit", "--allow-empty", "-m", "feat task head"], {
+    cwd: root,
+    env: cleanGitEnv(),
+  });
+  return { branch, root };
+}
+
 describe("PR task branch publication", { timeout: TEST_TIMEOUT_MS }, () => {
+  it("materializes the tracking ref after publication with a constrained fetch refspec", async () => {
+    const fixture = await setupConstrainedRefspecBranch();
+    const execFileAsync = promisify(execFile);
+
+    await expect(
+      pushTaskBranchUpstreamIfConfigured({
+        gitRoot: fixture.root,
+        branch: fixture.branch,
+      }),
+    ).resolves.toBe(true);
+
+    const [{ stdout: trackingHeadStdout }, { stdout: localHeadStdout }] = await Promise.all([
+      execFileAsync("git", ["rev-parse", `refs/remotes/origin/${fixture.branch}`], {
+        cwd: fixture.root,
+        env: cleanGitEnv(),
+      }),
+      execFileAsync("git", ["rev-parse", fixture.branch], {
+        cwd: fixture.root,
+        env: cleanGitEnv(),
+      }),
+    ]);
+
+    expect(trackingHeadStdout.trim()).toBe(localHeadStdout.trim());
+  });
+
   it("publishes a rebased existing open PR branch with a ref-scoped observed lease", async () => {
     const fixture = await setupRewrittenOpenPrBranch("force-lease-success");
     const originalPath = process.env.PATH;

--- a/packages/agentplane/src/commands/pr/branch-publication.ts
+++ b/packages/agentplane/src/commands/pr/branch-publication.ts
@@ -119,6 +119,28 @@ async function gitSetBranchUpstream(opts: {
   );
 }
 
+async function gitRefreshBranchTrackingRef(opts: {
+  gitRoot: string;
+  branch: string;
+  remote: string;
+}): Promise<void> {
+  const remoteTarget = await gitResolveRemotePushTarget(opts.gitRoot, opts.remote);
+  await execFileAsync(
+    "git",
+    [
+      "fetch",
+      "--no-tags",
+      "--no-write-fetch-head",
+      remoteTarget,
+      `refs/heads/${opts.branch}:refs/remotes/${opts.remote}/${opts.branch}`,
+    ],
+    {
+      cwd: opts.gitRoot,
+      env: gitEnv(),
+    },
+  );
+}
+
 async function resolvePublicationHeads(opts: {
   gitRoot: string;
   branch: string;
@@ -280,5 +302,10 @@ export async function pushTaskBranchUpstreamIfConfigured(opts: {
     });
     if (!publishedRebasedBranch) throw err;
   }
+  await gitRefreshBranchTrackingRef({
+    gitRoot: opts.gitRoot,
+    branch: opts.branch,
+    remote,
+  });
   return true;
 }

--- a/packages/core/src/git/git-client.test.ts
+++ b/packages/core/src/git/git-client.test.ts
@@ -5,7 +5,7 @@ import path from "node:path";
 import { promisify } from "node:util";
 import { describe, expect, it } from "vitest";
 
-import { GitContext, gitConfigGet, gitMergeBase } from "./git-client.js";
+import { GitContext, gitBranchUpstream, gitConfigGet, gitMergeBase } from "./git-client.js";
 
 const execFileAsync = promisify(execFile);
 
@@ -59,5 +59,30 @@ describe("git-client", () => {
 
     await expect(gitConfigGet(root, "remote.origin.url")).resolves.toBe("git@example.com:repo.git");
     await expect(gitConfigGet(root, "remote.missing.url")).resolves.toBeNull();
+  });
+
+  it("resolves a configured upstream when the fetch refspec omits its tracking branch", async () => {
+    const root = await mkRepo();
+    const remotePath = await mkdtemp(path.join(os.tmpdir(), "agentplane-git-client-origin-"));
+    await execFileAsync("git", ["init", "--bare", remotePath], { cwd: root });
+    await execFileAsync("git", ["remote", "add", "origin", remotePath], { cwd: root });
+    await execFileAsync(
+      "git",
+      ["config", "remote.origin.fetch", "+refs/heads/main:refs/remotes/origin/main"],
+      { cwd: root },
+    );
+    const branch = "task/T-TRACK/constrained-refspec";
+    await execFileAsync("git", ["checkout", "-b", branch], { cwd: root });
+    await execFileAsync("git", ["commit", "--allow-empty", "-m", "task head"], { cwd: root });
+    await execFileAsync("git", ["push", "-u", "origin", `HEAD:refs/heads/${branch}`], {
+      cwd: root,
+    });
+    await execFileAsync(
+      "git",
+      ["fetch", "origin", `refs/heads/${branch}:refs/remotes/origin/${branch}`],
+      { cwd: root },
+    );
+
+    await expect(gitBranchUpstream(root, branch)).resolves.toBe(`origin/${branch}`);
   });
 });

--- a/packages/core/src/git/git-client.ts
+++ b/packages/core/src/git/git-client.ts
@@ -171,9 +171,26 @@ export async function gitBranchUpstream(cwd: string, branch: string): Promise<st
   );
   for (const line of String(stdout).split("\n")) {
     const [name, upstream = ""] = line.split("\0");
-    if (name === branch) return upstream.trim() || null;
+    if (name === branch) {
+      const resolvedUpstream = upstream.trim();
+      if (resolvedUpstream) return resolvedUpstream;
+      break;
+    }
   }
-  return null;
+
+  const remote = await gitConfigGet(cwd, `branch.${branch}.remote`);
+  const mergeRef = await gitConfigGet(cwd, `branch.${branch}.merge`);
+  const remoteBranch = mergeRef?.replace(/^refs\/heads\//, "") ?? "";
+  if (!remote || !remoteBranch) return null;
+
+  const trackingRef =
+    remote === "." ? `refs/heads/${remoteBranch}` : `refs/remotes/${remote}/${remoteBranch}`;
+  try {
+    await gitRevParse(cwd, [trackingRef]);
+    return remote === "." ? remoteBranch : `${remote}/${remoteBranch}`;
+  } catch {
+    return null;
+  }
 }
 
 export async function gitListBranches(cwd: string): Promise<string[]> {


### PR DESCRIPTION
Task: `202607291650-R1N8C5`
Title: Restore PR head tracking after constrained refspec publication
Canonical task record: `.agentplane/tasks/202607291650-R1N8C5/README.md`

## Summary

Restore PR head tracking after constrained refspec publication

Fix branch_pr publication when origin fetches only main: after a task branch is successfully published and remote/head SHA match, ensure its local remote-tracking reference is available so pr flow and integrate classify the hosted SHA as published. Add a regression test for the constrained-refspec repository shape. Preserve unrelated deletion of the stale beta task README in the base checkout.

## Scope

- In scope: Fix branch_pr publication when origin fetches only main: after a task branch is successfully published and remote/head SHA match, ensure its local remote-tracking reference is available so pr flow and integrate classify the hosted SHA as published. Add a regression test for the constrained-refspec repository shape. Preserve unrelated deletion of the stale beta task README in the base checkout.
- Out of scope: unrelated refactors not required for "Restore PR head tracking after constrained refspec publication".

## Verification

- State: pending
- Note: Not recorded yet.
- Canonical workflow state lives in the task README.

<details>
<summary>Raw evidence</summary>

- Updated: 2026-07-29T16:51:35.238Z
- Branch: task/202607291650-R1N8C5/restore-pr-head-tracking-after-constrained-refsp
- Head: computed live by `agentplane pr check` / `agentplane integrate`

```text
No changes detected.
```

</details>
