### PR TITLE
🚧 773BXT task: Make merged worktree cleanup idempotent [202607311529-773BXT]

### DIFF
--- a/.agentplane/tasks/202607311529-773BXT/README.md
+++ b/.agentplane/tasks/202607311529-773BXT/README.md
@@ -1,0 +1,120 @@
+---
+id: "202607311529-773BXT"
+title: "Make merged worktree cleanup idempotent"
+status: "DOING"
+priority: "high"
+owner: "CODER"
+revision: 6
+origin:
+  system: "manual"
+depends_on: []
+tags:
+  - "post-merge"
+  - "release"
+verify:
+  - "bun run format:check"
+  - "bun run test:project agentplane packages/agentplane/src/commands/shared/merged-branch-cleanup.test.ts packages/agentplane/src/commands/pr/integrate/cmd.test.ts"
+  - "bun run typecheck"
+plan_approval:
+  state: "approved"
+  updated_at: "2026-07-31T15:29:17.510Z"
+  updated_by: "ORCHESTRATOR"
+  note: null
+verification:
+  state: "pending"
+  updated_at: null
+  updated_by: null
+  note: null
+  attempts: 0
+commit: null
+comments:
+  -
+    author: "CODER"
+    body: "Start: make merged worktree cleanup idempotent when post-merge hooks already removed the task worktree and branch."
+events:
+  -
+    type: "status"
+    at: "2026-07-31T15:29:40.641Z"
+    author: "CODER"
+    from: "TODO"
+    to: "DOING"
+    note: "Start: make merged worktree cleanup idempotent when post-merge hooks already removed the task worktree and branch."
+doc_version: 3
+doc_updated_at: "2026-07-31T15:34:00.883Z"
+doc_updated_by: "CODER"
+description: "Post-merge follow-up for v0.6.26: if a hook already removed the task worktree/branch, integration cleanup must treat that as completed instead of exiting non-zero after a successful merge."
+sections:
+  Summary: |-
+    Make merged worktree cleanup idempotent
+
+    Post-merge follow-up for v0.6.26: if a hook already removed the task worktree/branch, integration cleanup must treat that as completed instead of exiting non-zero after a successful merge.
+  Scope: |-
+    - In scope: Post-merge follow-up for v0.6.26: if a hook already removed the task worktree/branch, integration cleanup must treat that as completed instead of exiting non-zero after a successful merge.
+    - Out of scope: unrelated refactors not required for "Make merged worktree cleanup idempotent".
+  Plan: "1. Create an isolated post-merge worktree from the maintenance base. 2. Make merged worktree cleanup tolerate a worktree/branch already removed by the post-merge hook while preserving unexpected errors. 3. Add the exact regression and run focused tests, typecheck, format, lint, and release fast gate. 4. Open a maintenance PR, wait for hosted checks, and integrate through the serialized lane."
+  Verify Steps: |-
+    1. `bun run test:project agentplane packages/agentplane/src/commands/shared/merged-branch-cleanup.test.ts packages/agentplane/src/commands/pr/integrate/cmd.test.ts`
+       Expected: cleanup treats an already removed hook-owned worktree as complete and still surfaces genuine failures while registered.
+    2. `bun run typecheck`
+       Expected: TypeScript build passes.
+    3. `bun run format:check`
+       Expected: repository formatting passes.
+    4. `bun run lint:core`
+       Expected: core lint passes.
+    5. `bun run release:prepublish:fast`
+       Expected: release gates pass for v0.6.26.
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: |-
+    - Root cause: `cleanupMergedLocalBranch` trusted a stale `worktreePathHint` after the post-merge hook had already removed both worktree and branch, then treated `git worktree remove` exit 128 as a new integration failure.
+    - Resolution: re-check branch worktree registration after a cleanup exception; suppress only the already-removed race and rethrow when the worktree remains registered.
+    - Regression coverage includes both the idempotent race and the genuine-failure path.
+id_source: "generated"
+---
+## Summary
+
+Make merged worktree cleanup idempotent
+
+Post-merge follow-up for v0.6.26: if a hook already removed the task worktree/branch, integration cleanup must treat that as completed instead of exiting non-zero after a successful merge.
+
+## Scope
+
+- In scope: Post-merge follow-up for v0.6.26: if a hook already removed the task worktree/branch, integration cleanup must treat that as completed instead of exiting non-zero after a successful merge.
+- Out of scope: unrelated refactors not required for "Make merged worktree cleanup idempotent".
+
+## Plan
+
+1. Create an isolated post-merge worktree from the maintenance base. 2. Make merged worktree cleanup tolerate a worktree/branch already removed by the post-merge hook while preserving unexpected errors. 3. Add the exact regression and run focused tests, typecheck, format, lint, and release fast gate. 4. Open a maintenance PR, wait for hosted checks, and integrate through the serialized lane.
+
+## Verify Steps
+
+1. `bun run test:project agentplane packages/agentplane/src/commands/shared/merged-branch-cleanup.test.ts packages/agentplane/src/commands/pr/integrate/cmd.test.ts`
+   Expected: cleanup treats an already removed hook-owned worktree as complete and still surfaces genuine failures while registered.
+2. `bun run typecheck`
+   Expected: TypeScript build passes.
+3. `bun run format:check`
+   Expected: repository formatting passes.
+4. `bun run lint:core`
+   Expected: core lint passes.
+5. `bun run release:prepublish:fast`
+   Expected: release gates pass for v0.6.26.
+
+## Verification
+
+<!-- BEGIN VERIFICATION RESULTS -->
+<!-- END VERIFICATION RESULTS -->
+
+## Rollback Plan
+
+- Revert task-related commit(s).
+- Re-run required checks to confirm rollback safety.
+
+## Findings
+
+- Root cause: `cleanupMergedLocalBranch` trusted a stale `worktreePathHint` after the post-merge hook had already removed both worktree and branch, then treated `git worktree remove` exit 128 as a new integration failure.
+- Resolution: re-check branch worktree registration after a cleanup exception; suppress only the already-removed race and rethrow when the worktree remains registered.
+- Regression coverage includes both the idempotent race and the genuine-failure path.

