### PR TITLE
🚧 JBHKDW task: Fix direct verified-task closeout route [202607300757-JBHKDW]

### DIFF
--- a/.agentplane/tasks/202607300757-JBHKDW/README.md
+++ b/.agentplane/tasks/202607300757-JBHKDW/README.md
@@ -5,7 +5,7 @@ result_summary: "Fixed direct closeout and post-work-start routing"
 status: "DONE"
 priority: "high"
 owner: "CODER"
-revision: 14
+revision: 15
 origin:
   system: "manual"
 depends_on: []
@@ -18,7 +18,8 @@ mutation_scope: "code"
 blueprint_request: "code.branch_pr"
 verify:
   - "bun run typecheck"
-  - "bunx vitest --config vitest.workspace.ts run --project agentplane packages/agentplane/src/commands/shared/route-guidance.test.ts packages/agentplane/src/cli/run-cli.core.route-decision.test.ts"
+  - "bun run test:project -- agentplane packages/agentplane/src/commands/shared/route-guidance.test.ts"
+  - "bun run test:project -- cli-core packages/agentplane/src/cli/run-cli.core.route-decision.test.ts packages/agentplane/src/cli/run-cli.core.route-decision.direct-closeout.test.ts packages/agentplane/src/cli/run-cli.core.route-decision.work-start.test.ts"
   - "node .agentplane/policy/check-routing.mjs"
 plan_approval:
   state: "approved"
@@ -33,20 +34,19 @@ verification:
   attempts: 0
 quality_review:
   state: "pass"
-  updated_at: "2026-07-30T10:45:31.302Z"
+  updated_at: "2026-07-30T10:53:23.180Z"
   updated_by: "EVALUATOR"
-  note: "Routing fixes are scoped and release-ready after full local CI."
+  note: "Corrected integration verification contract passes on the routing implementation."
   evaluated_sha: "c3d51c336a9af8a0172c75e36c2597f2aa788841"
   blueprint_digest: "f46f992a26c22cb3a11cc073c1e371e5b58b0c03db398f719af23da0857ad2b6"
   evidence_refs:
     - ".agentplane/tasks/202607300757-JBHKDW/README.md"
-    - ".agentplane/tasks/202607300757-JBHKDW/quality/20260730-104531302-recovery-context/quality-report.json"
-    - ".agentplane/tasks/202607300757-JBHKDW/quality/20260730-104531302-recovery-context/evaluator-prompt.md"
-    - ".agentplane/tasks/202607300757-JBHKDW/quality/20260730-104531302-recovery-context/evaluator-opinion.md"
+    - ".agentplane/tasks/202607300757-JBHKDW/quality/20260730-105323180-recovery-context/quality-report.json"
+    - ".agentplane/tasks/202607300757-JBHKDW/quality/20260730-105323180-recovery-context/evaluator-prompt.md"
+    - ".agentplane/tasks/202607300757-JBHKDW/quality/20260730-105323180-recovery-context/evaluator-opinion.md"
     - ".agentplane/tasks/202607300757-JBHKDW/blueprint/resolved-snapshot.json"
-    - "packages/agentplane/src/cli/run-cli.core.route-decision.work-start.test.ts"
   findings:
-    - "Direct closeout emits argv-safe task complete and branch_pr recovery infers a unique local task branch without repeating work start."
+    - "All task Verify Steps now use the matching Vitest projects and pass together with full local and hosted CI."
 commit:
   hash: "c3d51c336a9af8a0172c75e36c2597f2aa788841"
   message: "🐛 JBHKDW routing: resume existing task worktree"
@@ -100,11 +100,11 @@ sections:
   Verify Steps: |-
     PLANNER fallback scaffold. Replace with task-specific acceptance checks when PLANNER context is available.
 
-    1. Run `bunx vitest --config vitest.workspace.ts run --project agentplane packages/agentplane/src/commands/shared/route-guidance.test.ts packages/agentplane/src/cli/run-cli.core.route-decision.test.ts`. Expected: it succeeds and confirms the requested outcome for this task.
-    2. Run `bun run typecheck`. Expected: it succeeds and confirms the requested outcome for this task.
-    3. Run `node .agentplane/policy/check-routing.mjs`. Expected: it succeeds and confirms the requested outcome for this task.
-    4. Review the changed artifact or behavior for the `code` task. Expected: the requested outcome is visible and matches the approved scope.
-    5. Compare the final result against the task summary and touched scope. Expected: remaining follow-up is either resolved or explicit in ## Findings.
+    1. Run `bun run test:project -- agentplane packages/agentplane/src/commands/shared/route-guidance.test.ts`. Expected: route guidance tests pass.
+    2. Run `bun run test:project -- cli-core packages/agentplane/src/cli/run-cli.core.route-decision.test.ts packages/agentplane/src/cli/run-cli.core.route-decision.direct-closeout.test.ts packages/agentplane/src/cli/run-cli.core.route-decision.work-start.test.ts`. Expected: direct closeout and post-work-start route regressions pass.
+    3. Run `bun run typecheck`. Expected: it succeeds.
+    4. Run `node .agentplane/policy/check-routing.mjs`. Expected: it succeeds.
+    5. Review the changed routing behavior and compare the final result against the task summary. Expected: both reported dead ends are closed and any remaining follow-up is explicit in Findings.
   Verification: |-
     <!-- BEGIN VERIFICATION RESULTS -->
     ### 2026-07-30T08:11:12.984Z — VERIFY — ok
@@ -214,11 +214,11 @@ Reproduce and fix v0.6.24 route guidance that selects task complete with placeho
 
 PLANNER fallback scaffold. Replace with task-specific acceptance checks when PLANNER context is available.
 
-1. Run `bunx vitest --config vitest.workspace.ts run --project agentplane packages/agentplane/src/commands/shared/route-guidance.test.ts packages/agentplane/src/cli/run-cli.core.route-decision.test.ts`. Expected: it succeeds and confirms the requested outcome for this task.
-2. Run `bun run typecheck`. Expected: it succeeds and confirms the requested outcome for this task.
-3. Run `node .agentplane/policy/check-routing.mjs`. Expected: it succeeds and confirms the requested outcome for this task.
-4. Review the changed artifact or behavior for the `code` task. Expected: the requested outcome is visible and matches the approved scope.
-5. Compare the final result against the task summary and touched scope. Expected: remaining follow-up is either resolved or explicit in ## Findings.
+1. Run `bun run test:project -- agentplane packages/agentplane/src/commands/shared/route-guidance.test.ts`. Expected: route guidance tests pass.
+2. Run `bun run test:project -- cli-core packages/agentplane/src/cli/run-cli.core.route-decision.test.ts packages/agentplane/src/cli/run-cli.core.route-decision.direct-closeout.test.ts packages/agentplane/src/cli/run-cli.core.route-decision.work-start.test.ts`. Expected: direct closeout and post-work-start route regressions pass.
+3. Run `bun run typecheck`. Expected: it succeeds.
+4. Run `node .agentplane/policy/check-routing.mjs`. Expected: it succeeds.
+5. Review the changed routing behavior and compare the final result against the task summary. Expected: both reported dead ends are closed and any remaining follow-up is explicit in Findings.
 
 ## Verification
 

