### PR TITLE
Maintain minor version tags at the latest stable releases

### DIFF
--- a/.github/workflows/minor-tags.yml
+++ b/.github/workflows/minor-tags.yml
@@ -1,0 +1,35 @@
+name: Update minor version tags
+
+on:
+  workflow_run:
+    workflows: [Publish release]
+    types: [completed]
+  release:
+    types: [published]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: minor-version-tags
+  cancel-in-progress: false
+
+jobs:
+  update:
+    if: github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-24.04
+    steps:
+      # Always execute trusted default-branch code, including for historical releases.
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+      - name: Test minor tag updates
+        run: node --test scripts/release/update-minor-tags.test.mjs
+      - name: Update and verify minor aliases
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: node scripts/release/update-minor-tags.mjs --apply

--- a/scripts/release/update-minor-tags.mjs
+++ b/scripts/release/update-minor-tags.mjs
@@ -22,7 +22,7 @@ export function planMinorTags(releases, remoteOutput) {
   for (const release of releases) {
     if (release.draft || release.prerelease || !release.tag_name.startsWith("v")) continue;
     const version = parseReleaseSemver(release.tag_name.slice(1));
-    if (!version || version.prerelease.length || version.build.length) continue;
+    if (!version || version.prerelease.length > 0 || version.build.length > 0) continue;
     const series = `${version.major}.${version.minor}`;
     if (!latest.has(series) || version.patch > latest.get(series).patch) {
       latest.set(series, { patch: version.patch, tag: release.tag_name });
@@ -41,7 +41,7 @@ export function planMinorTags(releases, remoteOutput) {
 
 export function applyMinorTags(plan, git) {
   const updates = plan.filter(({ previous, sha }) => previous !== sha);
-  if (!updates.length) return;
+  if (updates.length === 0) return;
   // Exact leases reject a stale snapshot; atomic push prevents partial alias updates.
   git([
     "push",
@@ -72,7 +72,7 @@ const main = defineScript({
       applyMinorTags(plan, git);
       const observed = git(["ls-remote", "--tags", "origin"]);
       for (const { ref, sha } of plan) {
-        if (!observed.split(/\r?\n/u).some((line) => line === `${sha}\t${ref}`)) {
+        if (!observed.split(/\r?\n/u).includes(`${sha}\t${ref}`)) {
           throw new Error(`Remote alias verification failed: ${ref}`);
         }
       }

--- a/scripts/release/update-minor-tags.mjs
+++ b/scripts/release/update-minor-tags.mjs
@@ -1,0 +1,84 @@
+import { execFileSync } from "node:child_process";
+import { parseReleaseSemver } from "../lib/release-semver.mjs";
+import {
+  defineScript,
+  isDirectRun,
+  parseScriptArgs,
+  runScriptMain,
+} from "../lib/script-runtime.mjs";
+
+export function planMinorTags(releases, remoteOutput) {
+  const refs = new Map(
+    remoteOutput
+      .trim()
+      .split(/\r?\n/u)
+      .filter(Boolean)
+      .map((line) => {
+        const [sha, ref] = line.split(/\s+/u);
+        return [ref, sha];
+      }),
+  );
+  const latest = new Map();
+  for (const release of releases) {
+    if (release.draft || release.prerelease || !release.tag_name.startsWith("v")) continue;
+    const version = parseReleaseSemver(release.tag_name.slice(1));
+    if (!version || version.prerelease.length || version.build.length) continue;
+    const series = `${version.major}.${version.minor}`;
+    if (!latest.has(series) || version.patch > latest.get(series).patch) {
+      latest.set(series, { patch: version.patch, tag: release.tag_name });
+    }
+  }
+  return [...latest].flatMap(([series, { tag }]) => {
+    const fullRef = `refs/tags/${tag}`;
+    const sha = refs.get(`${fullRef}^{}`) ?? refs.get(fullRef);
+    if (!sha) throw new Error(`Published release tag is missing: ${tag}`);
+    return [series, `v${series}`].map((alias) => {
+      const ref = `refs/tags/${alias}`;
+      return { ref, sha, tag, previous: refs.get(ref) ?? "" };
+    });
+  });
+}
+
+export function applyMinorTags(plan, git) {
+  const updates = plan.filter(({ previous, sha }) => previous !== sha);
+  if (!updates.length) return;
+  // Exact leases reject a stale snapshot; atomic push prevents partial alias updates.
+  git([
+    "push",
+    "--atomic",
+    ...updates.map(({ ref, previous }) => `--force-with-lease=${ref}:${previous}`),
+    "origin",
+    ...updates.map(({ ref, sha }) => `${sha}:${ref}`),
+  ]);
+}
+
+const main = defineScript({
+  name: "update-minor-tags",
+  run({ argv, stdout }) {
+    const { flags } = parseScriptArgs(argv, { booleanFlags: ["apply"] });
+    const git = (args) => execFileSync("git", args, { encoding: "utf8" });
+    const pages = JSON.parse(
+      execFileSync("gh", ["api", "--paginate", "--slurp", "repos/{owner}/{repo}/releases"], {
+        encoding: "utf8",
+        maxBuffer: 32 * 1024 * 1024,
+      }),
+    );
+    const plan = planMinorTags(pages.flat(), git(["ls-remote", "--tags", "origin"]));
+    stdout.write(`${JSON.stringify(plan, null, 2)}\n`);
+    if (flags.apply) {
+      // Fetch objects without modifying existing local tag refs.
+      for (const sha of new Set(plan.map((entry) => entry.sha)))
+        git(["fetch", "--no-tags", "origin", sha]);
+      applyMinorTags(plan, git);
+      const observed = git(["ls-remote", "--tags", "origin"]);
+      for (const { ref, sha } of plan) {
+        if (!observed.split(/\r?\n/u).some((line) => line === `${sha}\t${ref}`)) {
+          throw new Error(`Remote alias verification failed: ${ref}`);
+        }
+      }
+      stdout.write(`Verified ${plan.length} minor aliases.\n`);
+    }
+  },
+});
+
+if (isDirectRun(import.meta.url)) runScriptMain(main);

--- a/scripts/release/update-minor-tags.test.mjs
+++ b/scripts/release/update-minor-tags.test.mjs
@@ -1,0 +1,82 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { test } from "node:test";
+import { applyMinorTags, planMinorTags } from "./update-minor-tags.mjs";
+const release = (tag_name, extra = {}) => ({ tag_name, draft: false, prerelease: false, ...extra });
+test("selects numeric stable patches and peels annotated tags", () => {
+  const plan = planMinorTags(
+    [
+      release("v0.6.27"),
+      release("v0.6.9"),
+      release("v0.6.28-beta.1"),
+      release("v0.6.29", { draft: true }),
+      release("v0.6.30", { prerelease: true }),
+      release("v0.7.8"),
+    ],
+    "aaa refs/tags/v0.6.27\nbbb refs/tags/v0.6.27^{}\nccc refs/tags/v0.7.8\n",
+  );
+  assert.deepEqual(
+    plan.map(({ ref, sha }) => [ref, sha]),
+    [
+      ["refs/tags/0.6", "bbb"],
+      ["refs/tags/v0.6", "bbb"],
+      ["refs/tags/0.7", "ccc"],
+      ["refs/tags/v0.7", "ccc"],
+    ],
+  );
+  assert.throws(() => planMinorTags([release("v0.6.27")], ""), /missing/u);
+});
+test("real Git creation, advancement, rerun and atomic stale rejection", () => {
+  const root = mkdtempSync(path.join(tmpdir(), "minor-tags-"));
+  const env = {
+    ...process.env,
+    GIT_AUTHOR_NAME: "Test",
+    GIT_AUTHOR_EMAIL: "test@example.invalid",
+    GIT_COMMITTER_NAME: "Test",
+    GIT_COMMITTER_EMAIL: "test@example.invalid",
+  };
+  const run = (args, cwd = root) =>
+    execFileSync("git", args, {
+      cwd,
+      env,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    }).trim();
+  try {
+    run(["init", "--bare", "remote.git"]);
+    run(["init", "local"]);
+    const git = (args) => run(args, path.join(root, "local"));
+    git(["remote", "add", "origin", path.join(root, "remote.git")]);
+    git(["-c", "core.hooksPath=/dev/null", "commit", "--allow-empty", "-m", "first"]);
+    const first = git(["rev-parse", "HEAD"]);
+    git(["tag", "-a", "v0.6.9", "-m", "annotated"]);
+    git(["push", "origin", "refs/tags/v0.6.9"]);
+    const plan = () =>
+      planMinorTags(
+        [release("v0.6.9"), ...(git(["tag", "--list", "v0.6.27"]) ? [release("v0.6.27")] : [])],
+        git(["ls-remote", "--tags", "origin"]),
+      );
+    applyMinorTags(plan(), git);
+    assert.match(git(["ls-remote", "origin", "refs/tags/0.6"]), new RegExp(first));
+    applyMinorTags(plan(), () => assert.fail("rerun must not push"));
+    git(["-c", "core.hooksPath=/dev/null", "commit", "--allow-empty", "-m", "second"]);
+    const second = git(["rev-parse", "HEAD"]);
+    git(["tag", "v0.6.27"]);
+    git(["push", "origin", "refs/tags/v0.6.27"]);
+    const stale = plan();
+    git(["-c", "core.hooksPath=/dev/null", "commit", "--allow-empty", "-m", "concurrent"]);
+    const concurrent = git(["rev-parse", "HEAD"]);
+    git(["push", "--force", "origin", `${concurrent}:refs/tags/0.6`]);
+    assert.throws(() => applyMinorTags(stale, git));
+    assert.match(git(["ls-remote", "origin", "refs/tags/v0.6"]), new RegExp(first));
+    applyMinorTags(plan(), git);
+    for (const alias of ["0.6", "v0.6"])
+      assert.match(git(["ls-remote", "origin", `refs/tags/${alias}`]), new RegExp(second));
+    assert.equal(git(["rev-parse", "v0.6.9^{}"]), first);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
Create and advance bare and v-prefixed minor aliases from published stable releases. A dedicated workflow runs after Publish release, release publication, or manual dispatch, using default-branch code for historical releases. Atomic pushes with exact leases protect concurrent updates; full version tags remain unchanged.

Validation: node --test scripts/release/update-minor-tags.test.mjs passed, including real Git creation, advancement, idempotency, annotated tags, and atomic stale-update rejection. All 14 current aliases were published and verified against GitHub; 0.6 and v0.6 resolve to v0.6.27. Task: 202609071412-9Q9KQN. The user explicitly authorized direct operation outside the stalled AgentPlane protocol.