--- a/.agentplane/tasks/202607311529-773BXT/README.md
+++ b/.agentplane/tasks/202607311529-773BXT/README.md
@@ -4,7 +4,7 @@ title: "Make merged worktree cleanup idempotent"
 status: "DOING"
 priority: "high"
 owner: "CODER"
-revision: 6
+revision: 8
 origin:
   system: "manual"
 depends_on: []
@@ -21,11 +21,27 @@ plan_approval:
   updated_by: "ORCHESTRATOR"
   note: null
 verification:
-  state: "pending"
-  updated_at: null
-  updated_by: null
-  note: null
+  state: "ok"
+  updated_at: "2026-07-31T15:34:37.171Z"
+  updated_by: "CODER"
+  note: "20 focused cleanup/integration tests passed; typecheck, format, lint:core, and release:prepublish:fast passed."
   attempts: 0
+quality_review:
+  state: "pass"
+  updated_at: "2026-07-31T15:34:38.864Z"
+  updated_by: "EVALUATOR"
+  note: "Merged-worktree cleanup race is idempotent without hiding genuine failures."
+  evaluated_sha: "13509c41f93a7d600c25e11adc5a7aa3d2894c14"
+  blueprint_digest: "71d0efdc00c7dce41dfc166c3fcaf5e17dc441f74153342906a8da2e40fc6af7"
+  evidence_refs:
+    - ".agentplane/tasks/202607311529-773BXT/README.md"
+    - ".agentplane/tasks/202607311529-773BXT/quality/20260731-153438864-recovery-context/quality-report.json"
+    - ".agentplane/tasks/202607311529-773BXT/quality/20260731-153438864-recovery-context/evaluator-prompt.md"
+    - ".agentplane/tasks/202607311529-773BXT/quality/20260731-153438864-recovery-context/evaluator-opinion.md"
+    - ".agentplane/tasks/202607311529-773BXT/blueprint/resolved-snapshot.json"
+    - "packages/agentplane/src/commands/shared/merged-branch-cleanup.test.ts"
+  findings:
+    - "Regression coverage proves stale hints are accepted only after live registration disappears."
 commit: null
 comments:
   -
@@ -39,8 +55,14 @@ events:
     from: "TODO"
     to: "DOING"
     note: "Start: make merged worktree cleanup idempotent when post-merge hooks already removed the task worktree and branch."
+  -
+    type: "verify"
+    at: "2026-07-31T15:34:37.171Z"
+    author: "CODER"
+    state: "ok"
+    note: "20 focused cleanup/integration tests passed; typecheck, format, lint:core, and release:prepublish:fast passed."
 doc_version: 3
-doc_updated_at: "2026-07-31T15:34:00.883Z"
+doc_updated_at: "2026-07-31T15:34:37.370Z"
 doc_updated_by: "CODER"
 description: "Post-merge follow-up for v0.6.26: if a hook already removed the task worktree/branch, integration cleanup must treat that as completed instead of exiting non-zero after a successful merge."
 sections:
@@ -65,6 +87,36 @@ sections:
        Expected: release gates pass for v0.6.26.
   Verification: |-
     <!-- BEGIN VERIFICATION RESULTS -->
+    ### 2026-07-31T15:34:37.171Z — VERIFY — ok
+
+    By: CODER
+
+    Note: 20 focused cleanup/integration tests passed; typecheck, format, lint:core, and release:prepublish:fast passed.
+    Attempts: 0
+
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-07-31T15:34:00.883Z, excerpt_hash=sha256:a2694fba3c6dcdbf34fcfc853c1d4539d7f760370bae809be684266ea4cda9d5
+
+    Details:
+
+    BlueprintSnapshotRef:
+    - state: current
+    - path: /Users/densmirnov/Github/agentplane/.agentplane/tmp/v0625-release.eugTda/repo/.agentplane/worktrees/202607311529-773BXT-make-merged-worktree-cleanup-idempotent/.agentplane/tasks/202607311529-773BXT/blueprint/resolved-snapshot.json
+    - old_digest: 71d0efdc00c7dce41dfc166c3fcaf5e17dc441f74153342906a8da2e40fc6af7
+    - current_digest: 71d0efdc00c7dce41dfc166c3fcaf5e17dc441f74153342906a8da2e40fc6af7
+    - route_changed: no
+    - safe_command: agentplane blueprint snapshot 202607311529-773BXT
+
+    DecisionContextRef:
+    - operator_action: run_exact_argv
+    - can_execute_now: true
+    - safe_command: agentplane pr open 202607311529-773BXT --author CODER
+    - diagnostic_command: none
+    - source_of_truth: route=task_next_action diagnostic=task_next_action remote=not_checked
+    - freshness: route=computed_local remote=remote_skipped
+    - repeat_allowed: true
+    - repeat_stop_condition: after any non-zero exit or completed mutation, recompute task next-action before a second step
+    - risks: git_hook_side_effect
+
     <!-- END VERIFICATION RESULTS -->
   Rollback Plan: |-
     - Revert task-related commit(s).
@@ -73,6 +125,10 @@ sections:
     - Root cause: `cleanupMergedLocalBranch` trusted a stale `worktreePathHint` after the post-merge hook had already removed both worktree and branch, then treated `git worktree remove` exit 128 as a new integration failure.
     - Resolution: re-check branch worktree registration after a cleanup exception; suppress only the already-removed race and rethrow when the worktree remains registered.
     - Regression coverage includes both the idempotent race and the genuine-failure path.
+
+    - Observation: Post-merge hook cleanup can race with integration cleanup and remove the hinted worktree first.
+      Impact: A successful merge returned exit 4/E_IO, misleading the agent into treating completed integration as failed.
+      Resolution: After cleanup errors, re-check live worktree registration; accept the already-removed state and rethrow genuine registered-worktree failures.
 id_source: "generated"
 ---
 ## Summary