--- a/.agentplane/tasks/202607300757-JBHKDW/README.md
+++ b/.agentplane/tasks/202607300757-JBHKDW/README.md
@@ -4,7 +4,7 @@ title: "Fix direct verified-task closeout route"
 status: "DOING"
 priority: "high"
 owner: "CODER"
-revision: 8
+revision: 10
 origin:
   system: "manual"
 depends_on: []
@@ -21,7 +21,7 @@ verify:
   - "node .agentplane/policy/check-routing.mjs"
 plan_approval:
   state: "approved"
-  updated_at: "2026-07-30T07:58:43.838Z"
+  updated_at: "2026-07-30T10:24:21.735Z"
   updated_by: "ORCHESTRATOR"
   note: null
 verification:
@@ -67,7 +67,7 @@ events:
     state: "ok"
     note: "Verified: direct verified-task closeout now emits concrete exactArgv, safe_to_mutate=true, and canExecuteNow=true; targeted and full fast CI passed."
 doc_version: 3
-doc_updated_at: "2026-07-30T08:11:13.175Z"
+doc_updated_at: "2026-07-30T10:24:15.683Z"
 doc_updated_by: "CODER"
 description: "Reproduce and fix v0.6.24 route guidance that selects task complete with placeholder arguments, leaving verified direct-workflow tasks without an argv-safe closeout command."
 sections:
@@ -78,7 +78,7 @@ sections:
   Scope: |-
     - In scope: Reproduce and fix v0.6.24 route guidance that selects task complete with placeholder arguments, leaving verified direct-workflow tasks without an argv-safe closeout command.
     - Out of scope: unrelated refactors not required for "Fix direct verified-task closeout route".
-  Plan: "1. Reproduce direct verified-task next-action output on v0.6.24. 2. Make complete_direct emit a concrete argv-safe task complete command using recorded commit metadata and a deterministic one-token result. 3. Add unit and CLI regression coverage for operator guidance and persistent-carrier-shaped tasks. 4. Run targeted tests, typecheck, routing policy check, and final status review."
+  Plan: "1. Keep the direct verified-task argv-safe closeout fix. 2. Infer a unique existing local task branch when PR metadata is not recorded so next-action does not repeat work start after successful worktree creation. 3. Add regression coverage for the post-work-start route from the base checkout. 4. Run targeted route tests, typecheck, policy routing, full local CI, evaluator review, and release gates."
   Verify Steps: |-
     PLANNER fallback scaffold. Replace with task-specific acceptance checks when PLANNER context is available.
 
@@ -152,7 +152,7 @@ Reproduce and fix v0.6.24 route guidance that selects task complete with placeho
 
 ## Plan
 
-1. Reproduce direct verified-task next-action output on v0.6.24. 2. Make complete_direct emit a concrete argv-safe task complete command using recorded commit metadata and a deterministic one-token result. 3. Add unit and CLI regression coverage for operator guidance and persistent-carrier-shaped tasks. 4. Run targeted tests, typecheck, routing policy check, and final status review.
+1. Keep the direct verified-task argv-safe closeout fix. 2. Infer a unique existing local task branch when PR metadata is not recorded so next-action does not repeat work start after successful worktree creation. 3. Add regression coverage for the post-work-start route from the base checkout. 4. Run targeted route tests, typecheck, policy routing, full local CI, evaluator review, and release gates.
 
 ## Verify Steps
 

--- a/.agentplane/tasks/202607300757-JBHKDW/README.md
+++ b/.agentplane/tasks/202607300757-JBHKDW/README.md
@@ -1,10 +1,11 @@
 ---
 id: "202607300757-JBHKDW"
 title: "Fix direct verified-task closeout route"
-status: "DOING"
+result_summary: "Fixed direct closeout and post-work-start routing"
+status: "DONE"
 priority: "high"
 owner: "CODER"
-revision: 10
+revision: 14
 origin:
   system: "manual"
 depends_on: []
@@ -26,32 +27,36 @@ plan_approval:
   note: null
 verification:
   state: "ok"
-  updated_at: "2026-07-30T08:11:12.984Z"
+  updated_at: "2026-07-30T10:44:58.171Z"
   updated_by: "EVALUATOR"
-  note: "Verified: direct verified-task closeout now emits concrete exactArgv, safe_to_mutate=true, and canExecuteNow=true; targeted and full fast CI passed."
+  note: "Verified: both routing regressions pass targeted coverage and full local CI (369 files, 2176 unit tests, 14 critical CLI tests, 90 platform-critical tests, significant coverage)."
   attempts: 0
 quality_review:
   state: "pass"
-  updated_at: "2026-07-30T08:11:23.563Z"
+  updated_at: "2026-07-30T10:45:31.302Z"
   updated_by: "EVALUATOR"
-  note: "v0.6.24 direct verified-task closeout is argv-safe and covered by regression tests."
-  evaluated_sha: "aef3a0651787130e839d949ce4f9edbb4ff3e6c6"
+  note: "Routing fixes are scoped and release-ready after full local CI."
+  evaluated_sha: "c3d51c336a9af8a0172c75e36c2597f2aa788841"
   blueprint_digest: "f46f992a26c22cb3a11cc073c1e371e5b58b0c03db398f719af23da0857ad2b6"
   evidence_refs:
     - ".agentplane/tasks/202607300757-JBHKDW/README.md"
-    - ".agentplane/tasks/202607300757-JBHKDW/quality/20260730-081123563-recovery-context/quality-report.json"
-    - ".agentplane/tasks/202607300757-JBHKDW/quality/20260730-081123563-recovery-context/evaluator-prompt.md"
-    - ".agentplane/tasks/202607300757-JBHKDW/quality/20260730-081123563-recovery-context/evaluator-opinion.md"
+    - ".agentplane/tasks/202607300757-JBHKDW/quality/20260730-104531302-recovery-context/quality-report.json"
+    - ".agentplane/tasks/202607300757-JBHKDW/quality/20260730-104531302-recovery-context/evaluator-prompt.md"
+    - ".agentplane/tasks/202607300757-JBHKDW/quality/20260730-104531302-recovery-context/evaluator-opinion.md"
     - ".agentplane/tasks/202607300757-JBHKDW/blueprint/resolved-snapshot.json"
-    - "packages/agentplane/src/commands/shared/route-decision-next-action.ts"
-    - "packages/agentplane/src/cli/run-cli.core.route-decision.direct-closeout.test.ts"
+    - "packages/agentplane/src/cli/run-cli.core.route-decision.work-start.test.ts"
   findings:
-    - "complete_direct no longer emits placeholder arguments; it resolves a concrete commit and produces exactArgv with safe_to_mutate=true."
-commit: null
+    - "Direct closeout emits argv-safe task complete and branch_pr recovery infers a unique local task branch without repeating work start."
+commit:
+  hash: "c3d51c336a9af8a0172c75e36c2597f2aa788841"
+  message: "🐛 JBHKDW routing: resume existing task worktree"
 comments:
   -
     author: "CODER"
     body: "Start: reproduce the verified direct-workflow closeout dead end and implement the narrow argv-safe route fix on the v0.6.24 maintenance branch."
+  -
+    author: "CODER"
+    body: "Verified: both routing dead ends are fixed and full local CI passed before the v0.6.25 maintenance release."
 events:
   -
     type: "status"
