### PR TITLE
Keep only v-prefixed minor version tags

### DIFF
--- a/scripts/release/update-minor-tags.mjs
+++ b/scripts/release/update-minor-tags.mjs
@@ -28,14 +28,12 @@ export function planMinorTags(releases, remoteOutput) {
       latest.set(series, { patch: version.patch, tag: release.tag_name });
     }
   }
-  return [...latest].flatMap(([series, { tag }]) => {
+  return [...latest].map(([series, { tag }]) => {
     const fullRef = `refs/tags/${tag}`;
     const sha = refs.get(`${fullRef}^{}`) ?? refs.get(fullRef);
     if (!sha) throw new Error(`Published release tag is missing: ${tag}`);
-    return [series, `v${series}`].map((alias) => {
-      const ref = `refs/tags/${alias}`;
-      return { ref, sha, tag, previous: refs.get(ref) ?? "" };
-    });
+    const ref = `refs/tags/v${series}`;
+    return { ref, sha, tag, previous: refs.get(ref) ?? "" };
   });
 }
 

--- a/scripts/release/update-minor-tags.test.mjs
+++ b/scripts/release/update-minor-tags.test.mjs
@@ -21,9 +21,7 @@ test("selects numeric stable patches and peels annotated tags", () => {
   assert.deepEqual(
     plan.map(({ ref, sha }) => [ref, sha]),
     [
-      ["refs/tags/0.6", "bbb"],
       ["refs/tags/v0.6", "bbb"],
-      ["refs/tags/0.7", "ccc"],
       ["refs/tags/v0.7", "ccc"],
     ],
   );
@@ -60,7 +58,7 @@ test("real Git creation, advancement, rerun and atomic stale rejection", () => {
         git(["ls-remote", "--tags", "origin"]),
       );
     applyMinorTags(plan(), git);
-    assert.match(git(["ls-remote", "origin", "refs/tags/0.6"]), new RegExp(first));
+    assert.match(git(["ls-remote", "origin", "refs/tags/v0.6"]), new RegExp(first));
     applyMinorTags(plan(), () => assert.fail("rerun must not push"));
     git(["-c", "core.hooksPath=/dev/null", "commit", "--allow-empty", "-m", "second"]);
     const second = git(["rev-parse", "HEAD"]);
@@ -69,11 +67,11 @@ test("real Git creation, advancement, rerun and atomic stale rejection", () => {
     const stale = plan();
     git(["-c", "core.hooksPath=/dev/null", "commit", "--allow-empty", "-m", "concurrent"]);
     const concurrent = git(["rev-parse", "HEAD"]);
-    git(["push", "--force", "origin", `${concurrent}:refs/tags/0.6`]);
+    git(["push", "--force", "origin", `${concurrent}:refs/tags/v0.6`]);
     assert.throws(() => applyMinorTags(stale, git));
-    assert.match(git(["ls-remote", "origin", "refs/tags/v0.6"]), new RegExp(first));
+    assert.match(git(["ls-remote", "origin", "refs/tags/v0.6"]), new RegExp(concurrent));
     applyMinorTags(plan(), git);
-    for (const alias of ["0.6", "v0.6"])
+    for (const alias of ["v0.6"])
       assert.match(git(["ls-remote", "origin", `refs/tags/${alias}`]), new RegExp(second));
     assert.equal(git(["rev-parse", "v0.6.9^{}"]), first);
   } finally {


### PR DESCRIPTION
Maintain one minor alias per series, v0.1 through v0.7, matching full release tag naming. Remove generation of bare aliases so the seven user-approved deletions will remain deleted. Full release tags remain unchanged.

Validation: focused Node tests, including real Git creation, advancement, reruns and stale-update rejection; ESLint and formatting passed. Continues task 202609071412-9Q9KQN under the approved direct operator route.