@@ -106,6 +162,36 @@ Post-merge follow-up for v0.6.26: if a hook already removed the task worktree/br
 ## Verification
 
 <!-- BEGIN VERIFICATION RESULTS -->
+### 2026-07-31T15:34:37.171Z — VERIFY — ok
+
+By: CODER
+
+Note: 20 focused cleanup/integration tests passed; typecheck, format, lint:core, and release:prepublish:fast passed.
+Attempts: 0
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-07-31T15:34:00.883Z, excerpt_hash=sha256:a2694fba3c6dcdbf34fcfc853c1d4539d7f760370bae809be684266ea4cda9d5
+
+Details:
+
+BlueprintSnapshotRef:
+- state: current
+- path: /Users/densmirnov/Github/agentplane/.agentplane/tmp/v0625-release.eugTda/repo/.agentplane/worktrees/202607311529-773BXT-make-merged-worktree-cleanup-idempotent/.agentplane/tasks/202607311529-773BXT/blueprint/resolved-snapshot.json
+- old_digest: 71d0efdc00c7dce41dfc166c3fcaf5e17dc441f74153342906a8da2e40fc6af7
+- current_digest: 71d0efdc00c7dce41dfc166c3fcaf5e17dc441f74153342906a8da2e40fc6af7
+- route_changed: no
+- safe_command: agentplane blueprint snapshot 202607311529-773BXT
+
+DecisionContextRef:
+- operator_action: run_exact_argv
+- can_execute_now: true
+- safe_command: agentplane pr open 202607311529-773BXT --author CODER
+- diagnostic_command: none
+- source_of_truth: route=task_next_action diagnostic=task_next_action remote=not_checked
+- freshness: route=computed_local remote=remote_skipped
+- repeat_allowed: true
+- repeat_stop_condition: after any non-zero exit or completed mutation, recompute task next-action before a second step
+- risks: git_hook_side_effect
+
 <!-- END VERIFICATION RESULTS -->
 
 ## Rollback Plan
@@ -118,3 +204,7 @@ Post-merge follow-up for v0.6.26: if a hook already removed the task worktree/br
 - Root cause: `cleanupMergedLocalBranch` trusted a stale `worktreePathHint` after the post-merge hook had already removed both worktree and branch, then treated `git worktree remove` exit 128 as a new integration failure.
 - Resolution: re-check branch worktree registration after a cleanup exception; suppress only the already-removed race and rethrow when the worktree remains registered.
 - Regression coverage includes both the idempotent race and the genuine-failure path.
+
+- Observation: Post-merge hook cleanup can race with integration cleanup and remove the hinted worktree first.
+  Impact: A successful merge returned exit 4/E_IO, misleading the agent into treating completed integration as failed.
+  Resolution: After cleanup errors, re-check live worktree registration; accept the already-removed state and rethrow genuine registered-worktree failures.

--- a/.agentplane/tasks/202607311529-773BXT/README.md
+++ b/.agentplane/tasks/202607311529-773BXT/README.md
@@ -1,10 +1,11 @@
 ---
 id: "202607311529-773BXT"
 title: "Make merged worktree cleanup idempotent"
-status: "DOING"
+result_summary: "pre-merge closure"
+status: "DONE"
 priority: "high"
 owner: "CODER"
-revision: 8
+revision: 9
 origin:
   system: "manual"
 depends_on: []
@@ -42,11 +43,16 @@ quality_review:
     - "packages/agentplane/src/commands/shared/merged-branch-cleanup.test.ts"
   findings:
     - "Regression coverage proves stale hints are accepted only after live registration disappears."
-commit: null
+commit:
+  hash: "44e61b7c3b28bfaf4ac9323c3f5f8eaaa4996eeb"
+  message: "✅ 773BXT task: record verification"
 comments:
   -
     author: "CODER"
     body: "Start: make merged worktree cleanup idempotent when post-merge hooks already removed the task worktree and branch."
+  -
+    author: "CODER"
+    body: "Verified: pre-merge closure packet is ready for the task PR."
 events:
   -
     type: "status"
@@ -61,8 +67,15 @@ events:
     author: "CODER"
     state: "ok"
     note: "20 focused cleanup/integration tests passed; typecheck, format, lint:core, and release:prepublish:fast passed."
+  -
+    type: "status"
+    at: "2026-07-31T15:35:31.045Z"
+    author: "CODER"
+    from: "DOING"
+    to: "DONE"
+    note: "Verified: pre-merge closure packet is ready for the task PR."
 doc_version: 3
-doc_updated_at: "2026-07-31T15:34:37.370Z"
+doc_updated_at: "2026-07-31T15:35:31.047Z"
 doc_updated_by: "CODER"
 description: "Post-merge follow-up for v0.6.26: if a hook already removed the task worktree/branch, integration cleanup must treat that as completed instead of exiting non-zero after a successful merge."
 sections:
@@ -129,6 +142,10 @@ sections:
     - Observation: Post-merge hook cleanup can race with integration cleanup and remove the hinted worktree first.
       Impact: A successful merge returned exit 4/E_IO, misleading the agent into treating completed integration as failed.
       Resolution: After cleanup errors, re-check live worktree registration; accept the already-removed state and rethrow genuine registered-worktree failures.
+extensions:
+  implementation_commit:
+    hash: "13509c41f93a7d600c25e11adc5a7aa3d2894c14"
+    message: "🐛 773BXT post-merge: tolerate cleanup race"
 id_source: "generated"
 ---
 ## Summary