@@ -66,8 +71,21 @@ events:
     author: "EVALUATOR"
     state: "ok"
     note: "Verified: direct verified-task closeout now emits concrete exactArgv, safe_to_mutate=true, and canExecuteNow=true; targeted and full fast CI passed."
+  -
+    type: "verify"
+    at: "2026-07-30T10:44:58.171Z"
+    author: "EVALUATOR"
+    state: "ok"
+    note: "Verified: both routing regressions pass targeted coverage and full local CI (369 files, 2176 unit tests, 14 critical CLI tests, 90 platform-critical tests, significant coverage)."
+  -
+    type: "status"
+    at: "2026-07-30T10:45:44.721Z"
+    author: "CODER"
+    from: "DOING"
+    to: "DONE"
+    note: "Verified: both routing dead ends are fixed and full local CI passed before the v0.6.25 maintenance release."
 doc_version: 3
-doc_updated_at: "2026-07-30T10:24:15.683Z"
+doc_updated_at: "2026-07-30T10:45:44.721Z"
 doc_updated_by: "CODER"
 description: "Reproduce and fix v0.6.24 route guidance that selects task complete with placeholder arguments, leaving verified direct-workflow tasks without an argv-safe closeout command."
 sections:
@@ -119,6 +137,36 @@ sections:
     - repeat_stop_condition: after any non-zero exit or completed mutation, recompute task next-action before a second step
     - risks: worktree_projection_drift
 
+    ### 2026-07-30T10:44:58.171Z — VERIFY — ok
+
+    By: EVALUATOR
+
+    Note: Verified: both routing regressions pass targeted coverage and full local CI (369 files, 2176 unit tests, 14 critical CLI tests, 90 platform-critical tests, significant coverage).
+    Attempts: 0
+
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-07-30T10:24:15.683Z, excerpt_hash=sha256:e4725dfc056d3fa7a3c6ac3cdbc0f4ea4e7c4847b89f8d617889b09821e13e08
+
+    Details:
+
+    BlueprintSnapshotRef:
+    - state: current
+    - path: /Users/densmirnov/Github/agentplane/.agentplane/tmp/v0625-release.eugTda/repo/.agentplane/worktrees/202607300757-JBHKDW-fix-direct-verified-task-closeout-route/.agentplane/tasks/202607300757-JBHKDW/blueprint/resolved-snapshot.json
+    - old_digest: f46f992a26c22cb3a11cc073c1e371e5b58b0c03db398f719af23da0857ad2b6
+    - current_digest: f46f992a26c22cb3a11cc073c1e371e5b58b0c03db398f719af23da0857ad2b6
+    - route_changed: no
+    - safe_command: agentplane blueprint snapshot 202607300757-JBHKDW
+
+    DecisionContextRef:
+    - operator_action: run_exact_argv
+    - can_execute_now: true
+    - safe_command: agentplane finish 202607300757-JBHKDW --author CODER --body Verified: pre-merge closure packet is ready for the task PR. --result pre-merge closure --commit c3d51c336a9af8a0172c75e36c2597f2aa788841 --pre-merge-closure
+    - diagnostic_command: none
+    - source_of_truth: route=task_next_action diagnostic=task_next_action remote=not_checked
+    - freshness: route=computed_local remote=remote_skipped
+    - repeat_allowed: true
+    - repeat_stop_condition: after any non-zero exit or completed mutation, recompute task next-action before a second step
+    - risks: git_hook_side_effect
+
     <!-- END VERIFICATION RESULTS -->
   Rollback Plan: |-
     - Revert task-related commit(s).
@@ -137,6 +185,14 @@ sections:
     - Observation: v0.6.24 emitted literal result and commit placeholders in complete_direct.
       Impact: The route selected task complete but its own argv guard blocked mutation.
       Resolution: Resolve commit from task metadata or resume HEAD and emit a deterministic result token.
+
+    - Observation: After successful branch_pr work start, route state lacked a recorded PR branch and repeated work start.
+      Impact: Agents could enter a deterministic recovery loop and hit an existing-worktree error.
+      Resolution: Infer one matching local task branch, route unlinked worktrees to pr open, and cover the base-checkout transition.
+extensions:
+  implementation_commit:
+    hash: "c3d51c336a9af8a0172c75e36c2597f2aa788841"
+    message: "🐛 JBHKDW routing: resume existing task worktree"
 id_source: "generated"
 ---
 ## Summary
@@ -197,6 +253,36 @@ DecisionContextRef:
 - repeat_stop_condition: after any non-zero exit or completed mutation, recompute task next-action before a second step
 - risks: worktree_projection_drift
 
+### 2026-07-30T10:44:58.171Z — VERIFY — ok
+
+By: EVALUATOR
+
+Note: Verified: both routing regressions pass targeted coverage and full local CI (369 files, 2176 unit tests, 14 critical CLI tests, 90 platform-critical tests, significant coverage).
+Attempts: 0
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-07-30T10:24:15.683Z, excerpt_hash=sha256:e4725dfc056d3fa7a3c6ac3cdbc0f4ea4e7c4847b89f8d617889b09821e13e08
+
+Details:
+
+BlueprintSnapshotRef:
+- state: current
+- path: /Users/densmirnov/Github/agentplane/.agentplane/tmp/v0625-release.eugTda/repo/.agentplane/worktrees/202607300757-JBHKDW-fix-direct-verified-task-closeout-route/.agentplane/tasks/202607300757-JBHKDW/blueprint/resolved-snapshot.json
+- old_digest: f46f992a26c22cb3a11cc073c1e371e5b58b0c03db398f719af23da0857ad2b6
+- current_digest: f46f992a26c22cb3a11cc073c1e371e5b58b0c03db398f719af23da0857ad2b6
+- route_changed: no
+- safe_command: agentplane blueprint snapshot 202607300757-JBHKDW
+
+DecisionContextRef:
+- operator_action: run_exact_argv
+- can_execute_now: true
+- safe_command: agentplane finish 202607300757-JBHKDW --author CODER --body Verified: pre-merge closure packet is ready for the task PR. --result pre-merge closure --commit c3d51c336a9af8a0172c75e36c2597f2aa788841 --pre-merge-closure
+- diagnostic_command: none
+- source_of_truth: route=task_next_action diagnostic=task_next_action remote=not_checked
+- freshness: route=computed_local remote=remote_skipped
+- repeat_allowed: true
+- repeat_stop_condition: after any non-zero exit or completed mutation, recompute task next-action before a second step
+- risks: git_hook_side_effect
+
 <!-- END VERIFICATION RESULTS -->
 
 ## Rollback Plan
@@ -219,3 +305,7 @@ DecisionContextRef:
 - Observation: v0.6.24 emitted literal result and commit placeholders in complete_direct.
   Impact: The route selected task complete but its own argv guard blocked mutation.
   Resolution: Resolve commit from task metadata or resume HEAD and emit a deterministic result token.
+
+- Observation: After successful branch_pr work start, route state lacked a recorded PR branch and repeated work start.
+  Impact: Agents could enter a deterministic recovery loop and hit an existing-worktree error.
+  Resolution: Infer one matching local task branch, route unlinked worktrees to pr open, and cover the base-checkout transition.

