### PR TITLE
🚧 2M6168 task: Make task episode plans lossless and language-neutral [202608111010-2M6168]

### DIFF
--- a/.agentplane/tasks/202608111010-2M6168/README.md
+++ b/.agentplane/tasks/202608111010-2M6168/README.md
@@ -1,0 +1,142 @@
+---
+id: "202608111010-2M6168"
+title: "Make task episode plans lossless and language-neutral"
+status: "DOING"
+priority: "high"
+owner: "CODER"
+revision: 5
+origin:
+  system: "manual"
+depends_on: []
+tags:
+  - "code"
+  - "ux"
+task_kind: "code"
+mutation_scope: "code"
+blueprint_request: "code.branch_pr"
+verify:
+  - "bun run test:fast"
+  - "bun run typecheck"
+  - "bun test packages/agentplane/src/runner/context/task-context.test.ts"
+plan_approval:
+  state: "approved"
+  updated_at: "2026-08-11T10:10:56.971Z"
+  updated_by: "ORCHESTRATOR"
+  note: null
+verification:
+  state: "pending"
+  updated_at: null
+  updated_by: null
+  note: null
+  attempts: 0
+execution_route:
+  frozen: true
+  reason_codes:
+    - "repository_branch_pr_floor"
+  repository_mode: "branch_pr"
+  requested_mode: "branch_pr"
+  schema_version: 1
+  selected_mode: "branch_pr"
+commit:
+  hash: "931302565dd84e0381e7d4b2cb827563c9eb525e"
+  message: "🚧 2M6168 task: preserve required plan context"
+comments:
+  -
+    author: "CODER"
+    body: "Start: continue branch_pr task in the dedicated task worktree."
+  -
+    author: "CODER"
+    body: "Implementation committed: required task sections now use a language-neutral 64 KiB per-section ceiling with a separate aggregate budget; optional context remains compacted. Focused tests, typecheck, and test:fast pass."
+events:
+  -
+    type: "status"
+    at: "2026-08-11T10:11:16.127Z"
+    author: "CODER"
+    from: "TODO"
+    to: "DOING"
+    note: "Start: continue branch_pr task in the dedicated task worktree."
+  -
+    type: "status"
+    at: "2026-08-11T10:14:20.573Z"
+    author: "CODER"
+    from: "DOING"
+    to: "DOING"
+    note: "Implementation committed: required task sections now use a language-neutral 64 KiB per-section ceiling with a separate aggregate budget; optional context remains compacted. Focused tests, typecheck, and test:fast pass."
+    commit: "931302565dd84e0381e7d4b2cb827563c9eb525e"
+doc_version: 3
+doc_updated_at: "2026-08-11T10:14:20.573Z"
+doc_updated_by: "CODER"
+description: "Prevent valid user-authored Plan sections from blocking task brief, next-action, or advance. Preserve the task-selected language, keep full Plan content authoritative, and compact only optional context without mutating lifecycle state."
+sections:
+  Summary: |-
+    Make task episode plans lossless and language-neutral
+
+    Prevent valid user-authored Plan sections from blocking task brief, next-action, or advance. Preserve the task-selected language, keep full Plan content authoritative, and compact only optional context without mutating lifecycle state.
+  Scope: |-
+    - In scope: Prevent valid user-authored Plan sections from blocking task brief, next-action, or advance. Preserve the task-selected language, keep full Plan content authoritative, and compact only optional context without mutating lifecycle state.
+    - Out of scope: unrelated refactors not required for "Make task episode plans lossless and language-neutral".
+  Plan: |-
+    1. Raise the TaskEpisodeView required-section budget to a practical lossless ceiling without enforcing any language.
+    2. Keep the complete Plan authoritative and fail clearly only when the documented ceiling is exceeded; compact optional context first.
+    3. Add regression coverage for plans above the former 3072-byte boundary, including multilingual content and the existing CI task size.
+    4. Verify focused tests, typecheck, and the fast suite; document any residual packet-size tradeoff.
+  Verify Steps: |-
+    PLANNER fallback scaffold. Replace with task-specific acceptance checks when PLANNER context is available.
+
+    1. Run `bun test packages/agentplane/src/runner/context/task-context.test.ts`. Expected: it succeeds and confirms the requested outcome for this task.
+    2. Run `bun run typecheck`. Expected: it succeeds and confirms the requested outcome for this task.
+    3. Run `bun run test:fast`. Expected: it succeeds and confirms the requested outcome for this task.
+    4. Review the changed artifact or behavior for the `code` task. Expected: the requested outcome is visible and matches the approved scope.
+    5. Compare the final result against the task summary and touched scope. Expected: remaining follow-up is either resolved or explicit in ## Findings.
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: ""
+extensions:
+  workflow_route_baseline:
+    start_head_sha: "4fb274243d45470a2c9bb23ae0c939206bacf326"
+    version: 1
+id_source: "generated"
+---
+## Summary
+
+Make task episode plans lossless and language-neutral
+
+Prevent valid user-authored Plan sections from blocking task brief, next-action, or advance. Preserve the task-selected language, keep full Plan content authoritative, and compact only optional context without mutating lifecycle state.
+
+## Scope
+
+- In scope: Prevent valid user-authored Plan sections from blocking task brief, next-action, or advance. Preserve the task-selected language, keep full Plan content authoritative, and compact only optional context without mutating lifecycle state.
+- Out of scope: unrelated refactors not required for "Make task episode plans lossless and language-neutral".
+
+## Plan
+
+1. Raise the TaskEpisodeView required-section budget to a practical lossless ceiling without enforcing any language.
+2. Keep the complete Plan authoritative and fail clearly only when the documented ceiling is exceeded; compact optional context first.
+3. Add regression coverage for plans above the former 3072-byte boundary, including multilingual content and the existing CI task size.
+4. Verify focused tests, typecheck, and the fast suite; document any residual packet-size tradeoff.
+
+## Verify Steps
+
+PLANNER fallback scaffold. Replace with task-specific acceptance checks when PLANNER context is available.
+
+1. Run `bun test packages/agentplane/src/runner/context/task-context.test.ts`. Expected: it succeeds and confirms the requested outcome for this task.
+2. Run `bun run typecheck`. Expected: it succeeds and confirms the requested outcome for this task.
+3. Run `bun run test:fast`. Expected: it succeeds and confirms the requested outcome for this task.
+4. Review the changed artifact or behavior for the `code` task. Expected: the requested outcome is visible and matches the approved scope.
+5. Compare the final result against the task summary and touched scope. Expected: remaining follow-up is either resolved or explicit in ## Findings.
+
+## Verification
+
+<!-- BEGIN VERIFICATION RESULTS -->
+<!-- END VERIFICATION RESULTS -->
+
+## Rollback Plan
+
+- Revert task-related commit(s).
+- Re-run required checks to confirm rollback safety.
+
+## Findings