--- a/.agentplane/tasks/202607311529-773BXT/blueprint/resolved-snapshot.json
+++ b/.agentplane/tasks/202607311529-773BXT/blueprint/resolved-snapshot.json
@@ -1,0 +1,454 @@
+{
+  "schemaVersion": 1,
+  "artifactKind": "agentplane.blueprint.resolved_snapshot",
+  "resolverInput": {
+    "taskId": "202607311529-773BXT",
+    "title": "Make merged worktree cleanup idempotent",
+    "description": "Post-merge follow-up for v0.6.26: if a hook already removed the task worktree/branch, integration cleanup must treat that as completed instead of exiting non-zero after a successful merge.",
+    "tags": [
+      "post-merge",
+      "release"
+    ],
+    "owner": "CODER",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "mutation": "release",
+    "touchedPaths": [],
+    "recipeHints": [],
+    "riskFlags": []
+  },
+  "selectedBlueprint": {
+    "id": "release.strict",
+    "version": 1,
+    "title": "Strict release",
+    "taskKinds": [
+      "release"
+    ],
+    "workflowModes": [
+      "direct",
+      "branch_pr"
+    ]
+  },
+  "plan": {
+    "schemaVersion": 1,
+    "blueprintId": "release.strict",
+    "blueprintVersion": 1,
+    "title": "Strict release",
+    "taskId": "202607311529-773BXT",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "taskIntent": {
+      "mutationScope": "release"
+    },
+    "whySelected": [
+      "task kind resolved to release",
+      "workflow mode: branch_pr",
+      "mutation scope: release"
+    ],
+    "states": [
+      {
+        "id": "intake",
+        "kind": "intake",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": []
+      },
+      {
+        "id": "scope",
+        "kind": "scope",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "assumptions"
+        ]
+      },
+      {
+        "id": "approval_gate",
+        "kind": "approval_gate",
+        "mode": "approval",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "approval"
+        ]
+      },
+      {
+        "id": "context_resolve",
+        "kind": "context_resolve",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [
+          ".agentplane/policy/security.must.md",
+          ".agentplane/policy/dod.core.md",
+          ".agentplane/policy/dod.code.md",
+          ".agentplane/policy/workflow.release.md"
+        ],
+        "evidenceKinds": [
+          "context_manifest"
+        ]
+      },
+      {
+        "id": "work_unit",
+        "kind": "work_unit",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "artifact"
+        ]
+      },
+      {
+        "id": "deterministic_check",
+        "kind": "deterministic_check",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "publish_or_integrate",
+        "kind": "publish_or_integrate",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit",
+          "external_link"
+        ]
+      },
+      {
+        "id": "verify_record",
+        "kind": "verify_record",
+        "mode": "record",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "quality_gate",
+        "kind": "quality_gate",
+        "mode": "agentic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "quality_report"
+        ]
+      },
+      {
+        "id": "finish",
+        "kind": "finish",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit"
+        ]
+      }
+    ],
+    "requiredEvidence": [
+      {
+        "id": "release.approval",
+        "kind": "approval",
+        "producedBy": "approval_gate",
+        "required": true,
+        "description": "Release approval."
+      },
+      {
+        "id": "release.plan",
+        "kind": "artifact",
+        "producedBy": "work_unit",
+        "required": true,
+        "description": "Release plan or candidate artifact."
+      },
+      {
+        "id": "release.check",
+        "kind": "check_result",
+        "producedBy": "deterministic_check",
+        "required": true,
+        "description": "Release gates."
+      },
+      {
+        "id": "release.publish",
+        "kind": "external_link",
+        "producedBy": "publish_or_integrate",
+        "required": true,
+        "description": "Publish evidence."
+      },
+      {
+        "id": "release.commit",
+        "kind": "commit",
+        "producedBy": "publish_or_integrate",
+        "required": true,
+        "description": "Release commit."
+      },
+      {
+        "id": "release.quality",
+        "kind": "quality_report",
+        "producedBy": "quality_gate",
+        "required": true,
+        "description": "EVALUATOR quality verdict."
+      }
+    ],
+    "policyModules": [
+      ".agentplane/policy/dod.code.md",
+      ".agentplane/policy/dod.core.md",
+      ".agentplane/policy/security.must.md",
+      ".agentplane/policy/workflow.release.md"
+    ],
+    "allowedCommands": [
+      "agentplane task verify-show <task-id>",
+      "agentplane verify <task-id> --ok|--rework",
+      "publish commands after approval",
+      "release gates"
+    ],
+    "contextBudget": {
+      "maxPolicyModules": 4,
+      "maxPromptBlocks": 16,
+      "rationale": "Release work needs strict release policy, approval evidence, and rollback context."
+    },
+    "contextManifest": [],
+    "acceptedRecipeExtensions": [],
+    "rejectedRecipeExtensions": [],
+    "stopReasons": []
+  },
+  "nodes": [
+    {
+      "id": "intake",
+      "kind": "intake",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": []
+    },
+    {
+      "id": "scope",
+      "kind": "scope",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "assumptions"
+      ]
+    },
+    {
+      "id": "approval_gate",
+      "kind": "approval_gate",
+      "mode": "approval",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "approval"
+      ]
+    },
+    {
+      "id": "context_resolve",
+      "kind": "context_resolve",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [
+        ".agentplane/policy/security.must.md",
+        ".agentplane/policy/dod.core.md",
+        ".agentplane/policy/dod.code.md",
+        ".agentplane/policy/workflow.release.md"
+      ],
+      "evidenceKinds": [
+        "context_manifest"
+      ]
+    },
+    {
+      "id": "work_unit",
+      "kind": "work_unit",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "artifact"
+      ]
+    },
+    {
+      "id": "deterministic_check",
+      "kind": "deterministic_check",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "publish_or_integrate",
+      "kind": "publish_or_integrate",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit",
+        "external_link"
+      ]
+    },
+    {
+      "id": "verify_record",
+      "kind": "verify_record",
+      "mode": "record",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "quality_gate",
+      "kind": "quality_gate",
+      "mode": "agentic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "quality_report"
+      ]
+    },
+    {
+      "id": "finish",
+      "kind": "finish",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit"
+      ]
+    }
+  ],
+  "requiredEvidence": [
+    {
+      "id": "release.approval",
+      "kind": "approval",
+      "producedBy": "approval_gate",
+      "required": true,
+      "description": "Release approval."
+    },
+    {
+      "id": "release.plan",
+      "kind": "artifact",
+      "producedBy": "work_unit",
+      "required": true,
+      "description": "Release plan or candidate artifact."
+    },
+    {
+      "id": "release.check",
+      "kind": "check_result",
+      "producedBy": "deterministic_check",
+      "required": true,
+      "description": "Release gates."
+    },
+    {
+      "id": "release.publish",
+      "kind": "external_link",
+      "producedBy": "publish_or_integrate",
+      "required": true,
+      "description": "Publish evidence."
+    },
+    {
+      "id": "release.commit",
+      "kind": "commit",
+      "producedBy": "publish_or_integrate",
+      "required": true,
+      "description": "Release commit."
+    },
+    {
+      "id": "release.quality",
+      "kind": "quality_report",
+      "producedBy": "quality_gate",
+      "required": true,
+      "description": "EVALUATOR quality verdict."
+    }
+  ],
+  "policyModules": [
+    ".agentplane/policy/dod.code.md",
+    ".agentplane/policy/dod.core.md",
+    ".agentplane/policy/security.must.md",
+    ".agentplane/policy/workflow.release.md"
+  ],
+  "allowedCommands": [
+    "agentplane task verify-show <task-id>",
+    "agentplane verify <task-id> --ok|--rework",
+    "publish commands after approval",
+    "release gates"
+  ],
+  "contextBudget": {
+    "maxPolicyModules": 4,
+    "maxPromptBlocks": 16,
+    "rationale": "Release work needs strict release policy, approval evidence, and rollback context."
+  },
+  "contextManifest": [],
+  "acceptedRecipeExtensions": [],
+  "rejectedRecipeExtensions": [],
+  "stopReasons": [],
+  "selectionReasons": [
+    "task kind resolved to release",
+    "workflow mode: branch_pr",
+    "mutation scope: release"
+  ],
+  "digest": {
+    "algorithm": "sha256",
+    "value": "71d0efdc00c7dce41dfc166c3fcaf5e17dc441f74153342906a8da2e40fc6af7"
+  }
+}