--- a/.agentplane/tasks/202607300757-JBHKDW/pr/diffstat.txt
+++ b/.agentplane/tasks/202607300757-JBHKDW/pr/diffstat.txt
@@ -1,0 +1,4 @@
+ .../run-cli.core.route-decision.work-start.test.ts | 140 +++++++++++++++++++++
+ .../commands/shared/route-decision-next-action.ts  |   8 ++
+ .../agentplane/src/commands/task/handoff.shared.ts |  35 +++++-
+ 3 files changed, 181 insertions(+), 2 deletions(-)

--- a/.agentplane/tasks/202607300757-JBHKDW/pr/github-body.md
+++ b/.agentplane/tasks/202607300757-JBHKDW/pr/github-body.md
@@ -1,0 +1,41 @@
+Task: `202607300757-JBHKDW`
+Title: Fix direct verified-task closeout route
+Canonical task record: `.agentplane/tasks/202607300757-JBHKDW/README.md`
+
+## Summary
+
+Fix direct verified-task closeout route
+
+Reproduce and fix v0.6.24 route guidance that selects task complete with placeholder arguments, leaving verified direct-workflow tasks without an argv-safe closeout command.
+
+## Scope
+
+- In scope: Reproduce and fix v0.6.24 route guidance that selects task complete with placeholder arguments, leaving verified direct-workflow tasks without an argv-safe closeout command.
+- Out of scope: unrelated refactors not required for "Fix direct verified-task closeout route".
+
+## Verification
+
+- State: ok
+- Note:
+
+```text
+Verified: direct verified-task closeout now emits concrete exactArgv, safe_to_mutate=true, and
+canExecuteNow=true; targeted and full fast CI passed.
+```
+- Canonical workflow state lives in the task README.
+
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-07-30T10:44:25.661Z
+- Branch: task/202607300757-JBHKDW/fix-direct-verified-task-closeout-route
+- Head: computed live by `agentplane pr check` / `agentplane integrate`
+
+```text
+ .../run-cli.core.route-decision.work-start.test.ts | 140 +++++++++++++++++++++
+ .../commands/shared/route-decision-next-action.ts  |   8 ++
+ .../agentplane/src/commands/task/handoff.shared.ts |  35 +++++-
+ 3 files changed, 181 insertions(+), 2 deletions(-)
+```
+
+</details>

--- a/.agentplane/tasks/202607300757-JBHKDW/pr/github-body.md
+++ b/.agentplane/tasks/202607300757-JBHKDW/pr/github-body.md
@@ -19,15 +19,15 @@ Reproduce and fix v0.6.24 route guidance that selects task complete with placeho
 - Note:
 
 ```text
-Verified: direct verified-task closeout now emits concrete exactArgv, safe_to_mutate=true, and
-canExecuteNow=true; targeted and full fast CI passed.
+Verified: both routing regressions pass targeted coverage and full local CI (369 files, 2176 unit
+tests, 14 critical CLI tests, 90 platform-critical tests, significant coverage).
 ```
 - Canonical workflow state lives in the task README.
 
 <details>
 <summary>Raw evidence</summary>
 
-- Updated: 2026-07-30T10:44:25.661Z
+- Updated: 2026-07-30T10:44:29.202Z
 - Branch: task/202607300757-JBHKDW/fix-direct-verified-task-closeout-route
 - Head: computed live by `agentplane pr check` / `agentplane integrate`
 

--- a/.agentplane/tasks/202607300757-JBHKDW/pr/github-title.txt
+++ b/.agentplane/tasks/202607300757-JBHKDW/pr/github-title.txt
@@ -1,1 +1,1 @@
-🚧 JBHKDW task: Fix direct verified-task closeout route [202607300757-JBHKDW]
+✅ JBHKDW task: Fix direct verified-task closeout route [202607300757-JBHKDW]

--- a/.agentplane/tasks/202607300757-JBHKDW/pr/github-title.txt
+++ b/.agentplane/tasks/202607300757-JBHKDW/pr/github-title.txt
@@ -1,0 +1,1 @@
+🚧 JBHKDW task: Fix direct verified-task closeout route [202607300757-JBHKDW]

--- a/.agentplane/tasks/202607300757-JBHKDW/pr/meta.json
+++ b/.agentplane/tasks/202607300757-JBHKDW/pr/meta.json
@@ -1,0 +1,13 @@
+{
+  "base": "codex/fix-v0.6.24-closeout-route",
+  "branch": "task/202607300757-JBHKDW/fix-direct-verified-task-closeout-route",
+  "created_at": "2026-07-30T10:44:25.661Z",
+  "diffstat_sha256": "sha256:531e35d4bddcb386711a5b9ba70f2247ffb0687c37a68476428a46e3b3f974c0",
+  "last_verified_at": null,
+  "schema_version": 1,
+  "task_id": "202607300757-JBHKDW",
+  "updated_at": "2026-07-30T10:44:25.661Z",
+  "verify": {
+    "status": "skipped"
+  }
+}

--- a/.agentplane/tasks/202607300757-JBHKDW/pr/meta.json
+++ b/.agentplane/tasks/202607300757-JBHKDW/pr/meta.json
@@ -3,11 +3,22 @@
   "branch": "task/202607300757-JBHKDW/fix-direct-verified-task-closeout-route",
   "created_at": "2026-07-30T10:44:25.661Z",
   "diffstat_sha256": "sha256:531e35d4bddcb386711a5b9ba70f2247ffb0687c37a68476428a46e3b3f974c0",
-  "last_verified_at": null,
+  "last_verified_at": "2026-07-30T10:44:58.171Z",
+  "last_verified_diffstat_sha256": "sha256:531e35d4bddcb386711a5b9ba70f2247ffb0687c37a68476428a46e3b3f974c0",
+  "pr_number": 4689,
+  "pr_url": "https://github.com/basilisk-labs/agentplane/pull/4689",
+  "pre_merge_closure": {
+    "basis_commit": "c3d51c336a9af8a0172c75e36c2597f2aa788841",
+    "branch": "task/202607300757-JBHKDW/fix-direct-verified-task-closeout-route",
+    "pr_number": 4689,
+    "recorded_at": "2026-07-30T10:45:44.746Z",
+    "state": "closed_before_merge"
+  },
   "schema_version": 1,
+  "status": "OPEN",
   "task_id": "202607300757-JBHKDW",
-  "updated_at": "2026-07-30T10:44:25.661Z",
+  "updated_at": "2026-07-30T10:44:29.202Z",
   "verify": {
-    "status": "skipped"
+    "status": "pass"
   }
 }

--- a/.agentplane/tasks/202607300757-JBHKDW/pr/review.md
+++ b/.agentplane/tasks/202607300757-JBHKDW/pr/review.md
@@ -6,14 +6,14 @@ Created: 2026-07-30T10:44:25.661Z
 
 - Task: `202607300757-JBHKDW`
 - Title: Fix direct verified-task closeout route
-- Status: DOING
+- Status: DONE
 - Branch: `task/202607300757-JBHKDW/fix-direct-verified-task-closeout-route`
 - Canonical task record: `.agentplane/tasks/202607300757-JBHKDW/README.md`
 
 ## Verification
 
 - State: ok