--- a/.agentplane/tasks/202608111010-2M6168/blueprint/resolved-snapshot.json
+++ b/.agentplane/tasks/202608111010-2M6168/blueprint/resolved-snapshot.json
@@ -1,0 +1,578 @@
+{
+  "schemaVersion": 1,
+  "artifactKind": "agentplane.blueprint.resolved_snapshot",
+  "resolverInput": {
+    "taskId": "202608111010-2M6168",
+    "title": "Make task episode plans lossless and language-neutral",
+    "description": "Prevent valid user-authored Plan sections from blocking task brief, next-action, or advance. Preserve the task-selected language, keep full Plan content authoritative, and compact only optional context without mutating lifecycle state.",
+    "tags": [
+      "code",
+      "ux"
+    ],
+    "owner": "CODER",
+    "taskKind": "code",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "mutation": "code",
+    "mutationScope": "code",
+    "touchedPaths": [],
+    "recipeHints": [],
+    "riskFlags": [],
+    "blueprintRequest": "code.branch_pr"
+  },
+  "selectedBlueprint": {
+    "id": "code.branch_pr",
+    "version": 1,
+    "title": "Branch PR code change",
+    "taskKinds": [
+      "code"
+    ],
+    "workflowModes": [
+      "branch_pr"
+    ]
+  },
+  "plan": {
+    "schemaVersion": 1,
+    "blueprintId": "code.branch_pr",
+    "blueprintVersion": 1,
+    "title": "Branch PR code change",
+    "taskId": "202608111010-2M6168",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "taskIntent": {
+      "taskKind": "code",
+      "mutationScope": "code",
+      "blueprintRequest": "code.branch_pr"
+    },
+    "whySelected": [
+      "explicit blueprint requested: code.branch_pr",
+      "task intent kind: code",
+      "workflow mode: branch_pr",
+      "task intent mutation scope: code"
+    ],
+    "states": [
+      {
+        "id": "intake",
+        "kind": "intake",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": []
+      },
+      {
+        "id": "scope",
+        "kind": "scope",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "assumptions"
+        ]
+      },
+      {
+        "id": "approval_gate",
+        "kind": "approval_gate",
+        "mode": "approval",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "approval"
+        ]
+      },
+      {
+        "id": "context_resolve",
+        "kind": "context_resolve",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [
+          ".agentplane/policy/security.must.md",
+          ".agentplane/policy/dod.core.md",
+          ".agentplane/policy/dod.code.md",
+          ".agentplane/policy/workflow.branch_pr.md"
+        ],
+        "evidenceKinds": [
+          "context_manifest"
+        ]
+      },
+      {
+        "id": "worktree_start",
+        "kind": "worktree_start",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "work_unit",
+        "kind": "work_unit",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "fast_local_checks",
+        "kind": "fast_local_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane task verify-show <task-id>",
+          "project focused checks"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "pr_artifact",
+        "kind": "pr_artifact",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "artifact",
+          "external_link"
+        ]
+      },
+      {
+        "id": "verify_record",
+        "kind": "verify_record",
+        "mode": "record",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "quality_gate",
+        "kind": "quality_gate",
+        "mode": "agentic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane evaluator run <task-id> --provenance human_supplied|evaluator_supplied --verdict pass|rework|blocked|human_review"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "quality_report"
+        ]
+      },
+      {
+        "id": "hosted_checks",
+        "kind": "hosted_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result",
+          "external_link"
+        ]
+      },
+      {
+        "id": "publish_or_integrate",
+        "kind": "publish_or_integrate",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane integrate <task-id> --branch <branch> --run-verify"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit",
+          "external_link"
+        ]
+      },
+      {
+        "id": "finish",
+        "kind": "finish",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit"
+        ]
+      }
+    ],
+    "requiredEvidence": [
+      {
+        "id": "code_pr.paths",
+        "kind": "changed_paths",
+        "producedBy": "work_unit",
+        "required": true,
+        "description": "Changed source paths."
+      },
+      {
+        "id": "code_pr.fast_checks",
+        "kind": "check_result",
+        "producedBy": "fast_local_checks",
+        "required": true,
+        "description": "Fast local checks."
+      },
+      {
+        "id": "code_pr.pr",
+        "kind": "external_link",
+        "producedBy": "pr_artifact",
+        "required": true,
+        "description": "Pull request artifact."
+      },
+      {
+        "id": "code_pr.verify",
+        "kind": "check_result",
+        "producedBy": "verify_record",
+        "required": true,
+        "description": "Task branch verification."
+      },
+      {
+        "id": "code_pr.quality",
+        "kind": "quality_report",
+        "producedBy": "quality_gate",
+        "required": true,
+        "description": "EVALUATOR quality verdict."
+      },
+      {
+        "id": "code_pr.hosted",
+        "kind": "check_result",
+        "producedBy": "hosted_checks",
+        "required": true,
+        "description": "Hosted check evidence."
+      },
+      {
+        "id": "code_pr.commit",
+        "kind": "commit",
+        "producedBy": "publish_or_integrate",
+        "required": true,
+        "description": "Integration commit."
+      }
+    ],
+    "policyModules": [
+      ".agentplane/policy/dod.code.md",
+      ".agentplane/policy/dod.core.md",
+      ".agentplane/policy/security.must.md",
+      ".agentplane/policy/workflow.branch_pr.md"
+    ],
+    "allowedCommands": [
+      "agentplane evaluator run <task-id> --provenance human_supplied|evaluator_supplied --verdict pass|rework|blocked|human_review",
+      "agentplane integrate <task-id> --branch <branch> --run-verify",
+      "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+      "agentplane task verify-show <task-id>",
+      "agentplane verify <task-id> --ok|--rework",
+      "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+      "project focused checks"
+    ],
+    "contextBudget": {
+      "maxPolicyModules": 4,
+      "maxPromptBlocks": 14,
+      "rationale": "Branch PR code work needs code DoD, branch_pr route policy, and evidence checks."
+    },
+    "contextManifest": [],
+    "acceptedRecipeExtensions": [],
+    "rejectedRecipeExtensions": [],
+    "stopReasons": []
+  },
+  "nodes": [
+    {
+      "id": "intake",
+      "kind": "intake",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": []
+    },
+    {
+      "id": "scope",
+      "kind": "scope",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "assumptions"
+      ]
+    },
+    {
+      "id": "approval_gate",
+      "kind": "approval_gate",
+      "mode": "approval",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "approval"
+      ]
+    },
+    {
+      "id": "context_resolve",
+      "kind": "context_resolve",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [
+        ".agentplane/policy/security.must.md",
+        ".agentplane/policy/dod.core.md",
+        ".agentplane/policy/dod.code.md",
+        ".agentplane/policy/workflow.branch_pr.md"
+      ],
+      "evidenceKinds": [
+        "context_manifest"
+      ]
+    },
+    {
+      "id": "worktree_start",
+      "kind": "worktree_start",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "work_unit",
+      "kind": "work_unit",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "fast_local_checks",
+      "kind": "fast_local_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane task verify-show <task-id>",
+        "project focused checks"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "pr_artifact",
+      "kind": "pr_artifact",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "artifact",
+        "external_link"
+      ]
+    },
+    {
+      "id": "verify_record",
+      "kind": "verify_record",
+      "mode": "record",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "quality_gate",
+      "kind": "quality_gate",
+      "mode": "agentic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane evaluator run <task-id> --provenance human_supplied|evaluator_supplied --verdict pass|rework|blocked|human_review"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "quality_report"
+      ]
+    },
+    {
+      "id": "hosted_checks",
+      "kind": "hosted_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result",
+        "external_link"
+      ]
+    },
+    {
+      "id": "publish_or_integrate",
+      "kind": "publish_or_integrate",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane integrate <task-id> --branch <branch> --run-verify"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit",
+        "external_link"
+      ]
+    },
+    {
+      "id": "finish",
+      "kind": "finish",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit"
+      ]
+    }
+  ],
+  "requiredEvidence": [
+    {
+      "id": "code_pr.paths",
+      "kind": "changed_paths",
+      "producedBy": "work_unit",
+      "required": true,
+      "description": "Changed source paths."
+    },
+    {
+      "id": "code_pr.fast_checks",
+      "kind": "check_result",
+      "producedBy": "fast_local_checks",
+      "required": true,
+      "description": "Fast local checks."
+    },
+    {
+      "id": "code_pr.pr",
+      "kind": "external_link",
+      "producedBy": "pr_artifact",
+      "required": true,
+      "description": "Pull request artifact."
+    },
+    {
+      "id": "code_pr.verify",
+      "kind": "check_result",
+      "producedBy": "verify_record",
+      "required": true,
+      "description": "Task branch verification."
+    },
+    {
+      "id": "code_pr.quality",
+      "kind": "quality_report",
+      "producedBy": "quality_gate",
+      "required": true,
+      "description": "EVALUATOR quality verdict."
+    },
+    {
+      "id": "code_pr.hosted",
+      "kind": "check_result",
+      "producedBy": "hosted_checks",
+      "required": true,
+      "description": "Hosted check evidence."
+    },
+    {
+      "id": "code_pr.commit",
+      "kind": "commit",
+      "producedBy": "publish_or_integrate",
+      "required": true,
+      "description": "Integration commit."
+    }
+  ],
+  "policyModules": [
+    ".agentplane/policy/dod.code.md",
+    ".agentplane/policy/dod.core.md",
+    ".agentplane/policy/security.must.md",
+    ".agentplane/policy/workflow.branch_pr.md"
+  ],
+  "allowedCommands": [
+    "agentplane evaluator run <task-id> --provenance human_supplied|evaluator_supplied --verdict pass|rework|blocked|human_review",
+    "agentplane integrate <task-id> --branch <branch> --run-verify",
+    "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+    "agentplane task verify-show <task-id>",
+    "agentplane verify <task-id> --ok|--rework",
+    "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+    "project focused checks"
+  ],
+  "contextBudget": {
+    "maxPolicyModules": 4,
+    "maxPromptBlocks": 14,
+    "rationale": "Branch PR code work needs code DoD, branch_pr route policy, and evidence checks."
+  },
+  "contextManifest": [],
+  "acceptedRecipeExtensions": [],
+  "rejectedRecipeExtensions": [],
+  "stopReasons": [],
+  "selectionReasons": [
+    "explicit blueprint requested: code.branch_pr",
+    "task intent kind: code",
+    "workflow mode: branch_pr",
+    "task intent mutation scope: code"
+  ],
+  "digest": {
+    "algorithm": "sha256",
+    "value": "e1998251779afcf52f585b2292268c0c93731bf52a234f0025967c4c69a0340e"
+  }
+}