--- a/.agentplane/tasks/202607311529-773BXT/pr/diffstat.txt
+++ b/.agentplane/tasks/202607311529-773BXT/pr/diffstat.txt
@@ -1,0 +1,3 @@
+ .../commands/shared/merged-branch-cleanup.test.ts  | 39 +++++++++++++++++
+ .../src/commands/shared/merged-branch-cleanup.ts   | 49 +++++++++++++---------
+ 2 files changed, 68 insertions(+), 20 deletions(-)

--- a/.agentplane/tasks/202607311529-773BXT/pr/github-body.md
+++ b/.agentplane/tasks/202607311529-773BXT/pr/github-body.md
@@ -1,0 +1,35 @@
+Task: `202607311529-773BXT`
+Title: Make merged worktree cleanup idempotent
+Canonical task record: `.agentplane/tasks/202607311529-773BXT/README.md`
+
+## Summary
+
+Make merged worktree cleanup idempotent
+
+Post-merge follow-up for v0.6.26: if a hook already removed the task worktree/branch, integration cleanup must treat that as completed instead of exiting non-zero after a successful merge.
+
+## Scope
+
+- In scope: Post-merge follow-up for v0.6.26: if a hook already removed the task worktree/branch, integration cleanup must treat that as completed instead of exiting non-zero after a successful merge.
+- Out of scope: unrelated refactors not required for "Make merged worktree cleanup idempotent".
+
+## Verification
+
+- State: pending
+- Note: Not recorded yet.
+- Canonical workflow state lives in the task README.
+
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-07-31T15:29:40.734Z
+- Branch: task/202607311529-773BXT/make-merged-worktree-cleanup-idempotent
+- Head: computed live by `agentplane pr check` / `agentplane integrate`
+
+```text
+ .../commands/shared/merged-branch-cleanup.test.ts  | 39 +++++++++++++++++
+ .../src/commands/shared/merged-branch-cleanup.ts   | 49 +++++++++++++---------
+ 2 files changed, 68 insertions(+), 20 deletions(-)
+```
+
+</details>

--- a/.agentplane/tasks/202607311529-773BXT/pr/github-body.md
+++ b/.agentplane/tasks/202607311529-773BXT/pr/github-body.md
@@ -22,7 +22,7 @@ Post-merge follow-up for v0.6.26: if a hook already removed the task worktree/br
 <details>
 <summary>Raw evidence</summary>
 
-- Updated: 2026-07-31T15:29:40.734Z
+- Updated: 2026-07-31T15:35:00.152Z
 - Branch: task/202607311529-773BXT/make-merged-worktree-cleanup-idempotent
 - Head: computed live by `agentplane pr check` / `agentplane integrate`
 

--- a/.agentplane/tasks/202607311529-773BXT/pr/github-body.md
+++ b/.agentplane/tasks/202607311529-773BXT/pr/github-body.md
@@ -15,8 +15,8 @@ Post-merge follow-up for v0.6.26: if a hook already removed the task worktree/br
 
 ## Verification
 
-- State: pending
-- Note: Not recorded yet.
+- State: ok
+- Note: 20 focused cleanup/integration tests passed; typecheck, format, lint:core, and release:prepublish:fast passed.
 - Canonical workflow state lives in the task README.
 
 <details>

--- a/.agentplane/tasks/202607311529-773BXT/pr/github-title.txt
+++ b/.agentplane/tasks/202607311529-773BXT/pr/github-title.txt
@@ -1,0 +1,1 @@
+🚧 773BXT task: Make merged worktree cleanup idempotent [202607311529-773BXT]

--- a/.agentplane/tasks/202607311529-773BXT/pr/github-title.txt
+++ b/.agentplane/tasks/202607311529-773BXT/pr/github-title.txt
@@ -1,1 +1,1 @@
-🚧 773BXT task: Make merged worktree cleanup idempotent [202607311529-773BXT]
+✅ 773BXT task: Make merged worktree cleanup idempotent [202607311529-773BXT]