-- Note: Verified: direct verified-task closeout now emits concrete exactArgv, safe_to_mutate=true, and canExecuteNow=true; targeted and full fast CI passed.
+- Note: Verified: both routing regressions pass targeted coverage and full local CI (369 files, 2176 unit tests, 14 critical CLI tests, 90 platform-critical tests, significant coverage).
 - Canonical workflow state lives in the task README.
 
 ## Handoff Notes
@@ -24,7 +24,7 @@ Created: 2026-07-30T10:44:25.661Z
 <details>
 <summary>Raw evidence</summary>
 
-- Updated: 2026-07-30T10:44:25.661Z
+- Updated: 2026-07-30T10:44:29.202Z
 - Branch: task/202607300757-JBHKDW/fix-direct-verified-task-closeout-route
 - Head: computed live by `agentplane pr check` / `agentplane integrate`
 

--- a/.agentplane/tasks/202607300757-JBHKDW/pr/review.md
+++ b/.agentplane/tasks/202607300757-JBHKDW/pr/review.md
@@ -1,0 +1,39 @@
+# PR Review
+
+Created: 2026-07-30T10:44:25.661Z
+
+## Task
+
+- Task: `202607300757-JBHKDW`
+- Title: Fix direct verified-task closeout route
+- Status: DOING
+- Branch: `task/202607300757-JBHKDW/fix-direct-verified-task-closeout-route`
+- Canonical task record: `.agentplane/tasks/202607300757-JBHKDW/README.md`
+
+## Verification
+
+- State: ok
+- Note: Verified: direct verified-task closeout now emits concrete exactArgv, safe_to_mutate=true, and canExecuteNow=true; targeted and full fast CI passed.
+- Canonical workflow state lives in the task README.
+
+## Handoff Notes
+
+- No handoff notes recorded yet. Use `agentplane pr note ...` to append one.
+
+<!-- BEGIN AUTO SUMMARY -->
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-07-30T10:44:25.661Z
+- Branch: task/202607300757-JBHKDW/fix-direct-verified-task-closeout-route
+- Head: computed live by `agentplane pr check` / `agentplane integrate`
+
+```text
+ .../run-cli.core.route-decision.work-start.test.ts | 140 +++++++++++++++++++++
+ .../commands/shared/route-decision-next-action.ts  |   8 ++
+ .../agentplane/src/commands/task/handoff.shared.ts |  35 +++++-
+ 3 files changed, 181 insertions(+), 2 deletions(-)
+```
+
+</details>
+<!-- END AUTO SUMMARY -->

--- a/.agentplane/tasks/202607300757-JBHKDW/quality/20260730-104448336-recovery-context/evaluator-opinion.md
+++ b/.agentplane/tasks/202607300757-JBHKDW/quality/20260730-104448336-recovery-context/evaluator-opinion.md
@@ -1,0 +1,19 @@
+# EVALUATOR opinion: pass
+
+Routing fixes are scoped and release-ready after full local CI.
+
+## Findings
+- Direct closeout emits argv-safe task complete and branch_pr recovery infers a unique local task branch without repeating work start.
+
+## Evidence
+- .agentplane/tasks/202607300757-JBHKDW/README.md
+- packages/agentplane/src/cli/run-cli.core.route-decision.work-start.test.ts
+
+## Missing Tests
+- none recorded
+
+## Hidden Assumptions
+- none recorded
+
+## Residual Risks
+- none recorded

--- a/.agentplane/tasks/202607300757-JBHKDW/quality/20260730-104448336-recovery-context/evaluator-prompt.md
+++ b/.agentplane/tasks/202607300757-JBHKDW/quality/20260730-104448336-recovery-context/evaluator-prompt.md
@@ -1,0 +1,74 @@
+# AgentPlane EVALUATOR quality review
+
+Use the evaluator module below as binding review procedure.
+Do not edit implementation files. Inspect task scope, diff, verification evidence, and residual risk.
+Write the final structured review to the report path as JSON matching the requested report shape.
+
+- task_id: 202607300757-JBHKDW
+- task_readme: .agentplane/tasks/202607300757-JBHKDW/README.md
+- report_path: .agentplane/tasks/202607300757-JBHKDW/quality/20260730-104448336-recovery-context/quality-report.json
+
+Required report fields:
+- verdict: pass | rework | blocked | human_review
+- summary: concise judgement
+- findings: non-empty list for pass/rework/blocked
+- evidence_refs: concrete files, checks, PRs, traces, or reports inspected
+- missing_tests: tests or checks that should exist but do not
+- hidden_assumptions: assumptions the implementation relies on
+- residual_risks: known remaining risks
+
+## Evaluator module
+
+---
+id: recovery-context
+title: Recovery Context Invariant Review
+version: 1
+status: preview
+profile: EVALUATOR
+tags:
+  - recovery
+  - invariants
+  - concurrency
+---
+
+# Recovery Context Invariant Review
+
+Use this evaluator only when the primary implementation path already produced a concrete change or when recovery context is needed after an interruption.
+
+## Inputs
+
+- Task id, task README, approved plan, and Verify Steps.
+- Current diff or PR patch.
+- Relevant comments, review findings, incidents, and recovery/handoff context.
+- Known concurrent-agent activity and task-artifact drift classification, if present.
+
+## Review Procedure
+
+1. Reconstruct the intended contract from the task, not from the implementation summary.
+2. Compare the diff against explicit invariants, stop rules, negative cases, and user constraints.
+3. Check whether recovery context changes the interpretation of the task or exposes stale assumptions.
+4. Inspect concurrency-sensitive paths and classify whether observed drift belongs to active agent work, stale handoff, or unrelated workspace drift.
+5. Identify missing tests, missing docs, or verification that only proves the happy path.
+6. Do not execute fixes. Return review findings only.
+7. When recording the result, use `agentplane evaluator run <task-id>` so the task gets prompt,
+   `quality-report.json`, and opinion artifacts. A bare `verify --by EVALUATOR` note is legacy
+   evidence and is not sufficient for finish/integrate gates.
+
+## Output
+
+Return a concise structured review:
+
+- `verdict`: `pass`, `rework`, `blocked`, or `human_review`.
+- `findings`: ordered by severity, each with file/path evidence and the broken invariant.
+- `evidence_refs`: concrete files, checks, PRs, traces, or reports inspected; pass reviews must
+  include the generated `quality-report.json`.
+- `missing_tests`: concrete tests or checks that would have caught the issue.
+- `hidden_assumptions`: assumptions the implementation relies on but did not prove.
+- `residual_risks`: known risks after the review.
+- `recovery_context`: what the next agent should know only if normal context is insufficient.
+
+## Stop Rules
+
+- Use `blocked` when required task context, diff, or recovery context is missing.
+- Use `rework` when behavior diverges from the approved contract even if local checks pass.
+- Use `pass` only when the implementation and verification evidence cover positive, negative, and concurrency-sensitive paths relevant to the task.