--- a/.agentplane/tasks/202608111010-2M6168/pr/diffstat.txt
+++ b/.agentplane/tasks/202608111010-2M6168/pr/diffstat.txt
@@ -1,0 +1,3 @@
+ .../src/runner/context/task-context.test.ts        | 50 +++++++++++++++++++++-
+ .../agentplane/src/runner/context/task-context.ts  | 27 ++++++++----
+ 2 files changed, 67 insertions(+), 10 deletions(-)

--- a/.agentplane/tasks/202608111010-2M6168/pr/github-body.md
+++ b/.agentplane/tasks/202608111010-2M6168/pr/github-body.md
@@ -1,0 +1,35 @@
+Task: `202608111010-2M6168`
+Title: Make task episode plans lossless and language-neutral
+Canonical task record: `.agentplane/tasks/202608111010-2M6168/README.md`
+
+## Summary
+
+Make task episode plans lossless and language-neutral
+
+Prevent valid user-authored Plan sections from blocking task brief, next-action, or advance. Preserve the task-selected language, keep full Plan content authoritative, and compact only optional context without mutating lifecycle state.
+
+## Scope
+
+- In scope: Prevent valid user-authored Plan sections from blocking task brief, next-action, or advance. Preserve the task-selected language, keep full Plan content authoritative, and compact only optional context without mutating lifecycle state.
+- Out of scope: unrelated refactors not required for "Make task episode plans lossless and language-neutral".
+
+## Verification
+
+- State: pending
+- Note: Not recorded yet.
+- Canonical workflow state lives in the task README.
+
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-08-11T10:11:16.241Z
+- Branch: task/202608111010-2M6168/make-task-episode-plans-lossless-and-language-ne
+- Head: computed live by `agentplane pr check` / `agentplane integrate`
+
+```text
+ .../src/runner/context/task-context.test.ts        | 50 +++++++++++++++++++++-
+ .../agentplane/src/runner/context/task-context.ts  | 27 ++++++++----
+ 2 files changed, 67 insertions(+), 10 deletions(-)
+```
+
+</details>