--- a/.agentplane/tasks/202607311529-773BXT/pr/meta.json
+++ b/.agentplane/tasks/202607311529-773BXT/pr/meta.json
@@ -1,0 +1,13 @@
+{
+  "base": "codex/fix-v0.6.24-closeout-route",
+  "branch": "task/202607311529-773BXT/make-merged-worktree-cleanup-idempotent",
+  "created_at": "2026-07-31T15:29:40.734Z",
+  "diffstat_sha256": "sha256:bc73bfbf840291dfd4e92407fa633bb4327ebe126a9a666e5f095c3e99801995",
+  "last_verified_at": null,
+  "schema_version": 1,
+  "task_id": "202607311529-773BXT",
+  "updated_at": "2026-07-31T15:29:40.734Z",
+  "verify": {
+    "status": "skipped"
+  }
+}

--- a/.agentplane/tasks/202607311529-773BXT/pr/meta.json
+++ b/.agentplane/tasks/202607311529-773BXT/pr/meta.json
@@ -5,9 +5,19 @@
   "diffstat_sha256": "sha256:bc73bfbf840291dfd4e92407fa633bb4327ebe126a9a666e5f095c3e99801995",
   "last_verified_at": "2026-07-31T15:34:37.171Z",
   "last_verified_diffstat_sha256": "sha256:bc73bfbf840291dfd4e92407fa633bb4327ebe126a9a666e5f095c3e99801995",
+  "pr_number": 4707,
+  "pr_url": "https://github.com/basilisk-labs/agentplane/pull/4707",
+  "pre_merge_closure": {
+    "basis_commit": "44e61b7c3b28bfaf4ac9323c3f5f8eaaa4996eeb",
+    "branch": "task/202607311529-773BXT/make-merged-worktree-cleanup-idempotent",
+    "pr_number": 4707,
+    "recorded_at": "2026-07-31T15:35:31.094Z",
+    "state": "closed_before_merge"
+  },
   "schema_version": 1,
+  "status": "OPEN",
   "task_id": "202607311529-773BXT",
-  "updated_at": "2026-07-31T15:29:40.734Z",
+  "updated_at": "2026-07-31T15:35:00.152Z",
   "verify": {
     "status": "pass"
   }

--- a/.agentplane/tasks/202607311529-773BXT/pr/meta.json
+++ b/.agentplane/tasks/202607311529-773BXT/pr/meta.json
@@ -3,11 +3,12 @@
   "branch": "task/202607311529-773BXT/make-merged-worktree-cleanup-idempotent",
   "created_at": "2026-07-31T15:29:40.734Z",
   "diffstat_sha256": "sha256:bc73bfbf840291dfd4e92407fa633bb4327ebe126a9a666e5f095c3e99801995",
-  "last_verified_at": null,
+  "last_verified_at": "2026-07-31T15:34:37.171Z",
+  "last_verified_diffstat_sha256": "sha256:bc73bfbf840291dfd4e92407fa633bb4327ebe126a9a666e5f095c3e99801995",
   "schema_version": 1,
   "task_id": "202607311529-773BXT",
   "updated_at": "2026-07-31T15:29:40.734Z",
   "verify": {
-    "status": "skipped"
+    "status": "pass"
   }
 }

--- a/.agentplane/tasks/202607311529-773BXT/pr/review.md
+++ b/.agentplane/tasks/202607311529-773BXT/pr/review.md
@@ -1,0 +1,38 @@
+# PR Review
+
+Created: 2026-07-31T15:29:40.734Z
+
+## Task
+
+- Task: `202607311529-773BXT`
+- Title: Make merged worktree cleanup idempotent
+- Status: DOING
+- Branch: `task/202607311529-773BXT/make-merged-worktree-cleanup-idempotent`
+- Canonical task record: `.agentplane/tasks/202607311529-773BXT/README.md`
+
+## Verification
+
+- State: pending
+- Note: Not recorded yet.
+- Canonical workflow state lives in the task README.
+
+## Handoff Notes
+
+- No handoff notes recorded yet. Use `agentplane pr note ...` to append one.
+
+<!-- BEGIN AUTO SUMMARY -->
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-07-31T15:29:40.734Z
+- Branch: task/202607311529-773BXT/make-merged-worktree-cleanup-idempotent
+- Head: computed live by `agentplane pr check` / `agentplane integrate`
+
+```text
+ .../commands/shared/merged-branch-cleanup.test.ts  | 39 +++++++++++++++++
+ .../src/commands/shared/merged-branch-cleanup.ts   | 49 +++++++++++++---------
+ 2 files changed, 68 insertions(+), 20 deletions(-)
+```
+
+</details>
+<!-- END AUTO SUMMARY -->

--- a/.agentplane/tasks/202607311529-773BXT/pr/review.md
+++ b/.agentplane/tasks/202607311529-773BXT/pr/review.md
@@ -12,8 +12,8 @@ Created: 2026-07-31T15:29:40.734Z
 
 ## Verification
 
-- State: pending
-- Note: Not recorded yet.
+- State: ok
+- Note: 20 focused cleanup/integration tests passed; typecheck, format, lint:core, and release:prepublish:fast passed.
 - Canonical workflow state lives in the task README.
 
 ## Handoff Notes

--- a/.agentplane/tasks/202607311529-773BXT/pr/review.md
+++ b/.agentplane/tasks/202607311529-773BXT/pr/review.md
@@ -6,7 +6,7 @@ Created: 2026-07-31T15:29:40.734Z
 
 - Task: `202607311529-773BXT`
 - Title: Make merged worktree cleanup idempotent
-- Status: DOING
+- Status: DONE
 - Branch: `task/202607311529-773BXT/make-merged-worktree-cleanup-idempotent`
 - Canonical task record: `.agentplane/tasks/202607311529-773BXT/README.md`
 
@@ -24,7 +24,7 @@ Created: 2026-07-31T15:29:40.734Z
 <details>
 <summary>Raw evidence</summary>
 