--- a/.agentplane/tasks/202607300757-JBHKDW/quality/20260730-104448336-recovery-context/quality-report.json
+++ b/.agentplane/tasks/202607300757-JBHKDW/quality/20260730-104448336-recovery-context/quality-report.json
@@ -1,0 +1,21 @@
+{
+  "schema_version": 1,
+  "task_id": "202607300757-JBHKDW",
+  "evaluator_id": "recovery-context",
+  "evaluator_profile": "EVALUATOR",
+  "generated_at": "2026-07-30T10:44:48.336Z",
+  "verdict": "pass",
+  "summary": "Routing fixes are scoped and release-ready after full local CI.",
+  "evaluated_sha": "c3d51c336a9af8a0172c75e36c2597f2aa788841",
+  "blueprint_digest": "f46f992a26c22cb3a11cc073c1e371e5b58b0c03db398f719af23da0857ad2b6",
+  "findings": [
+    "Direct closeout emits argv-safe task complete and branch_pr recovery infers a unique local task branch without repeating work start."
+  ],
+  "evidence_refs": [
+    ".agentplane/tasks/202607300757-JBHKDW/README.md",
+    "packages/agentplane/src/cli/run-cli.core.route-decision.work-start.test.ts"
+  ],
+  "missing_tests": [],
+  "hidden_assumptions": [],
+  "residual_risks": []
+}

--- a/.agentplane/tasks/202607300757-JBHKDW/quality/20260730-104531302-recovery-context/evaluator-opinion.md
+++ b/.agentplane/tasks/202607300757-JBHKDW/quality/20260730-104531302-recovery-context/evaluator-opinion.md
@@ -1,0 +1,19 @@
+# EVALUATOR opinion: pass
+
+Routing fixes are scoped and release-ready after full local CI.
+
+## Findings
+- Direct closeout emits argv-safe task complete and branch_pr recovery infers a unique local task branch without repeating work start.
+
+## Evidence
+- .agentplane/tasks/202607300757-JBHKDW/README.md
+- packages/agentplane/src/cli/run-cli.core.route-decision.work-start.test.ts
+
+## Missing Tests
+- none recorded
+
+## Hidden Assumptions
+- none recorded
+
+## Residual Risks
+- none recorded

--- a/.agentplane/tasks/202607300757-JBHKDW/quality/20260730-104531302-recovery-context/evaluator-prompt.md
+++ b/.agentplane/tasks/202607300757-JBHKDW/quality/20260730-104531302-recovery-context/evaluator-prompt.md
@@ -1,0 +1,74 @@
+# AgentPlane EVALUATOR quality review
+
+Use the evaluator module below as binding review procedure.
+Do not edit implementation files. Inspect task scope, diff, verification evidence, and residual risk.
+Write the final structured review to the report path as JSON matching the requested report shape.
+
+- task_id: 202607300757-JBHKDW
+- task_readme: .agentplane/tasks/202607300757-JBHKDW/README.md
+- report_path: .agentplane/tasks/202607300757-JBHKDW/quality/20260730-104531302-recovery-context/quality-report.json
+
+Required report fields:
+- verdict: pass | rework | blocked | human_review
+- summary: concise judgement
+- findings: non-empty list for pass/rework/blocked
+- evidence_refs: concrete files, checks, PRs, traces, or reports inspected
+- missing_tests: tests or checks that should exist but do not
+- hidden_assumptions: assumptions the implementation relies on
+- residual_risks: known remaining risks
+
+## Evaluator module
+
+---
+id: recovery-context
+title: Recovery Context Invariant Review
+version: 1
+status: preview
+profile: EVALUATOR
+tags:
+  - recovery
+  - invariants
+  - concurrency
+---
+
+# Recovery Context Invariant Review
+
+Use this evaluator only when the primary implementation path already produced a concrete change or when recovery context is needed after an interruption.
+
+## Inputs
+
+- Task id, task README, approved plan, and Verify Steps.
+- Current diff or PR patch.
+- Relevant comments, review findings, incidents, and recovery/handoff context.
+- Known concurrent-agent activity and task-artifact drift classification, if present.
+
+## Review Procedure
+
+1. Reconstruct the intended contract from the task, not from the implementation summary.
+2. Compare the diff against explicit invariants, stop rules, negative cases, and user constraints.
+3. Check whether recovery context changes the interpretation of the task or exposes stale assumptions.
+4. Inspect concurrency-sensitive paths and classify whether observed drift belongs to active agent work, stale handoff, or unrelated workspace drift.
+5. Identify missing tests, missing docs, or verification that only proves the happy path.
+6. Do not execute fixes. Return review findings only.
+7. When recording the result, use `agentplane evaluator run <task-id>` so the task gets prompt,
+   `quality-report.json`, and opinion artifacts. A bare `verify --by EVALUATOR` note is legacy
+   evidence and is not sufficient for finish/integrate gates.
+
+## Output
+
+Return a concise structured review:
+
+- `verdict`: `pass`, `rework`, `blocked`, or `human_review`.
+- `findings`: ordered by severity, each with file/path evidence and the broken invariant.
+- `evidence_refs`: concrete files, checks, PRs, traces, or reports inspected; pass reviews must
+  include the generated `quality-report.json`.
+- `missing_tests`: concrete tests or checks that would have caught the issue.
+- `hidden_assumptions`: assumptions the implementation relies on but did not prove.
+- `residual_risks`: known risks after the review.
+- `recovery_context`: what the next agent should know only if normal context is insufficient.
+
+## Stop Rules
+
+- Use `blocked` when required task context, diff, or recovery context is missing.
+- Use `rework` when behavior diverges from the approved contract even if local checks pass.
+- Use `pass` only when the implementation and verification evidence cover positive, negative, and concurrency-sensitive paths relevant to the task.

--- a/.agentplane/tasks/202607300757-JBHKDW/quality/20260730-104531302-recovery-context/quality-report.json
+++ b/.agentplane/tasks/202607300757-JBHKDW/quality/20260730-104531302-recovery-context/quality-report.json
@@ -1,0 +1,21 @@
+{
+  "schema_version": 1,
+  "task_id": "202607300757-JBHKDW",
+  "evaluator_id": "recovery-context",
+  "evaluator_profile": "EVALUATOR",
+  "generated_at": "2026-07-30T10:45:31.302Z",
+  "verdict": "pass",
+  "summary": "Routing fixes are scoped and release-ready after full local CI.",
+  "evaluated_sha": "c3d51c336a9af8a0172c75e36c2597f2aa788841",
+  "blueprint_digest": "f46f992a26c22cb3a11cc073c1e371e5b58b0c03db398f719af23da0857ad2b6",
+  "findings": [
+    "Direct closeout emits argv-safe task complete and branch_pr recovery infers a unique local task branch without repeating work start."
+  ],
+  "evidence_refs": [
+    ".agentplane/tasks/202607300757-JBHKDW/README.md",
+    "packages/agentplane/src/cli/run-cli.core.route-decision.work-start.test.ts"
+  ],
+  "missing_tests": [],
+  "hidden_assumptions": [],
+  "residual_risks": []
+}