--- a/.agentplane/tasks/202608111010-2M6168/pr/github-title.txt
+++ b/.agentplane/tasks/202608111010-2M6168/pr/github-title.txt
@@ -1,0 +1,1 @@
+🚧 2M6168 task: Make task episode plans lossless and language-neutral [202608111010-2M6168]

--- a/.agentplane/tasks/202608111010-2M6168/pr/meta.json
+++ b/.agentplane/tasks/202608111010-2M6168/pr/meta.json
@@ -1,0 +1,13 @@
+{
+  "base": "main",
+  "branch": "task/202608111010-2M6168/make-task-episode-plans-lossless-and-language-ne",
+  "created_at": "2026-08-11T10:11:16.241Z",
+  "diffstat_sha256": "sha256:97010e11004b68698f4fa71529d095ba4636e941d6d3d2bcb0d1684871e0513c",
+  "last_verified_at": null,
+  "schema_version": 1,
+  "task_id": "202608111010-2M6168",
+  "updated_at": "2026-08-11T10:11:16.241Z",
+  "verify": {
+    "status": "skipped"
+  }
+}

--- a/.agentplane/tasks/202608111010-2M6168/pr/review.md
+++ b/.agentplane/tasks/202608111010-2M6168/pr/review.md
@@ -1,0 +1,38 @@
+# PR Review
+
+Created: 2026-08-11T10:11:16.241Z
+
+## Task
+
+- Task: `202608111010-2M6168`
+- Title: Make task episode plans lossless and language-neutral
+- Status: DOING
+- Branch: `task/202608111010-2M6168/make-task-episode-plans-lossless-and-language-ne`
+- Canonical task record: `.agentplane/tasks/202608111010-2M6168/README.md`
+
+## Verification
+
+- State: pending
+- Note: Not recorded yet.
+- Canonical workflow state lives in the task README.
+
+## Handoff Notes
+
+- No handoff notes recorded yet. Use `agentplane pr note ...` to append one.
+
+<!-- BEGIN AUTO SUMMARY -->
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-08-11T10:11:16.241Z
+- Branch: task/202608111010-2M6168/make-task-episode-plans-lossless-and-language-ne
+- Head: computed live by `agentplane pr check` / `agentplane integrate`
+
+```text
+ .../src/runner/context/task-context.test.ts        | 50 +++++++++++++++++++++-
+ .../agentplane/src/runner/context/task-context.ts  | 27 ++++++++----
+ 2 files changed, 67 insertions(+), 10 deletions(-)
+```
+
+</details>
+<!-- END AUTO SUMMARY -->