-- Updated: 2026-07-31T15:29:40.734Z
+- Updated: 2026-07-31T15:35:00.152Z
 - Branch: task/202607311529-773BXT/make-merged-worktree-cleanup-idempotent
 - Head: computed live by `agentplane pr check` / `agentplane integrate`
 

--- a/.agentplane/tasks/202607311529-773BXT/quality/20260731-153438864-recovery-context/evaluator-opinion.md
+++ b/.agentplane/tasks/202607311529-773BXT/quality/20260731-153438864-recovery-context/evaluator-opinion.md
@@ -1,0 +1,19 @@
+# EVALUATOR opinion: pass
+
+Merged-worktree cleanup race is idempotent without hiding genuine failures.
+
+## Findings
+- Regression coverage proves stale hints are accepted only after live registration disappears.
+
+## Evidence
+- .agentplane/tasks/202607311529-773BXT/README.md
+- packages/agentplane/src/commands/shared/merged-branch-cleanup.test.ts
+
+## Missing Tests
+- none recorded
+
+## Hidden Assumptions
+- none recorded
+
+## Residual Risks
+- none recorded

--- a/.agentplane/tasks/202607311529-773BXT/quality/20260731-153438864-recovery-context/evaluator-prompt.md
+++ b/.agentplane/tasks/202607311529-773BXT/quality/20260731-153438864-recovery-context/evaluator-prompt.md
@@ -1,0 +1,74 @@
+# AgentPlane EVALUATOR quality review
+
+Use the evaluator module below as binding review procedure.
+Do not edit implementation files. Inspect task scope, diff, verification evidence, and residual risk.
+Write the final structured review to the report path as JSON matching the requested report shape.
+
+- task_id: 202607311529-773BXT
+- task_readme: .agentplane/tasks/202607311529-773BXT/README.md
+- report_path: .agentplane/tasks/202607311529-773BXT/quality/20260731-153438864-recovery-context/quality-report.json
+
+Required report fields:
+- verdict: pass | rework | blocked | human_review
+- summary: concise judgement
+- findings: non-empty list for pass/rework/blocked
+- evidence_refs: concrete files, checks, PRs, traces, or reports inspected
+- missing_tests: tests or checks that should exist but do not
+- hidden_assumptions: assumptions the implementation relies on
+- residual_risks: known remaining risks
+
+## Evaluator module
+
+---
+id: recovery-context
+title: Recovery Context Invariant Review
+version: 1
+status: preview
+profile: EVALUATOR
+tags:
+  - recovery
+  - invariants
+  - concurrency
+---
+
+# Recovery Context Invariant Review
+
+Use this evaluator only when the primary implementation path already produced a concrete change or when recovery context is needed after an interruption.
+
+## Inputs
+
+- Task id, task README, approved plan, and Verify Steps.
+- Current diff or PR patch.
+- Relevant comments, review findings, incidents, and recovery/handoff context.
+- Known concurrent-agent activity and task-artifact drift classification, if present.
+
+## Review Procedure
+
+1. Reconstruct the intended contract from the task, not from the implementation summary.
+2. Compare the diff against explicit invariants, stop rules, negative cases, and user constraints.
+3. Check whether recovery context changes the interpretation of the task or exposes stale assumptions.
+4. Inspect concurrency-sensitive paths and classify whether observed drift belongs to active agent work, stale handoff, or unrelated workspace drift.
+5. Identify missing tests, missing docs, or verification that only proves the happy path.
+6. Do not execute fixes. Return review findings only.
+7. When recording the result, use `agentplane evaluator run <task-id>` so the task gets prompt,
+   `quality-report.json`, and opinion artifacts. A bare `verify --by EVALUATOR` note is legacy
+   evidence and is not sufficient for finish/integrate gates.
+
+## Output
+
+Return a concise structured review:
+
+- `verdict`: `pass`, `rework`, `blocked`, or `human_review`.
+- `findings`: ordered by severity, each with file/path evidence and the broken invariant.
+- `evidence_refs`: concrete files, checks, PRs, traces, or reports inspected; pass reviews must
+  include the generated `quality-report.json`.
+- `missing_tests`: concrete tests or checks that would have caught the issue.
+- `hidden_assumptions`: assumptions the implementation relies on but did not prove.
+- `residual_risks`: known risks after the review.
+- `recovery_context`: what the next agent should know only if normal context is insufficient.
+
+## Stop Rules
+
+- Use `blocked` when required task context, diff, or recovery context is missing.
+- Use `rework` when behavior diverges from the approved contract even if local checks pass.
+- Use `pass` only when the implementation and verification evidence cover positive, negative, and concurrency-sensitive paths relevant to the task.

--- a/.agentplane/tasks/202607311529-773BXT/quality/20260731-153438864-recovery-context/quality-report.json
+++ b/.agentplane/tasks/202607311529-773BXT/quality/20260731-153438864-recovery-context/quality-report.json
@@ -1,0 +1,21 @@
+{
+  "schema_version": 1,
+  "task_id": "202607311529-773BXT",
+  "evaluator_id": "recovery-context",
+  "evaluator_profile": "EVALUATOR",
+  "generated_at": "2026-07-31T15:34:38.864Z",
+  "verdict": "pass",
+  "summary": "Merged-worktree cleanup race is idempotent without hiding genuine failures.",
+  "evaluated_sha": "13509c41f93a7d600c25e11adc5a7aa3d2894c14",
+  "blueprint_digest": "71d0efdc00c7dce41dfc166c3fcaf5e17dc441f74153342906a8da2e40fc6af7",
+  "findings": [
+    "Regression coverage proves stale hints are accepted only after live registration disappears."
+  ],
+  "evidence_refs": [
+    ".agentplane/tasks/202607311529-773BXT/README.md",
+    "packages/agentplane/src/commands/shared/merged-branch-cleanup.test.ts"
+  ],
+  "missing_tests": [],
+  "hidden_assumptions": [],
+  "residual_risks": []
+}