--- a/.agentplane/tasks/202607300757-JBHKDW/quality/20260730-105323180-recovery-context/evaluator-opinion.md
+++ b/.agentplane/tasks/202607300757-JBHKDW/quality/20260730-105323180-recovery-context/evaluator-opinion.md
@@ -1,0 +1,18 @@
+# EVALUATOR opinion: pass
+
+Corrected integration verification contract passes on the routing implementation.
+
+## Findings
+- All task Verify Steps now use the matching Vitest projects and pass together with full local and hosted CI.
+
+## Evidence
+- .agentplane/tasks/202607300757-JBHKDW/README.md
+
+## Missing Tests
+- none recorded
+
+## Hidden Assumptions
+- none recorded
+
+## Residual Risks
+- none recorded

--- a/.agentplane/tasks/202607300757-JBHKDW/quality/20260730-105323180-recovery-context/evaluator-prompt.md
+++ b/.agentplane/tasks/202607300757-JBHKDW/quality/20260730-105323180-recovery-context/evaluator-prompt.md
@@ -1,0 +1,74 @@
+# AgentPlane EVALUATOR quality review
+
+Use the evaluator module below as binding review procedure.
+Do not edit implementation files. Inspect task scope, diff, verification evidence, and residual risk.
+Write the final structured review to the report path as JSON matching the requested report shape.
+
+- task_id: 202607300757-JBHKDW
+- task_readme: .agentplane/tasks/202607300757-JBHKDW/README.md
+- report_path: .agentplane/tasks/202607300757-JBHKDW/quality/20260730-105323180-recovery-context/quality-report.json
+
+Required report fields:
+- verdict: pass | rework | blocked | human_review
+- summary: concise judgement
+- findings: non-empty list for pass/rework/blocked
+- evidence_refs: concrete files, checks, PRs, traces, or reports inspected
+- missing_tests: tests or checks that should exist but do not
+- hidden_assumptions: assumptions the implementation relies on
+- residual_risks: known remaining risks
+
+## Evaluator module
+
+---
+id: recovery-context
+title: Recovery Context Invariant Review
+version: 1
+status: preview
+profile: EVALUATOR
+tags:
+  - recovery
+  - invariants
+  - concurrency
+---
+
+# Recovery Context Invariant Review
+
+Use this evaluator only when the primary implementation path already produced a concrete change or when recovery context is needed after an interruption.
+
+## Inputs
+
+- Task id, task README, approved plan, and Verify Steps.
+- Current diff or PR patch.
+- Relevant comments, review findings, incidents, and recovery/handoff context.
+- Known concurrent-agent activity and task-artifact drift classification, if present.
+
+## Review Procedure
+
+1. Reconstruct the intended contract from the task, not from the implementation summary.
+2. Compare the diff against explicit invariants, stop rules, negative cases, and user constraints.
+3. Check whether recovery context changes the interpretation of the task or exposes stale assumptions.
+4. Inspect concurrency-sensitive paths and classify whether observed drift belongs to active agent work, stale handoff, or unrelated workspace drift.
+5. Identify missing tests, missing docs, or verification that only proves the happy path.
+6. Do not execute fixes. Return review findings only.
+7. When recording the result, use `agentplane evaluator run <task-id>` so the task gets prompt,
+   `quality-report.json`, and opinion artifacts. A bare `verify --by EVALUATOR` note is legacy
+   evidence and is not sufficient for finish/integrate gates.
+
+## Output
+
+Return a concise structured review:
+
+- `verdict`: `pass`, `rework`, `blocked`, or `human_review`.
+- `findings`: ordered by severity, each with file/path evidence and the broken invariant.
+- `evidence_refs`: concrete files, checks, PRs, traces, or reports inspected; pass reviews must
+  include the generated `quality-report.json`.
+- `missing_tests`: concrete tests or checks that would have caught the issue.
+- `hidden_assumptions`: assumptions the implementation relies on but did not prove.
+- `residual_risks`: known risks after the review.
+- `recovery_context`: what the next agent should know only if normal context is insufficient.
+
+## Stop Rules
+
+- Use `blocked` when required task context, diff, or recovery context is missing.
+- Use `rework` when behavior diverges from the approved contract even if local checks pass.
+- Use `pass` only when the implementation and verification evidence cover positive, negative, and concurrency-sensitive paths relevant to the task.

--- a/.agentplane/tasks/202607300757-JBHKDW/quality/20260730-105323180-recovery-context/quality-report.json
+++ b/.agentplane/tasks/202607300757-JBHKDW/quality/20260730-105323180-recovery-context/quality-report.json
@@ -1,0 +1,20 @@
+{
+  "schema_version": 1,
+  "task_id": "202607300757-JBHKDW",
+  "evaluator_id": "recovery-context",
+  "evaluator_profile": "EVALUATOR",
+  "generated_at": "2026-07-30T10:53:23.180Z",
+  "verdict": "pass",
+  "summary": "Corrected integration verification contract passes on the routing implementation.",
+  "evaluated_sha": "c3d51c336a9af8a0172c75e36c2597f2aa788841",
+  "blueprint_digest": "f46f992a26c22cb3a11cc073c1e371e5b58b0c03db398f719af23da0857ad2b6",
+  "findings": [
+    "All task Verify Steps now use the matching Vitest projects and pass together with full local and hosted CI."
+  ],
+  "evidence_refs": [
+    ".agentplane/tasks/202607300757-JBHKDW/README.md"
+  ],
+  "missing_tests": [],
+  "hidden_assumptions": [],
+  "residual_risks": []
+}