--- a/packages/agentplane/src/runner/context/task-context.test.ts
+++ b/packages/agentplane/src/runner/context/task-context.test.ts
@@ -238,7 +238,52 @@ describe("assembleRunnerTaskContext", () => {
     );
   });
 
-  it("fails with a structured issue instead of truncating a required section", async () => {
+  it("preserves a multilingual required Plan above the former 3072-byte limit", async () => {
+    const root = await mkGitRepoRoot();
+    await writeDefaultConfig(root);
+    await writeLocalBackendConfig(root);
+    const task = await createTask({
+      cwd: root,
+      rootOverride: root,
+      title: "Multilingual plan budget fixture",
+      description: "Exercise lossless required-section transport.",
+      owner: "CODER",
+      priority: "high",
+      tags: ["runner"],
+      dependsOn: [],
+      verify: [],
+    });
+    const ctx = await loadCommandContext({ cwd: root, rootOverride: root });
+    ctx.config.tasks.doc.required_sections = ["Plan"];
+    const loaded = await loadTaskFromContext({ ctx, taskId: task.id });
+    const plan = Array.from(
+      { length: 120 },
+      () => "Шаг: preserve the complete user decision.",
+    ).join("\n");
+    expect(Buffer.byteLength(plan, "utf8")).toBeGreaterThan(3072);
+    const sections = { ...(loaded.sections ?? {}), Plan: plan };
+    await ctx.taskBackend.writeTask({
+      ...loaded,
+      doc: renderTaskDocFromSections(sections),
+      sections,
+    });
+
+    const assembled = await assembleRunnerTaskContext({
+      ctx,
+      cwd: root,
+      rootOverride: root,
+      task_id: task.id,
+    });
+
+    expect(assembled.task.narrative.sections[0]).toEqual({
+      name: "Plan",
+      text: plan,
+      required: true,
+    });
+    expect(assembled.task.compaction.sections.truncated).toBe(false);
+  });
+
+  it("fails with a structured issue instead of truncating a required section above 64 KiB", async () => {
     const root = await mkGitRepoRoot();
     await writeDefaultConfig(root);
     await writeLocalBackendConfig(root);
@@ -256,7 +301,7 @@ describe("assembleRunnerTaskContext", () => {
     const ctx = await loadCommandContext({ cwd: root, rootOverride: root });
     ctx.config.tasks.doc.required_sections = ["Summary"];
     const loaded = await loadTaskFromContext({ ctx, taskId: task.id });
-    const sections = { ...(loaded.sections ?? {}), Summary: "required ".repeat(500) };
+    const sections = { ...(loaded.sections ?? {}), Summary: "required ".repeat(8000) };
     await ctx.taskBackend.writeTask({
       ...loaded,
       doc: renderTaskDocFromSections(sections),
@@ -270,6 +315,7 @@ describe("assembleRunnerTaskContext", () => {
       context: {
         reason_code: "task_episode_required_section_exceeds_budget",
         section: "Summary",
+        allowed_bytes: RUNNER_TASK_CONTEXT_BUDGETS.required_section_max_bytes,
       },
     });
   });

--- a/packages/agentplane/src/runner/context/task-context.ts
+++ b/packages/agentplane/src/runner/context/task-context.ts
@@ -30,8 +30,10 @@ const TRUNCATED_MARKER = "\n\n[TRUNCATED]";
 const VERIFICATION_RESULTS_BEGIN = "<!-- BEGIN VERIFICATION RESULTS -->";
 
 export const RUNNER_TASK_CONTEXT_BUDGETS = {
-  section_max_bytes: 3072,
-  sections_total_max_bytes: 20_480,
+  required_section_max_bytes: 65_536,
+  required_sections_total_max_bytes: 262_144,
+  optional_section_max_bytes: 3072,
+  optional_sections_total_max_bytes: 20_480,
   comments_max_count: 20,
   comment_body_max_bytes: 1024,
   comments_total_max_bytes: 12_288,
@@ -167,7 +169,10 @@ function compactSections(opts: {
     .filter(([section]) => !requiredByKey.has(sectionKey(section)))
     .map(([name, text]) => ({ name, text, required: false as const }));
   const originalEntries = [...requiredEntries, ...optionalEntries];
-  let remainingBudget: number = RUNNER_TASK_CONTEXT_BUDGETS.sections_total_max_bytes;
+  let remainingRequiredBudget: number =
+    RUNNER_TASK_CONTEXT_BUDGETS.required_sections_total_max_bytes;
+  let remainingOptionalBudget: number =
+    RUNNER_TASK_CONTEXT_BUDGETS.optional_sections_total_max_bytes;
   let truncated = false;
   const omissions: TaskEpisodeOmissionReceipt[] = [
     ...missing.map((section) => ({
@@ -185,7 +190,10 @@ function compactSections(opts: {
   for (const entry of originalEntries) {
     const textBytes = utf8Bytes(entry.text);
     if (entry.required) {
-      const allowedBytes = Math.min(RUNNER_TASK_CONTEXT_BUDGETS.section_max_bytes, remainingBudget);
+      const allowedBytes = Math.min(
+        RUNNER_TASK_CONTEXT_BUDGETS.required_section_max_bytes,
+        remainingRequiredBudget,
+      );
       if (textBytes > allowedBytes) {
         throw new CliError({
           code: "E_VALIDATION",
@@ -201,11 +209,11 @@ function compactSections(opts: {
           },
         });
       }
-      remainingBudget -= textBytes;
+      remainingRequiredBudget -= textBytes;
       compactedEntries.push(entry);
       continue;
     }
-    if (remainingBudget <= 0) {
+    if (remainingOptionalBudget <= 0) {
       truncated = true;
       omissions.push({
         section: entry.name,
@@ -214,10 +222,13 @@ function compactSections(opts: {
       });
       continue;
     }
-    const allowedBytes = Math.min(RUNNER_TASK_CONTEXT_BUDGETS.section_max_bytes, remainingBudget);
+    const allowedBytes = Math.min(
+      RUNNER_TASK_CONTEXT_BUDGETS.optional_section_max_bytes,
+      remainingOptionalBudget,
+    );
     const nextText = textBytes > allowedBytes ? truncateUtf8(entry.text, allowedBytes) : entry.text;
     if (nextText !== entry.text) truncated = true;
-    remainingBudget = Math.max(0, remainingBudget - utf8Bytes(nextText));
+    remainingOptionalBudget = Math.max(0, remainingOptionalBudget - utf8Bytes(nextText));
     compactedEntries.push({ ...entry, text: nextText });
   }
   return {

--- a/packages/agentplane/src/runner/context/task-context.ts
+++ b/packages/agentplane/src/runner/context/task-context.ts
@@ -32,8 +32,8 @@ const VERIFICATION_RESULTS_BEGIN = "<!-- BEGIN VERIFICATION RESULTS -->";
 export const RUNNER_TASK_CONTEXT_BUDGETS = {
   required_section_max_bytes: 65_536,
   required_sections_total_max_bytes: 262_144,
-  optional_section_max_bytes: 3072,
-  optional_sections_total_max_bytes: 20_480,
+  section_max_bytes: 3072,
+  sections_total_max_bytes: 20_480,
   comments_max_count: 20,
   comment_body_max_bytes: 1024,
   comments_total_max_bytes: 12_288,
@@ -171,8 +171,7 @@ function compactSections(opts: {
   const originalEntries = [...requiredEntries, ...optionalEntries];
   let remainingRequiredBudget: number =
     RUNNER_TASK_CONTEXT_BUDGETS.required_sections_total_max_bytes;
-  let remainingOptionalBudget: number =
-    RUNNER_TASK_CONTEXT_BUDGETS.optional_sections_total_max_bytes;
+  let remainingOptionalBudget: number = RUNNER_TASK_CONTEXT_BUDGETS.sections_total_max_bytes;
   let truncated = false;
   const omissions: TaskEpisodeOmissionReceipt[] = [
     ...missing.map((section) => ({
@@ -223,7 +222,7 @@ function compactSections(opts: {
       continue;
     }
     const allowedBytes = Math.min(
-      RUNNER_TASK_CONTEXT_BUDGETS.optional_section_max_bytes,
+      RUNNER_TASK_CONTEXT_BUDGETS.section_max_bytes,
       remainingOptionalBudget,
     );
     const nextText = textBytes > allowedBytes ? truncateUtf8(entry.text, allowedBytes) : entry.text;


### PR DESCRIPTION
Task: `202608111010-2M6168`
Title: Make task episode plans lossless and language-neutral
Canonical task record: `.agentplane/tasks/202608111010-2M6168/README.md`

## Summary

Make task episode plans lossless and language-neutral

Prevent valid user-authored Plan sections from blocking task brief, next-action, or advance. Preserve the task-selected language, keep full Plan content authoritative, and compact only optional context without mutating lifecycle state.

## Scope

- In scope: Prevent valid user-authored Plan sections from blocking task brief, next-action, or advance. Preserve the task-selected language, keep full Plan content authoritative, and compact only optional context without mutating lifecycle state.
- Out of scope: unrelated refactors not required for "Make task episode plans lossless and language-neutral".

## Verification

- State: pending
- Note: Not recorded yet.
- Canonical workflow state lives in the task README.

<details>
<summary>Raw evidence</summary>

- Updated: 2026-08-11T10:11:16.241Z
- Branch: task/202608111010-2M6168/make-task-episode-plans-lossless-and-language-ne
- Head: computed live by `agentplane pr check` / `agentplane integrate`

```text
 .../src/runner/context/task-context.test.ts        | 50 +++++++++++++++++++++-
 .../agentplane/src/runner/context/task-context.ts  | 27 ++++++++----
 2 files changed, 67 insertions(+), 10 deletions(-)
```

</details>