--- a/packages/agentplane/src/commands/shared/merged-branch-cleanup.test.ts
+++ b/packages/agentplane/src/commands/shared/merged-branch-cleanup.test.ts
@@ -105,6 +105,45 @@ describe("commands/shared/merged-branch-cleanup", () => {
     );
   });
 
+  it("treats a stale worktree hint already removed by a hook as cleaned up", async () => {
+    const { cleanupMergedLocalBranch } = await import("./merged-branch-cleanup.js");
+    mocks.gitBranchExists.mockResolvedValue(false);
+    mocks.execFileAsync.mockRejectedValueOnce(new Error("not a working tree"));
+
+    const result = await cleanupMergedLocalBranch({
+      gitRoot: "/repo",
+      branch: "task/T-6",
+      worktreePathHint: "/repo/.agentplane/worktrees/task-T6",
+    });
+
+    expect(result).toEqual({
+      removedBranch: false,
+      removedWorktree: false,
+      worktreePath: "/repo/.agentplane/worktrees/task-T6",
+      skippedReason: null,
+      preservedDirtyState: false,
+      stashMessage: null,
+    });
+    expect(mocks.findWorktreeForBranch).toHaveBeenCalledTimes(2);
+    expect(mocks.execFileAsync).toHaveBeenCalledTimes(1);
+  });
+
+  it("preserves a cleanup failure while the worktree is still registered", async () => {
+    const { cleanupMergedLocalBranch } = await import("./merged-branch-cleanup.js");
+    mocks.findWorktreeForBranch
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce("/repo/.agentplane/worktrees/task-T7");
+    mocks.execFileAsync.mockRejectedValueOnce(new Error("permission denied"));
+
+    await expect(
+      cleanupMergedLocalBranch({
+        gitRoot: "/repo",
+        branch: "task/T-7",
+        worktreePathHint: "/repo/.agentplane/worktrees/task-T7",
+      }),
+    ).rejects.toThrow("permission denied");
+  });
+
   it("skips cleanup when the branch worktree lives outside the repo", async () => {
     const { cleanupMergedLocalBranch } = await import("./merged-branch-cleanup.js");
     mocks.findWorktreeForBranch.mockResolvedValue("/tmp/agentplane-external-worktree");

--- a/packages/agentplane/src/commands/shared/merged-branch-cleanup.ts
+++ b/packages/agentplane/src/commands/shared/merged-branch-cleanup.ts
@@ -45,31 +45,40 @@ export async function cleanupMergedLocalBranch(opts: {
         stashMessage: null,
       };
     }
-    if (opts.preserveDirty === true) {
-      const { stdout } = await execFileAsync(
-        "git",
-        ["status", "--porcelain", "--untracked-files=all"],
-        {
-          cwd: worktreePath,
-          env: gitEnv(),
-        },
-      );
-      if (stdout.trim()) {
-        stashMessage = `agentplane/cleanup-preserve:${opts.branch}`;
-        await execFileAsync("git", ["stash", "push", "-u", "-m", stashMessage], {
-          cwd: worktreePath,
-          env: gitEnv(),
-        });
+    let removedWorktree = false;
+    try {
+      if (opts.preserveDirty === true) {
+        const { stdout } = await execFileAsync(
+          "git",
+          ["status", "--porcelain", "--untracked-files=all"],
+          {
+            cwd: worktreePath,
+            env: gitEnv(),
+          },
+        );
+        if (stdout.trim()) {
+          stashMessage = `agentplane/cleanup-preserve:${opts.branch}`;
+          await execFileAsync("git", ["stash", "push", "-u", "-m", stashMessage], {
+            cwd: worktreePath,
+            env: gitEnv(),
+          });
+        }
+      }
+      await execFileAsync("git", ["worktree", "remove", "--force", worktreePath], {
+        cwd: opts.gitRoot,
+        env: gitEnv(),
+      });
+      removedWorktree = true;
+    } catch (error) {
+      const stillRegistered = await findWorktreeForBranch(opts.gitRoot, opts.branch);
+      if (stillRegistered) {
+        throw error;
       }
     }
-    await execFileAsync("git", ["worktree", "remove", "--force", worktreePath], {
-      cwd: opts.gitRoot,
-      env: gitEnv(),
-    });
     const removed = await removeBranch(opts.gitRoot, opts.branch);
     return {
       removedBranch: removed,
-      removedWorktree: true,
+      removedWorktree,
       worktreePath,
       skippedReason: null,
       preservedDirtyState: stashMessage !== null,


### PR DESCRIPTION
Task: `202607311529-773BXT`
Title: Make merged worktree cleanup idempotent
Canonical task record: `.agentplane/tasks/202607311529-773BXT/README.md`

## Summary

Make merged worktree cleanup idempotent

Post-merge follow-up for v0.6.26: if a hook already removed the task worktree/branch, integration cleanup must treat that as completed instead of exiting non-zero after a successful merge.

## Scope

- In scope: Post-merge follow-up for v0.6.26: if a hook already removed the task worktree/branch, integration cleanup must treat that as completed instead of exiting non-zero after a successful merge.
- Out of scope: unrelated refactors not required for "Make merged worktree cleanup idempotent".

## Verification

- State: ok
- Note: 20 focused cleanup/integration tests passed; typecheck, format, lint:core, and release:prepublish:fast passed.
- Canonical workflow state lives in the task README.

<details>
<summary>Raw evidence</summary>

- Updated: 2026-07-31T15:29:40.734Z
- Branch: task/202607311529-773BXT/make-merged-worktree-cleanup-idempotent
- Head: computed live by `agentplane pr check` / `agentplane integrate`

```text
 .../commands/shared/merged-branch-cleanup.test.ts  | 39 +++++++++++++++++
 .../src/commands/shared/merged-branch-cleanup.ts   | 49 +++++++++++++---------
 2 files changed, 68 insertions(+), 20 deletions(-)
```

</details>