--- a/packages/agentplane/src/cli/run-cli.core.route-decision.work-start.test.ts
+++ b/packages/agentplane/src/cli/run-cli.core.route-decision.work-start.test.ts
@@ -1,0 +1,140 @@
+import { realpath } from "node:fs/promises";
+import path from "node:path";
+
+import { describe } from "vitest";
+
+import {
+  captureStdIO,
+  commitAll,
+  defaultConfig,
+  expect,
+  it,
+  mkGitRepoRootWithBranch,
+  runCli,
+  runCliSilent,
+  writeConfig,
+} from "@agentplane/testkit/cli-core-pr-flow";
+
+async function createApprovedTask(root: string): Promise<string> {
+  const taskIo = captureStdIO();
+  let taskId = "";
+  try {
+    const code = await runCli([
+      "task",
+      "new",
+      "--title",
+      "Post work-start route",
+      "--description",
+      "Route an existing task worktree to PR publication.",
+      "--priority",
+      "med",
+      "--owner",
+      "CODER",
+      "--tag",
+      "code",
+      "--root",
+      root,
+    ]);
+    expect(code).toBe(0);
+    taskId = taskIo.stdout.trim();
+  } finally {
+    taskIo.restore();
+  }
+  await runCliSilent([
+    "task",
+    "plan",
+    "set",
+    taskId,
+    "--text",
+    "Create the task worktree and continue to PR publication.",
+    "--updated-by",
+    "ORCHESTRATOR",
+    "--root",
+    root,
+  ]);
+  await runCliSilent(["task", "plan", "approve", taskId, "--by", "ORCHESTRATOR", "--root", root]);
+  return taskId;
+}
+
+describe("post work-start route decision", () => {
+  it("routes the base checkout to PR publication when the task worktree already exists", async () => {
+    const root = await mkGitRepoRootWithBranch("main");
+    const config = defaultConfig();
+    config.workflow_mode = "branch_pr";
+    await writeConfig(root, config);
+    await runCliSilent(["branch", "base", "set", "main", "--root", root]);
+    const taskId = await createApprovedTask(root);
+    await commitAll(root, "test: prepare approved task");
+
+    const startOutput = captureStdIO();
+    try {
+      const code = await runCli([
+        "work",
+        "start",
+        taskId,
+        "--agent",
+        "CODER",
+        "--slug",
+        "post-work-start-route",
+        "--worktree",
+        "--root",
+        root,
+      ]);
+      if (code !== 0) {
+        throw new Error(`${startOutput.stderr}\n${startOutput.stdout}`.trim());
+      }
+    } finally {
+      startOutput.restore();
+    }
+
+    const output = captureStdIO();
+    try {
+      const code = await runCli(["task", "next-action", taskId, "--json", "--root", root]);
+      expect(code).toBe(0);
+      const parsed = JSON.parse(output.stdout) as {
+        route_oracle: {
+          phase: string;
+          authoritativeCheckout: string;
+          authoritativeCheckoutPath: string | null;
+          nextCommand: string | null;
+        };
+        execution_packet: {
+          mustRunFrom: string | null;
+          exactArgv: string[] | null;
+        };
+        next_action: { code: string; command: string | null };
+      };
+      const worktreePath = path.join(
+        root,
+        ".agentplane",
+        "worktrees",
+        `${taskId}-post-work-start-route`,
+      );
+      expect(parsed.route_oracle).toMatchObject({
+        phase: "pr_needed",
+        authoritativeCheckout: "task_worktree",
+        nextCommand: `agentplane pr open ${taskId} --author CODER`,
+      });
+      expect(await realpath(parsed.route_oracle.authoritativeCheckoutPath ?? "")).toBe(
+        await realpath(worktreePath),
+      );
+      expect(await realpath(parsed.execution_packet.mustRunFrom ?? "")).toBe(
+        await realpath(worktreePath),
+      );
+      expect(parsed.execution_packet.exactArgv).toEqual([
+        "agentplane",
+        "pr",
+        "open",
+        taskId,
+        "--author",
+        "CODER",
+      ]);
+      expect(parsed.next_action).toMatchObject({
+        code: "open_pr",
+        command: `agentplane pr open ${taskId} --author CODER`,
+      });
+    } finally {
+      output.restore();
+    }
+  });
+});

--- a/packages/agentplane/src/commands/shared/route-decision-next-action.ts
+++ b/packages/agentplane/src/commands/shared/route-decision-next-action.ts
@@ -204,6 +204,14 @@ export function deriveNextAction(opts: {
       requiresApproval: false,
     };
   }
+  if (opts.resume.local_task_branch && !opts.prFlow) {
+    return {
+      code: "open_pr",
+      command: `agentplane pr open ${id} --author ${opts.task.owner}`,
+      summary: "publish/link the task PR",
+      requiresApproval: false,
+    };
+  }
   if (opts.blockers.some((blocker) => blocker.code === "pr_meta_stale")) {
     return {
       code: "update_pr_artifacts",

--- a/packages/agentplane/src/commands/task/handoff.shared.ts
+++ b/packages/agentplane/src/commands/task/handoff.shared.ts
@@ -1,4 +1,8 @@
-import { resolveBaseBranch } from "@agentplaneorg/core/git";
+import {
+  gitListTaskBranches,
+  parseTaskIdFromBranch,
+  resolveBaseBranch,
+} from "@agentplaneorg/core/git";
 import { normalizeTaskStatus } from "@agentplaneorg/core/tasks";
 
 import type { TaskData } from "../../backends/task-backend.js";
@@ -29,6 +33,7 @@ export type TaskResumeContext = {
   head_sha: string | null;
   workspace_root: string;
   pr_branch: string | null;
+  local_task_branch?: string | null;
   latest_handoff: TaskHandoffArtifact | null;
   runner: TaskHandoffRunnerHint;
 };
@@ -40,6 +45,22 @@ function taskStatus(task: TaskData): string {
 function nullIfCliIo(err: unknown): null {
   if (err instanceof CliError && err.code === "E_IO") return null;
   throw err;
+}
+
+async function inferLocalTaskBranch(opts: {
+  ctx: CommandContext;
+  taskId: string;
+  currentBranch: string | null;
+}): Promise<string | null> {
+  const taskPrefix = opts.ctx.config.branch.task_prefix;
+  if (opts.currentBranch && parseTaskIdFromBranch(taskPrefix, opts.currentBranch) === opts.taskId) {
+    return opts.currentBranch;
+  }
+  const taskBranches = await gitListTaskBranches(opts.ctx.resolvedProject.gitRoot, taskPrefix);
+  const matchingBranches = taskBranches.filter(
+    (branch) => parseTaskIdFromBranch(taskPrefix, branch) === opts.taskId,
+  );
+  return matchingBranches.length === 1 ? (matchingBranches[0] ?? null) : null;
 }
 
 export async function buildTaskResumeContext(opts: {
@@ -71,6 +92,15 @@ export async function buildTaskResumeContext(opts: {
       rootOverride: ctx.resolvedProject.gitRoot,
       mode: ctx.config.workflow_mode,
     }).catch(() => null));
+  const local_task_branch =
+    ctx.config.workflow_mode === "branch_pr"
+      ? await inferLocalTaskBranch({
+          ctx,
+          taskId: opts.task_id,
+          currentBranch: branch,
+        })
+      : null;
+  const pr_branch = prMeta.branch ?? local_task_branch;
 
   let runner: TaskHandoffRunnerHint;
   try {
@@ -121,7 +151,8 @@ export async function buildTaskResumeContext(opts: {
     base_branch,
     head_sha,
     workspace_root: ctx.resolvedProject.gitRoot,
-    pr_branch: prMeta.branch,
+    pr_branch,
+    local_task_branch,
     latest_handoff,
     runner,
   };


### PR DESCRIPTION
Task: `202607300757-JBHKDW`
Title: Fix direct verified-task closeout route
Canonical task record: `.agentplane/tasks/202607300757-JBHKDW/README.md`

## Summary

Fix direct verified-task closeout route

Reproduce and fix v0.6.24 route guidance that selects task complete with placeholder arguments, leaving verified direct-workflow tasks without an argv-safe closeout command.

## Scope

- In scope: Reproduce and fix v0.6.24 route guidance that selects task complete with placeholder arguments, leaving verified direct-workflow tasks without an argv-safe closeout command.
- Out of scope: unrelated refactors not required for "Fix direct verified-task closeout route".

## Verification

- State: ok
- Note:

```text
Verified: direct verified-task closeout now emits concrete exactArgv, safe_to_mutate=true, and
canExecuteNow=true; targeted and full fast CI passed.
```
- Canonical workflow state lives in the task README.

<details>
<summary>Raw evidence</summary>

- Updated: 2026-07-30T10:44:25.661Z
- Branch: task/202607300757-JBHKDW/fix-direct-verified-task-closeout-route
- Head: computed live by `agentplane pr check` / `agentplane integrate`

```text
 .../run-cli.core.route-decision.work-start.test.ts | 140 +++++++++++++++++++++
 .../commands/shared/route-decision-next-action.ts  |   8 ++
 .../agentplane/src/commands/task/handoff.shared.ts |  35 +++++-
 3 files changed, 181 insertions(+), 2 deletions(-)
```

</details>
