### PR TITLE
🚧 VN1FN4 task: reduce agent context and lifecycle overhead [202609071501-VN1FN4]

### DIFF
--- a/.agentplane/tasks/202609071501-VN1FN4/quality/objects/sha256/99d332e68d987a4eed07a0b25b6ed47cf0b520ad1424c7afcdc7d868dd2aa6a0.json
+++ b/.agentplane/tasks/202609071501-VN1FN4/quality/objects/sha256/99d332e68d987a4eed07a0b25b6ed47cf0b520ad1424c7afcdc7d868dd2aa6a0.json
@@ -1,0 +1,4621 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://agentplane.org/schemas/agent-semantic-result.schema.json",
+  "title": "Agent semantic result (v2)",
+  "description": "Agent-writable semantic output. Process, Git, filesystem, artifact, and observed check facts are intentionally excluded and remain supervisor-owned.",
+  "oneOf": [
+    {
+      "type": "object",
+      "properties": {
+        "schema_version": {
+          "type": "number",
+          "const": 2
+        },
+        "kind": {
+          "type": "string",
+          "const": "agent_semantic_result"
+        },
+        "work_order_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "summary": {
+          "type": "string",
+          "minLength": 1
+        },
+        "findings": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "uncertainty": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "task_intent": {
+          "type": "object",
+          "properties": {
+            "task_kind": {
+              "type": "string",
+              "enum": [
+                "analysis",
+                "content",
+                "docs",
+                "code",
+                "release",
+                "ops",
+                "context"
+              ]
+            },
+            "mutation_scope": {
+              "type": "string",
+              "enum": [
+                "none",
+                "docs",
+                "code",
+                "release",
+                "ops",
+                "context"
+              ]
+            },
+            "risk_flags": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "enum": [
+                  "network",
+                  "credentials",
+                  "deploy",
+                  "publish",
+                  "merge",
+                  "security",
+                  "external_system"
+                ]
+              }
+            },
+            "tags": {
+              "minItems": 1,
+              "type": "array",
+              "items": {
+                "type": "string",
+                "minLength": 1
+              }
+            },
+            "blueprint_request": {
+              "type": "string",
+              "enum": [
+                "analysis.light",
+                "content.light",
+                "docs.change",
+                "code.direct",
+                "code.branch_pr",
+                "performance.benchmark",
+                "quality.regression",
+                "context.assimilation",
+                "context.maximum_assimilation",
+                "post_run.improvement_review",
+                "release.strict",
+                "ops.approval"
+              ]
+            },
+            "execution": {
+              "anyOf": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "schema_version": {
+                      "type": "number",
+                      "const": 2
+                    },
+                    "preferred_mode": {
+                      "type": "string",
+                      "enum": [
+                        "direct",
+                        "branch_pr"
+                      ]
+                    },
+                    "scope_roots": {
+                      "type": "array",
+                      "items": {
+                        "type": "string",
+                        "minLength": 1
+                      }
+                    },
+                    "repository_effects": {
+                      "type": "array",
+                      "items": {
+                        "type": "string",
+                        "enum": [
+                          "repository_write",
+                          "documentation",
+                          "source_code",
+                          "tests",
+                          "public_api",
+                          "schema",
+                          "dependencies",
+                          "ci",
+                          "release_metadata",
+                          "security_boundary"
+                        ]
+                      }
+                    },
+                    "external_effects": {
+                      "type": "array",
+                      "items": {
+                        "type": "string",
+                        "enum": [
+                          "network_read",
+                          "external_write",
+                          "credentials",
+                          "publish",
+                          "deploy",
+                          "destructive_git"
+                        ]
+                      }
+                    },
+                    "reversibility": {
+                      "type": "string",
+                      "enum": [
+                        "reversible",
+                        "recovery_required",
+                        "irreversible"
+                      ]
+                    },
+                    "rationale": {
+                      "minItems": 1,
+                      "type": "array",
+                      "items": {
+                        "type": "string",
+                        "minLength": 1
+                      }
+                    },
+                    "requirements_uncertainty": {
+                      "type": "string",
+                      "enum": [
+                        "bounded",
+                        "material"
+                      ]
+                    },
+                    "implementation_uncertainty": {
+                      "type": "string",
+                      "enum": [
+                        "bounded",
+                        "material"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "schema_version",
+                    "preferred_mode",
+                    "scope_roots",
+                    "repository_effects",
+                    "external_effects",
+                    "reversibility",
+                    "rationale",
+                    "requirements_uncertainty",
+                    "implementation_uncertainty"
+                  ],
+                  "additionalProperties": false
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "schema_version": {
+                      "type": "number",
+                      "const": 1
+                    },
+                    "preferred_mode": {
+                      "type": "string",
+                      "enum": [
+                        "direct",
+                        "branch_pr"
+                      ]
+                    },
+                    "scope_roots": {
+                      "type": "array",
+                      "items": {
+                        "type": "string",
+                        "minLength": 1
+                      }
+                    },
+                    "repository_effects": {
+                      "type": "array",
+                      "items": {
+                        "type": "string",
+                        "enum": [
+                          "repository_write",
+                          "documentation",
+                          "source_code",
+                          "tests",
+                          "public_api",
+                          "schema",
+                          "dependencies",
+                          "ci",
+                          "release_metadata",
+                          "security_boundary"
+                        ]
+                      }
+                    },
+                    "external_effects": {
+                      "type": "array",
+                      "items": {
+                        "type": "string",
+                        "enum": [
+                          "network_read",
+                          "external_write",
+                          "credentials",
+                          "publish",
+                          "deploy",
+                          "destructive_git"
+                        ]
+                      }
+                    },
+                    "reversibility": {
+                      "type": "string",
+                      "enum": [
+                        "reversible",
+                        "recovery_required",
+                        "irreversible"
+                      ]
+                    },
+                    "rationale": {
+                      "minItems": 1,
+                      "type": "array",
+                      "items": {
+                        "type": "string",
+                        "minLength": 1
+                      }
+                    },
+                    "uncertainty": {
+                      "type": "string",
+                      "enum": [
+                        "bounded",
+                        "material"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "schema_version",
+                    "preferred_mode",
+                    "scope_roots",
+                    "repository_effects",
+                    "external_effects",
+                    "reversibility",
+                    "rationale",
+                    "uncertainty"
+                  ],
+                  "additionalProperties": false
+                }
+              ]
+            }
+          },
+          "required": [
+            "task_kind",
+            "mutation_scope",
+            "risk_flags",
+            "tags"
+          ],
+          "additionalProperties": false
+        },
+        "task_plan_proposal": {
+          "type": "object",
+          "properties": {
+            "schema_version": {
+              "type": "number",
+              "const": 1
+            },
+            "task_id": {
+              "type": "string",
+              "minLength": 1
+            },
+            "planning_baseline": {
+              "type": "object",
+              "properties": {
+                "schema_version": {
+                  "type": "number",
+                  "const": 1
+                },
+                "digest": {},
+                "git": {
+                  "oneOf": [
+                    {
+                      "type": "object",
+                      "properties": {
+                        "kind": {
+                          "type": "string",
+                          "const": "commit"
+                        },
+                        "sha": {
+                          "type": "string",
+                          "pattern": "^[0-9a-f]{40}$|^[0-9a-f]{64}$"
+                        },
+                        "ref": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
+                        }
+                      },
+                      "required": [
+                        "kind",
+                        "sha",
+                        "ref"
+                      ],
+                      "additionalProperties": false
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "kind": {
+                          "type": "string",
+                          "const": "unborn"
+                        },
+                        "ref": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
+                        }
+                      },
+                      "required": [
+                        "kind",
+                        "ref"
+                      ],
+                      "additionalProperties": false
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "kind": {
+                          "type": "string",
+                          "const": "unavailable"
+                        },
+                        "reason_code": {
+                          "type": "string",
+                          "minLength": 1
+                        },
+                        "detail": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "kind",
+                        "reason_code"
+                      ],
+                      "additionalProperties": false
+                    }
+                  ]
+                },
+                "dirty_paths": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "policy_digest": {
+                  "anyOf": [
+                    {},
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "config_digest": {
+                  "anyOf": [
+                    {},
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "context_digest": {
+                  "anyOf": [
+                    {},
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "task_history_cursor": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "captured_at": {
+                  "type": "string",
+                  "format": "date-time",
+                  "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z|([+-](?:[01]\\d|2[0-3]):[0-5]\\d)))$"
+                }
+              },
+              "required": [
+                "schema_version",
+                "digest",
+                "git",
+                "dirty_paths",
+                "policy_digest",
+                "config_digest",
+                "context_digest",
+                "task_history_cursor",
+                "captured_at"
+              ],
+              "additionalProperties": false
+            },
+            "work_items": {
+              "type": "object",
+              "properties": {
+                "schema_version": {
+                  "type": "number",
+                  "const": 1
+                },
+                "work_items": {
+                  "minItems": 1,
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "id": {
+                        "type": "string",
+                        "minLength": 1
+                      },
+                      "objective": {
+                        "type": "string",
+                        "minLength": 1
+                      },
+                      "depends_on": {
+                        "type": "array",
+                        "items": {
+                          "type": "string",
+                          "minLength": 1
+                        }
+                      },
+                      "required_inputs": {
+                        "type": "array",
+                        "items": {
+                          "type": "string",
+                          "minLength": 1
+                        }
+                      },
+                      "expected_outputs": {
+                        "type": "array",
+                        "items": {
+                          "type": "string",
+                          "minLength": 1
+                        }
+                      },
+                      "scope_roots": {
+                        "type": "array",
+                        "items": {
+                          "type": "string",
+                          "minLength": 1
+                        }
+                      },
+                      "acceptance_criteria": {
+                        "minItems": 1,
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "id": {
+                              "type": "string",
+                              "minLength": 1
+                            },
+                            "description": {
+                              "type": "string",
+                              "minLength": 1
+                            },
+                            "required": {
+                              "type": "boolean"
+                            },
+                            "check_ids": {
+                              "type": "array",
+                              "items": {
+                                "type": "string",
+                                "minLength": 1
+                              }
+                            }
+                          },
+                          "required": [
+                            "id",
+                            "description",
+                            "required",
+                            "check_ids"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "validation": {
+                        "type": "object",
+                        "properties": {
+                          "schema_version": {
+                            "type": "number",
+                            "const": 1
+                          },
+                          "criteria": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "id": {
+                                  "type": "string",
+                                  "minLength": 1
+                                },
+                                "description": {
+                                  "type": "string",
+                                  "minLength": 1
+                                },
+                                "required": {
+                                  "type": "boolean"
+                                },
+                                "check_ids": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string",
+                                    "minLength": 1
+                                  }
+                                }
+                              },
+                              "required": [
+                                "id",
+                                "description",
+                                "required",
+                                "check_ids"
+                              ],
+                              "additionalProperties": false
+                            }
+                          },
+                          "checks": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "id": {
+                                  "type": "string",
+                                  "minLength": 1
+                                },
+                                "kind": {
+                                  "type": "string",
+                                  "enum": [
+                                    "structural",
+                                    "deterministic",
+                                    "semantic",
+                                    "provider"
+                                  ]
+                                },
+                                "required": {
+                                  "type": "boolean"
+                                },
+                                "capability": {
+                                  "type": "string",
+                                  "minLength": 1
+                                },
+                                "command": {
+                                  "type": "string",
+                                  "minLength": 1
+                                },
+                                "timeout_ms": {
+                                  "type": "integer",
+                                  "exclusiveMinimum": 0,
+                                  "maximum": 9007199254740991
+                                }
+                              },
+                              "required": [
+                                "id",
+                                "kind",
+                                "required",
+                                "capability"
+                              ],
+                              "additionalProperties": false
+                            }
+                          },
+                          "evidence_fingerprint": {}
+                        },
+                        "required": [
+                          "schema_version",
+                          "criteria",
+                          "checks",
+                          "evidence_fingerprint"
+                        ],
+                        "additionalProperties": false
+                      },
+                      "context": {
+                        "type": "object",
+                        "properties": {
+                          "required_sources": {
+                            "type": "array",
+                            "items": {
+                              "type": "string",
+                              "minLength": 1
+                            }
+                          },
+                          "optional_sources": {
+                            "type": "array",
+                            "items": {
+                              "type": "string",
+                              "minLength": 1
+                            }
+                          },
+                          "symbol_hints": {
+                            "type": "array",
+                            "items": {
+                              "type": "string",
+                              "minLength": 1
+                            }
+                          },
+                          "max_bytes": {
+                            "type": "integer",
+                            "exclusiveMinimum": 0,
+                            "maximum": 9007199254740991
+                          }
+                        },
+                        "required": [
+                          "required_sources",
+                          "optional_sources",
+                          "symbol_hints",
+                          "max_bytes"
+                        ],
+                        "additionalProperties": false
+                      },
+                      "risk": {
+                        "type": "string",
+                        "enum": [
+                          "low",
+                          "medium",
+                          "high"
+                        ]
+                      },
+                      "capabilities": {
+                        "type": "array",
+                        "items": {
+                          "type": "string",
+                          "minLength": 1
+                        }
+                      },
+                      "resource_claims": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "kind": {
+                              "type": "string",
+                              "enum": [
+                                "path",
+                                "workspace",
+                                "provider_queue",
+                                "exclusive"
+                              ]
+                            },
+                            "resource": {
+                              "type": "string",
+                              "minLength": 1
+                            },
+                            "mode": {
+                              "type": "string",
+                              "enum": [
+                                "read",
+                                "write",
+                                "exclusive"
+                              ]
+                            }
+                          },
+                          "required": [
+                            "kind",
+                            "resource",
+                            "mode"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "optional": {
+                        "type": "boolean"
+                      },
+                      "priority": {
+                        "type": "integer",
+                        "minimum": -9007199254740991,
+                        "maximum": 9007199254740991
+                      }
+                    },
+                    "required": [
+                      "id",
+                      "objective",
+                      "depends_on",
+                      "required_inputs",
+                      "expected_outputs",
+                      "scope_roots",
+                      "acceptance_criteria",
+                      "validation",
+                      "context",
+                      "risk",
+                      "capabilities",
+                      "resource_claims",
+                      "optional",
+                      "priority"
+                    ],
+                    "additionalProperties": false
+                  }
+                }
+              },
+              "required": [
+                "schema_version",
+                "work_items"
+              ],
+              "additionalProperties": false
+            },
+            "assumptions": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "unresolved_questions": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "top_level_validation": {
+              "type": "object",
+              "properties": {
+                "schema_version": {
+                  "type": "number",
+                  "const": 1
+                },
+                "criteria": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "id": {
+                        "type": "string",
+                        "minLength": 1
+                      },
+                      "description": {
+                        "type": "string",
+                        "minLength": 1
+                      },
+                      "required": {
+                        "type": "boolean"
+                      },
+                      "check_ids": {
+                        "type": "array",
+                        "items": {
+                          "type": "string",
+                          "minLength": 1
+                        }
+                      }
+                    },
+                    "required": [
+                      "id",
+                      "description",
+                      "required",
+                      "check_ids"
+                    ],
+                    "additionalProperties": false
+                  }
+                },
+                "checks": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "id": {
+                        "type": "string",
+                        "minLength": 1
+                      },
+                      "kind": {
+                        "type": "string",
+                        "enum": [
+                          "structural",
+                          "deterministic",
+                          "semantic",
+                          "provider"
+                        ]
+                      },
+                      "required": {
+                        "type": "boolean"
+                      },
+                      "capability": {
+                        "type": "string",
+                        "minLength": 1
+                      },
+                      "command": {
+                        "type": "string",
+                        "minLength": 1
+                      },
+                      "timeout_ms": {
+                        "type": "integer",
+                        "exclusiveMinimum": 0,
+                        "maximum": 9007199254740991
+                      }
+                    },
+                    "required": [
+                      "id",
+                      "kind",
+                      "required",
+                      "capability"
+                    ],
+                    "additionalProperties": false
+                  }
+                },
+                "evidence_fingerprint": {}
+              },
+              "required": [
+                "schema_version",
+                "criteria",
+                "checks",
+                "evidence_fingerprint"
+              ],
+              "additionalProperties": false
+            }
+          },
+          "required": [
+            "schema_version",
+            "task_id",
+            "planning_baseline",
+            "work_items",
+            "assumptions",
+            "unresolved_questions",
+            "top_level_validation"
+          ],
+          "additionalProperties": false
+        },
+        "canonical_binding": {
+          "oneOf": [
+            {
+              "type": "object",
+              "properties": {
+                "task_id": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "repository_identity": {
+                  "type": "string",
+                  "pattern": "^sha256:[a-f0-9]{64}$"
+                },
+                "repository_fingerprint": {
+                  "type": "string",
+                  "pattern": "^sha256:[a-f0-9]{64}$"
+                },
+                "plan_revision": {
+                  "type": "integer",
+                  "minimum": 0,
+                  "maximum": 9007199254740991
+                },
+                "plan_digest": {
+                  "type": "string",
+                  "pattern": "^sha256:[a-f0-9]{64}$"
+                },
+                "phase": {
+                  "type": "string",
+                  "const": "planning"
+                }
+              },
+              "required": [
+                "task_id",
+                "repository_identity",
+                "repository_fingerprint",
+                "plan_revision",
+                "plan_digest",
+                "phase"
+              ],
+              "additionalProperties": false
+            },
+            {
+              "type": "object",
+              "properties": {
+                "task_id": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "repository_identity": {
+                  "type": "string",
+                  "pattern": "^sha256:[a-f0-9]{64}$"
+                },
+                "repository_fingerprint": {
+                  "type": "string",
+                  "pattern": "^sha256:[a-f0-9]{64}$"
+                },
+                "plan_revision": {
+                  "type": "integer",
+                  "minimum": 0,
+                  "maximum": 9007199254740991
+                },
+                "plan_digest": {
+                  "type": "string",
+                  "pattern": "^sha256:[a-f0-9]{64}$"
+                },
+                "phase": {
+                  "type": "string",
+                  "const": "implementation"
+                },
+                "work_item_id": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "attempt": {
+                  "type": "integer",
+                  "exclusiveMinimum": 0,
+                  "maximum": 9007199254740991
+                },
+                "claim_id": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "contract_digest": {
+                  "type": "string",
+                  "pattern": "^sha256:[a-f0-9]{64}$"
+                },
+                "authority_digest": {
+                  "type": "string",
+                  "pattern": "^sha256:[a-f0-9]{64}$"
+                }
+              },
+              "required": [
+                "task_id",
+                "repository_identity",
+                "repository_fingerprint",
+                "plan_revision",
+                "plan_digest",
+                "phase",
+                "work_item_id",
+                "attempt",
+                "claim_id",
+                "contract_digest",
+                "authority_digest"
+              ],
+              "additionalProperties": false
+            },
+            {
+              "type": "object",
+              "properties": {
+                "task_id": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "repository_identity": {
+                  "type": "string",
+                  "pattern": "^sha256:[a-f0-9]{64}$"
+                },
+                "repository_fingerprint": {
+                  "type": "string",
+                  "pattern": "^sha256:[a-f0-9]{64}$"
+                },
+                "plan_revision": {
+                  "type": "integer",
+                  "minimum": 0,
+                  "maximum": 9007199254740991
+                },
+                "plan_digest": {
+                  "type": "string",
+                  "pattern": "^sha256:[a-f0-9]{64}$"
+                },
+                "phase": {
+                  "type": "string",
+                  "const": "inspection"
+                },
+                "work_item_id": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "attempt": {
+                  "type": "integer",
+                  "exclusiveMinimum": 0,
+                  "maximum": 9007199254740991
+                },
+                "claim_id": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "contract_digest": {
+                  "type": "string",
+                  "pattern": "^sha256:[a-f0-9]{64}$"
+                },
+                "authority_digest": {
+                  "type": "string",
+                  "pattern": "^sha256:[a-f0-9]{64}$"
+                },
+                "result_digest": {
+                  "type": "string",
+                  "pattern": "^sha256:[a-f0-9]{64}$"
+                }
+              },
+              "required": [
+                "task_id",
+                "repository_identity",
+                "repository_fingerprint",
+                "plan_revision",
+                "plan_digest",
+                "phase",
+                "work_item_id",
+                "attempt",
+                "claim_id",
+                "contract_digest",
+                "authority_digest",
+                "result_digest"
+              ],
+              "additionalProperties": false
+            }
+          ]
+        },
+        "canonical_plan": {
+          "type": "object",
+          "properties": {
+            "work_items": {
+              "minItems": 1,
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "depends_on": {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "minLength": 1
+                    }
+                  },
+                  "required_inputs": {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "minLength": 1
+                    }
+                  },
+                  "expected_outputs": {
+                    "minItems": 1,
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "minLength": 1
+                    }
+                  },
+                  "execution_requirements": {
+                    "type": "object",
+                    "properties": {
+                      "scope_roots": {
+                        "type": "array",
+                        "items": {
+                          "type": "string",
+                          "minLength": 1
+                        }
+                      },
+                      "repository_effects": {
+                        "type": "array",
+                        "items": {
+                          "type": "string",
+                          "minLength": 1
+                        }
+                      },
+                      "external_effects": {
+                        "type": "array",
+                        "items": {
+                          "type": "string",
+                          "minLength": 1
+                        }
+                      },
+                      "capabilities": {
+                        "type": "array",
+                        "items": {
+                          "type": "string",
+                          "minLength": 1
+                        }
+                      },
+                      "resources": {
+                        "type": "array",
+                        "items": {
+                          "type": "string",
+                          "minLength": 1
+                        }
+                      }
+                    },
+                    "required": [
+                      "scope_roots",
+                      "repository_effects",
+                      "external_effects",
+                      "capabilities",
+                      "resources"
+                    ],
+                    "additionalProperties": false
+                  },
+                  "optional": {
+                    "type": "boolean"
+                  },
+                  "contract": {
+                    "type": "object",
+                    "properties": {
+                      "objective": {
+                        "type": "string",
+                        "minLength": 1
+                      },
+                      "acceptance_criteria": {
+                        "minItems": 1,
+                        "type": "array",
+                        "items": {
+                          "type": "string",
+                          "minLength": 1
+                        }
+                      },
+                      "verification_commands": {
+                        "type": "array",
+                        "items": {
+                          "type": "string",
+                          "minLength": 1
+                        }
+                      },
+                      "role": {
+                        "type": "string",
+                        "enum": [
+                          "PLANNER",
+                          "EXECUTOR",
+                          "EVALUATOR"
+                        ]
+                      }
+                    },
+                    "required": [
+                      "objective",
+                      "acceptance_criteria",
+                      "verification_commands",
+                      "role"
+                    ],
+                    "additionalProperties": false
+                  }
+                },
+                "required": [
+                  "id",
+                  "depends_on",
+                  "required_inputs",
+                  "expected_outputs",
+                  "execution_requirements",
+                  "optional",
+                  "contract"
+                ],
+                "additionalProperties": false
+              }
+            }
+          },
+          "required": [
+            "work_items"
+          ],
+          "additionalProperties": false
+        },
+        "canonical_outputs": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "string",
+                "minLength": 1
+              },
+              "kind": {
+                "type": "string",
+                "minLength": 1
+              },
+              "digest": {
+                "type": "string",
+                "pattern": "^sha256:[a-f0-9]{64}$"
+              }
+            },
+            "required": [
+              "id",
+              "kind",
+              "digest"
+            ],
+            "additionalProperties": false
+          }
+        },
+        "plan_refinement": {
+          "type": "object",
+          "properties": {
+            "description": {
+              "type": "string",
+              "minLength": 1
+            },
+            "scope_roots_added": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "minLength": 1
+              }
+            },
+            "outputs_added": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "minLength": 1
+              }
+            },
+            "acceptance_changed": {
+              "type": "boolean"
+            },
+            "risk_changed": {
+              "type": "boolean"
+            },
+            "external_effects_added": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "minLength": 1
+              }
+            },
+            "dependencies_changed": {
+              "type": "boolean"
+            },
+            "architecture_constraints_changed": {
+              "type": "boolean"
+            },
+            "operations": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "enum": [
+                  "split",
+                  "reorder",
+                  "add_test",
+                  "clarify"
+                ]
+              }
+            }
+          },
+          "required": [
+            "description",
+            "scope_roots_added",
+            "outputs_added",
+            "acceptance_changed",
+            "risk_changed",
+            "external_effects_added",
+            "dependencies_changed",
+            "architecture_constraints_changed",
+            "operations"
+          ],
+          "additionalProperties": false
+        },
+        "claimed_checks": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "check": {
+                "type": "string",
+                "minLength": 1
+              },
+              "claimed_status": {
+                "type": "string",
+                "enum": [
+                  "passed",
+                  "failed",
+                  "not_run"
+                ]
+              },
+              "details": {
+                "type": "string",
+                "minLength": 1
+              }
+            },
+            "required": [
+              "check",
+              "claimed_status"
+            ],
+            "additionalProperties": false
+          }
+        },
+        "review": {
+          "type": "object",
+          "properties": {
+            "verdict": {
+              "type": "string",
+              "enum": [
+                "pass",
+                "rework",
+                "blocked",
+                "human_review"
+              ]
+            },
+            "missing_tests": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "hidden_assumptions": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "residual_risks": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "recovery_context": {
+              "type": "string",
+              "minLength": 1
+            }
+          },
+          "required": [
+            "verdict",
+            "missing_tests",
+            "hidden_assumptions",
+            "residual_risks"
+          ],
+          "additionalProperties": false
+        },
+        "status": {
+          "type": "string",
+          "const": "blocked"
+        },
+        "blocker": {
+          "type": "object",
+          "properties": {
+            "summary": {
+              "type": "string",
+              "minLength": 1
+            },
+            "recommended_action": {
+              "type": "string",
+              "minLength": 1
+            },
+            "scope_extension_request": {
+              "anyOf": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "schema_version": {
+                      "type": "number",
+                      "const": 1
+                    },
+                    "rationale": {
+                      "type": "string",
+                      "minLength": 1
+                    },
+                    "scope_roots": {
+                      "minItems": 1,
+                      "type": "array",
+                      "items": {
+                        "type": "string",
+                        "minLength": 1
+                      }
+                    },
+                    "repository_effects": {
+                      "type": "array",
+                      "items": {
+                        "type": "string",
+                        "enum": [
+                          "repository_write",
+                          "documentation",
+                          "source_code",
+                          "tests",
+                          "public_api",
+                          "schema",
+                          "dependencies",
+                          "ci",
+                          "release_metadata",
+                          "security_boundary"
+                        ]
+                      }
+                    }
+                  },
+                  "required": [
+                    "schema_version",
+                    "rationale",
+                    "scope_roots",
+                    "repository_effects"
+                  ],
+                  "additionalProperties": false
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "schema_version": {
+                      "type": "number",
+                      "const": 1
+                    },
+                    "rationale": {
+                      "type": "string",
+                      "minLength": 1
+                    },
+                    "scope_roots": {
+                      "type": "array",
+                      "items": {
+                        "type": "string",
+                        "minLength": 1
+                      }
+                    },
+                    "repository_effects": {
+                      "minItems": 1,
+                      "type": "array",
+                      "items": {
+                        "type": "string",
+                        "enum": [
+                          "repository_write",
+                          "documentation",
+                          "source_code",
+                          "tests",
+                          "public_api",
+                          "schema",
+                          "dependencies",
+                          "ci",
+                          "release_metadata",
+                          "security_boundary"
+                        ]
+                      }
+                    }
+                  },
+                  "required": [
+                    "schema_version",
+                    "rationale",
+                    "scope_roots",
+                    "repository_effects"
+                  ],
+                  "additionalProperties": false
+                }
+              ]
+            }
+          },
+          "required": [
+            "summary"
+          ],
+          "additionalProperties": false
+        },
+        "knowledge_request": {
+          "type": "object",
+          "properties": {
+            "schema_version": {
+              "type": "number",
+              "const": 1
+            },
+            "kind": {
+              "type": "string",
+              "const": "knowledge_request"
+            },
+            "query": {
+              "type": "string",
+              "minLength": 1
+            },
+            "reason": {
+              "type": "string",
+              "minLength": 1
+            },
+            "desired_kind": {
+              "type": "string",
+              "enum": [
+                "any",
+                "wiki",
+                "source",
+                "fact",
+                "entity",
+                "edge"
+              ]
+            },
+            "scope": {
+              "type": "string",
+              "enum": [
+                "task_context"
+              ]
+            },
+            "blocking": {
+              "type": "boolean"
+            }
+          },
+          "required": [
+            "schema_version",
+            "kind",
+            "query",
+            "reason",
+            "desired_kind",
+            "scope",
+            "blocking"
+          ],
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "schema_version",
+        "kind",
+        "work_order_id",
+        "summary",
+        "findings",
+        "uncertainty",
+        "status",
+        "blocker"
+      ],
+      "additionalProperties": false
+    },
+    {
+      "type": "object",
+      "properties": {
+        "schema_version": {
+          "type": "number",
+          "const": 2
+        },
+        "kind": {
+          "type": "string",
+          "const": "agent_semantic_result"
+        },
+        "work_order_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "summary": {
+          "type": "string",
+          "minLength": 1
+        },
+        "findings": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "uncertainty": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "task_intent": {
+          "type": "object",
+          "properties": {
+            "task_kind": {
+              "type": "string",
+              "enum": [
+                "analysis",
+                "content",
+                "docs",
+                "code",
+                "release",
+                "ops",
+                "context"
+              ]
+            },
+            "mutation_scope": {
+              "type": "string",
+              "enum": [
+                "none",
+                "docs",
+                "code",
+                "release",
+                "ops",
+                "context"
+              ]
+            },
+            "risk_flags": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "enum": [
+                  "network",
+                  "credentials",
+                  "deploy",
+                  "publish",
+                  "merge",
+                  "security",
+                  "external_system"
+                ]
+              }
+            },
+            "tags": {
+              "minItems": 1,
+              "type": "array",
+              "items": {
+                "type": "string",
+                "minLength": 1
+              }
+            },
+            "blueprint_request": {
+              "type": "string",
+              "enum": [
+                "analysis.light",
+                "content.light",
+                "docs.change",
+                "code.direct",
+                "code.branch_pr",
+                "performance.benchmark",
+                "quality.regression",
+                "context.assimilation",
+                "context.maximum_assimilation",
+                "post_run.improvement_review",
+                "release.strict",
+                "ops.approval"
+              ]
+            },
+            "execution": {
+              "anyOf": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "schema_version": {
+                      "type": "number",
+                      "const": 2
+                    },
+                    "preferred_mode": {
+                      "type": "string",
+                      "enum": [
+                        "direct",
+                        "branch_pr"
+                      ]
+                    },
+                    "scope_roots": {
+                      "type": "array",
+                      "items": {
+                        "type": "string",
+                        "minLength": 1
+                      }
+                    },
+                    "repository_effects": {
+                      "type": "array",
+                      "items": {
+                        "type": "string",
+                        "enum": [
+                          "repository_write",
+                          "documentation",
+                          "source_code",
+                          "tests",
+                          "public_api",
+                          "schema",
+                          "dependencies",
+                          "ci",
+                          "release_metadata",
+                          "security_boundary"
+                        ]
+                      }
+                    },
+                    "external_effects": {
+                      "type": "array",
+                      "items": {
+                        "type": "string",
+                        "enum": [
+                          "network_read",
+                          "external_write",
+                          "credentials",
+                          "publish",
+                          "deploy",
+                          "destructive_git"
+                        ]
+                      }
+                    },
+                    "reversibility": {
+                      "type": "string",
+                      "enum": [
+                        "reversible",
+                        "recovery_required",
+                        "irreversible"
+                      ]
+                    },
+                    "rationale": {
+                      "minItems": 1,
+                      "type": "array",
+                      "items": {
+                        "type": "string",
+                        "minLength": 1
+                      }
+                    },
+                    "requirements_uncertainty": {
+                      "type": "string",
+                      "enum": [
+                        "bounded",
+                        "material"
+                      ]
+                    },
+                    "implementation_uncertainty": {
+                      "type": "string",
+                      "enum": [
+                        "bounded",
+                        "material"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "schema_version",
+                    "preferred_mode",
+                    "scope_roots",
+                    "repository_effects",
+                    "external_effects",
+                    "reversibility",
+                    "rationale",
+                    "requirements_uncertainty",
+                    "implementation_uncertainty"
+                  ],
+                  "additionalProperties": false
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "schema_version": {
+                      "type": "number",
+                      "const": 1
+                    },
+                    "preferred_mode": {
+                      "type": "string",
+                      "enum": [
+                        "direct",
+                        "branch_pr"
+                      ]
+                    },
+                    "scope_roots": {
+                      "type": "array",
+                      "items": {
+                        "type": "string",
+                        "minLength": 1
+                      }
+                    },
+                    "repository_effects": {
+                      "type": "array",
+                      "items": {
+                        "type": "string",
+                        "enum": [
+                          "repository_write",
+                          "documentation",
+                          "source_code",
+                          "tests",
+                          "public_api",
+                          "schema",
+                          "dependencies",
+                          "ci",
+                          "release_metadata",
+                          "security_boundary"
+                        ]
+                      }
+                    },
+                    "external_effects": {
+                      "type": "array",
+                      "items": {
+                        "type": "string",
+                        "enum": [
+                          "network_read",
+                          "external_write",
+                          "credentials",
+                          "publish",
+                          "deploy",
+                          "destructive_git"
+                        ]
+                      }
+                    },
+                    "reversibility": {
+                      "type": "string",
+                      "enum": [
+                        "reversible",
+                        "recovery_required",
+                        "irreversible"
+                      ]
+                    },
+                    "rationale": {
+                      "minItems": 1,
+                      "type": "array",
+                      "items": {
+                        "type": "string",
+                        "minLength": 1
+                      }
+                    },
+                    "uncertainty": {
+                      "type": "string",
+                      "enum": [
+                        "bounded",
+                        "material"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "schema_version",
+                    "preferred_mode",
+                    "scope_roots",
+                    "repository_effects",
+                    "external_effects",
+                    "reversibility",
+                    "rationale",
+                    "uncertainty"
+                  ],
+                  "additionalProperties": false
+                }
+              ]
+            }
+          },
+          "required": [
+            "task_kind",
+            "mutation_scope",
+            "risk_flags",
+            "tags"
+          ],
+          "additionalProperties": false
+        },
+        "task_plan_proposal": {
+          "type": "object",
+          "properties": {
+            "schema_version": {
+              "type": "number",
+              "const": 1
+            },
+            "task_id": {
+              "type": "string",
+              "minLength": 1
+            },
+            "planning_baseline": {
+              "type": "object",
+              "properties": {
+                "schema_version": {
+                  "type": "number",
+                  "const": 1
+                },
+                "digest": {},
+                "git": {
+                  "oneOf": [
+                    {
+                      "type": "object",
+                      "properties": {
+                        "kind": {
+                          "type": "string",
+                          "const": "commit"
+                        },
+                        "sha": {
+                          "type": "string",
+                          "pattern": "^[0-9a-f]{40}$|^[0-9a-f]{64}$"
+                        },
+                        "ref": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
+                        }
+                      },
+                      "required": [
+                        "kind",
+                        "sha",
+                        "ref"
+                      ],
+                      "additionalProperties": false
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "kind": {
+                          "type": "string",
+                          "const": "unborn"
+                        },
+                        "ref": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
+                        }
+                      },
+                      "required": [
+                        "kind",
+                        "ref"
+                      ],
+                      "additionalProperties": false
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "kind": {
+                          "type": "string",
+                          "const": "unavailable"
+                        },
+                        "reason_code": {
+                          "type": "string",
+                          "minLength": 1
+                        },
+                        "detail": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "kind",
+                        "reason_code"
+                      ],
+                      "additionalProperties": false
+                    }
+                  ]
+                },
+                "dirty_paths": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "policy_digest": {
+                  "anyOf": [
+                    {},
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "config_digest": {
+                  "anyOf": [
+                    {},
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "context_digest": {
+                  "anyOf": [
+                    {},
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "task_history_cursor": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "captured_at": {
+                  "type": "string",
+                  "format": "date-time",
+                  "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z|([+-](?:[01]\\d|2[0-3]):[0-5]\\d)))$"
+                }
+              },
+              "required": [
+                "schema_version",
+                "digest",
+                "git",
+                "dirty_paths",
+                "policy_digest",
+                "config_digest",
+                "context_digest",
+                "task_history_cursor",
+                "captured_at"
+              ],
+              "additionalProperties": false
+            },
+            "work_items": {
+              "type": "object",
+              "properties": {
+                "schema_version": {
+                  "type": "number",
+                  "const": 1
+                },
+                "work_items": {
+                  "minItems": 1,
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "id": {
+                        "type": "string",
+                        "minLength": 1
+                      },
+                      "objective": {
+                        "type": "string",
+                        "minLength": 1
+                      },
+                      "depends_on": {
+                        "type": "array",
+                        "items": {
+                          "type": "string",
+                          "minLength": 1
+                        }
+                      },
+                      "required_inputs": {
+                        "type": "array",
+                        "items": {
+                          "type": "string",
+                          "minLength": 1
+                        }
+                      },
+                      "expected_outputs": {
+                        "type": "array",
+                        "items": {
+                          "type": "string",
+                          "minLength": 1
+                        }
+                      },
+                      "scope_roots": {
+                        "type": "array",
+                        "items": {
+                          "type": "string",
+                          "minLength": 1
+                        }
+                      },
+                      "acceptance_criteria": {
+                        "minItems": 1,
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "id": {
+                              "type": "string",
+                              "minLength": 1
+                            },
+                            "description": {
+                              "type": "string",
+                              "minLength": 1
+                            },
+                            "required": {
+                              "type": "boolean"
+                            },
+                            "check_ids": {
+                              "type": "array",
+                              "items": {
+                                "type": "string",
+                                "minLength": 1
+                              }
+                            }
+                          },
+                          "required": [
+                            "id",
+                            "description",
+                            "required",
+                            "check_ids"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "validation": {
+                        "type": "object",
+                        "properties": {
+                          "schema_version": {
+                            "type": "number",
+                            "const": 1
+                          },
+                          "criteria": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "id": {
+                                  "type": "string",
+                                  "minLength": 1
+                                },
+                                "description": {
+                                  "type": "string",
+                                  "minLength": 1
+                                },
+                                "required": {
+                                  "type": "boolean"
+                                },
+                                "check_ids": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string",
+                                    "minLength": 1
+                                  }
+                                }
+                              },
+                              "required": [
+                                "id",
+                                "description",
+                                "required",
+                                "check_ids"
+                              ],
+                              "additionalProperties": false
+                            }
+                          },
+                          "checks": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "id": {
+                                  "type": "string",
+                                  "minLength": 1
+                                },
+                                "kind": {
+                                  "type": "string",
+                                  "enum": [
+                                    "structural",
+                                    "deterministic",
+                                    "semantic",
+                                    "provider"
+                                  ]
+                                },
+                                "required": {
+                                  "type": "boolean"
+                                },
+                                "capability": {
+                                  "type": "string",
+                                  "minLength": 1
+                                },
+                                "command": {
+                                  "type": "string",
+                                  "minLength": 1
+                                },
+                                "timeout_ms": {
+                                  "type": "integer",
+                                  "exclusiveMinimum": 0,
+                                  "maximum": 9007199254740991
+                                }
+                              },
+                              "required": [
+                                "id",
+                                "kind",
+                                "required",
+                                "capability"
+                              ],
+                              "additionalProperties": false
+                            }
+                          },
+                          "evidence_fingerprint": {}
+                        },
+                        "required": [
+                          "schema_version",
+                          "criteria",
+                          "checks",
+                          "evidence_fingerprint"
+                        ],
+                        "additionalProperties": false
+                      },
+                      "context": {
+                        "type": "object",
+                        "properties": {
+                          "required_sources": {
+                            "type": "array",
+                            "items": {
+                              "type": "string",
+                              "minLength": 1
+                            }
+                          },
+                          "optional_sources": {
+                            "type": "array",
+                            "items": {
+                              "type": "string",
+                              "minLength": 1
+                            }
+                          },
+                          "symbol_hints": {
+                            "type": "array",
+                            "items": {
+                              "type": "string",
+                              "minLength": 1
+                            }
+                          },
+                          "max_bytes": {
+                            "type": "integer",
+                            "exclusiveMinimum": 0,
+                            "maximum": 9007199254740991
+                          }
+                        },
+                        "required": [
+                          "required_sources",
+                          "optional_sources",
+                          "symbol_hints",
+                          "max_bytes"
+                        ],
+                        "additionalProperties": false
+                      },
+                      "risk": {
+                        "type": "string",
+                        "enum": [
+                          "low",
+                          "medium",
+                          "high"
+                        ]
+                      },
+                      "capabilities": {
+                        "type": "array",
+                        "items": {
+                          "type": "string",
+                          "minLength": 1
+                        }
+                      },
+                      "resource_claims": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "kind": {
+                              "type": "string",
+                              "enum": [
+                                "path",
+                                "workspace",
+                                "provider_queue",
+                                "exclusive"
+                              ]
+                            },
+                            "resource": {
+                              "type": "string",
+                              "minLength": 1
+                            },
+                            "mode": {
+                              "type": "string",
+                              "enum": [
+                                "read",
+                                "write",
+                                "exclusive"
+                              ]
+                            }
+                          },
+                          "required": [
+                            "kind",
+                            "resource",
+                            "mode"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "optional": {
+                        "type": "boolean"
+                      },
+                      "priority": {
+                        "type": "integer",
+                        "minimum": -9007199254740991,
+                        "maximum": 9007199254740991
+                      }
+                    },
+                    "required": [
+                      "id",
+                      "objective",
+                      "depends_on",
+                      "required_inputs",
+                      "expected_outputs",
+                      "scope_roots",
+                      "acceptance_criteria",
+                      "validation",
+                      "context",
+                      "risk",
+                      "capabilities",
+                      "resource_claims",
+                      "optional",
+                      "priority"
+                    ],
+                    "additionalProperties": false
+                  }
+                }
+              },
+              "required": [
+                "schema_version",
+                "work_items"
+              ],
+              "additionalProperties": false
+            },
+            "assumptions": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "unresolved_questions": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "top_level_validation": {
+              "type": "object",
+              "properties": {
+                "schema_version": {
+                  "type": "number",
+                  "const": 1
+                },
+                "criteria": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "id": {
+                        "type": "string",
+                        "minLength": 1
+                      },
+                      "description": {
+                        "type": "string",
+                        "minLength": 1
+                      },
+                      "required": {
+                        "type": "boolean"
+                      },
+                      "check_ids": {
+                        "type": "array",
+                        "items": {
+                          "type": "string",
+                          "minLength": 1
+                        }
+                      }
+                    },
+                    "required": [
+                      "id",
+                      "description",
+                      "required",
+                      "check_ids"
+                    ],
+                    "additionalProperties": false
+                  }
+                },
+                "checks": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "id": {
+                        "type": "string",
+                        "minLength": 1
+                      },
+                      "kind": {
+                        "type": "string",
+                        "enum": [
+                          "structural",
+                          "deterministic",
+                          "semantic",
+                          "provider"
+                        ]
+                      },
+                      "required": {
+                        "type": "boolean"
+                      },
+                      "capability": {
+                        "type": "string",
+                        "minLength": 1
+                      },
+                      "command": {
+                        "type": "string",
+                        "minLength": 1
+                      },
+                      "timeout_ms": {
+                        "type": "integer",
+                        "exclusiveMinimum": 0,
+                        "maximum": 9007199254740991
+                      }
+                    },
+                    "required": [
+                      "id",
+                      "kind",
+                      "required",
+                      "capability"
+                    ],
+                    "additionalProperties": false
+                  }
+                },
+                "evidence_fingerprint": {}
+              },
+              "required": [
+                "schema_version",
+                "criteria",
+                "checks",
+                "evidence_fingerprint"
+              ],
+              "additionalProperties": false
+            }
+          },
+          "required": [
+            "schema_version",
+            "task_id",
+            "planning_baseline",
+            "work_items",
+            "assumptions",
+            "unresolved_questions",
+            "top_level_validation"
+          ],
+          "additionalProperties": false
+        },
+        "canonical_binding": {
+          "oneOf": [
+            {
+              "type": "object",
+              "properties": {
+                "task_id": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "repository_identity": {
+                  "type": "string",
+                  "pattern": "^sha256:[a-f0-9]{64}$"
+                },
+                "repository_fingerprint": {
+                  "type": "string",
+                  "pattern": "^sha256:[a-f0-9]{64}$"
+                },
+                "plan_revision": {
+                  "type": "integer",
+                  "minimum": 0,
+                  "maximum": 9007199254740991
+                },
+                "plan_digest": {
+                  "type": "string",
+                  "pattern": "^sha256:[a-f0-9]{64}$"
+                },
+                "phase": {
+                  "type": "string",
+                  "const": "planning"
+                }
+              },
+              "required": [
+                "task_id",
+                "repository_identity",
+                "repository_fingerprint",
+                "plan_revision",
+                "plan_digest",
+                "phase"
+              ],
+              "additionalProperties": false
+            },
+            {
+              "type": "object",
+              "properties": {
+                "task_id": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "repository_identity": {
+                  "type": "string",
+                  "pattern": "^sha256:[a-f0-9]{64}$"
+                },
+                "repository_fingerprint": {
+                  "type": "string",
+                  "pattern": "^sha256:[a-f0-9]{64}$"
+                },
+                "plan_revision": {
+                  "type": "integer",
+                  "minimum": 0,
+                  "maximum": 9007199254740991
+                },
+                "plan_digest": {
+                  "type": "string",
+                  "pattern": "^sha256:[a-f0-9]{64}$"
+                },
+                "phase": {
+                  "type": "string",
+                  "const": "implementation"
+                },
+                "work_item_id": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "attempt": {
+                  "type": "integer",
+                  "exclusiveMinimum": 0,
+                  "maximum": 9007199254740991
+                },
+                "claim_id": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "contract_digest": {
+                  "type": "string",
+                  "pattern": "^sha256:[a-f0-9]{64}$"
+                },
+                "authority_digest": {
+                  "type": "string",
+                  "pattern": "^sha256:[a-f0-9]{64}$"
+                }
+              },
+              "required": [
+                "task_id",
+                "repository_identity",
+                "repository_fingerprint",
+                "plan_revision",
+                "plan_digest",
+                "phase",
+                "work_item_id",
+                "attempt",
+                "claim_id",
+                "contract_digest",
+                "authority_digest"
+              ],
+              "additionalProperties": false
+            },
+            {
+              "type": "object",
+              "properties": {
+                "task_id": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "repository_identity": {
+                  "type": "string",
+                  "pattern": "^sha256:[a-f0-9]{64}$"
+                },
+                "repository_fingerprint": {
+                  "type": "string",
+                  "pattern": "^sha256:[a-f0-9]{64}$"
+                },
+                "plan_revision": {
+                  "type": "integer",
+                  "minimum": 0,
+                  "maximum": 9007199254740991
+                },
+                "plan_digest": {
+                  "type": "string",
+                  "pattern": "^sha256:[a-f0-9]{64}$"
+                },
+                "phase": {
+                  "type": "string",
+                  "const": "inspection"
+                },
+                "work_item_id": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "attempt": {
+                  "type": "integer",
+                  "exclusiveMinimum": 0,
+                  "maximum": 9007199254740991
+                },
+                "claim_id": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "contract_digest": {
+                  "type": "string",
+                  "pattern": "^sha256:[a-f0-9]{64}$"
+                },
+                "authority_digest": {
+                  "type": "string",
+                  "pattern": "^sha256:[a-f0-9]{64}$"
+                },
+                "result_digest": {
+                  "type": "string",
+                  "pattern": "^sha256:[a-f0-9]{64}$"
+                }
+              },
+              "required": [
+                "task_id",
+                "repository_identity",
+                "repository_fingerprint",
+                "plan_revision",
+                "plan_digest",
+                "phase",
+                "work_item_id",
+                "attempt",
+                "claim_id",
+                "contract_digest",
+                "authority_digest",
+                "result_digest"
+              ],
+              "additionalProperties": false
+            }
+          ]
+        },
+        "canonical_plan": {
+          "type": "object",
+          "properties": {
+            "work_items": {
+              "minItems": 1,
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "depends_on": {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "minLength": 1
+                    }
+                  },
+                  "required_inputs": {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "minLength": 1
+                    }
+                  },
+                  "expected_outputs": {
+                    "minItems": 1,
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "minLength": 1
+                    }
+                  },
+                  "execution_requirements": {
+                    "type": "object",
+                    "properties": {
+                      "scope_roots": {
+                        "type": "array",
+                        "items": {
+                          "type": "string",
+                          "minLength": 1
+                        }
+                      },
+                      "repository_effects": {
+                        "type": "array",
+                        "items": {
+                          "type": "string",
+                          "minLength": 1
+                        }
+                      },
+                      "external_effects": {
+                        "type": "array",
+                        "items": {
+                          "type": "string",
+                          "minLength": 1
+                        }
+                      },
+                      "capabilities": {
+                        "type": "array",
+                        "items": {
+                          "type": "string",
+                          "minLength": 1
+                        }
+                      },
+                      "resources": {
+                        "type": "array",
+                        "items": {
+                          "type": "string",
+                          "minLength": 1
+                        }
+                      }
+                    },
+                    "required": [
+                      "scope_roots",
+                      "repository_effects",
+                      "external_effects",
+                      "capabilities",
+                      "resources"
+                    ],
+                    "additionalProperties": false
+                  },
+                  "optional": {
+                    "type": "boolean"
+                  },
+                  "contract": {
+                    "type": "object",
+                    "properties": {
+                      "objective": {
+                        "type": "string",
+                        "minLength": 1
+                      },
+                      "acceptance_criteria": {
+                        "minItems": 1,
+                        "type": "array",
+                        "items": {
+                          "type": "string",
+                          "minLength": 1
+                        }
+                      },
+                      "verification_commands": {
+                        "type": "array",
+                        "items": {
+                          "type": "string",
+                          "minLength": 1
+                        }
+                      },
+                      "role": {
+                        "type": "string",
+                        "enum": [
+                          "PLANNER",
+                          "EXECUTOR",
+                          "EVALUATOR"
+                        ]
+                      }
+                    },
+                    "required": [
+                      "objective",
+                      "acceptance_criteria",
+                      "verification_commands",
+                      "role"
+                    ],
+                    "additionalProperties": false
+                  }
+                },
+                "required": [
+                  "id",
+                  "depends_on",
+                  "required_inputs",
+                  "expected_outputs",
+                  "execution_requirements",
+                  "optional",
+                  "contract"
+                ],
+                "additionalProperties": false
+              }
+            }
+          },
+          "required": [
+            "work_items"
+          ],
+          "additionalProperties": false
+        },
+        "canonical_outputs": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "string",
+                "minLength": 1
+              },
+              "kind": {
+                "type": "string",
+                "minLength": 1
+              },
+              "digest": {
+                "type": "string",
+                "pattern": "^sha256:[a-f0-9]{64}$"
+              }
+            },
+            "required": [
+              "id",
+              "kind",
+              "digest"
+            ],
+            "additionalProperties": false
+          }
+        },
+        "plan_refinement": {
+          "type": "object",
+          "properties": {
+            "description": {
+              "type": "string",
+              "minLength": 1
+            },
+            "scope_roots_added": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "minLength": 1
+              }
+            },
+            "outputs_added": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "minLength": 1
+              }
+            },
+            "acceptance_changed": {
+              "type": "boolean"
+            },
+            "risk_changed": {
+              "type": "boolean"
+            },
+            "external_effects_added": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "minLength": 1
+              }
+            },
+            "dependencies_changed": {
+              "type": "boolean"
+            },
+            "architecture_constraints_changed": {
+              "type": "boolean"
+            },
+            "operations": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "enum": [
+                  "split",
+                  "reorder",
+                  "add_test",
+                  "clarify"
+                ]
+              }
+            }
+          },
+          "required": [
+            "description",
+            "scope_roots_added",
+            "outputs_added",
+            "acceptance_changed",
+            "risk_changed",
+            "external_effects_added",
+            "dependencies_changed",
+            "architecture_constraints_changed",
+            "operations"
+          ],
+          "additionalProperties": false
+        },
+        "claimed_checks": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "check": {
+                "type": "string",
+                "minLength": 1
+              },
+              "claimed_status": {
+                "type": "string",
+                "enum": [
+                  "passed",
+                  "failed",
+                  "not_run"
+                ]
+              },
+              "details": {
+                "type": "string",
+                "minLength": 1
+              }
+            },
+            "required": [
+              "check",
+              "claimed_status"
+            ],
+            "additionalProperties": false
+          }
+        },
+        "review": {
+          "type": "object",
+          "properties": {
+            "verdict": {
+              "type": "string",
+              "enum": [
+                "pass",
+                "rework",
+                "blocked",
+                "human_review"
+              ]
+            },
+            "missing_tests": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "hidden_assumptions": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "residual_risks": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "recovery_context": {
+              "type": "string",
+              "minLength": 1
+            }
+          },
+          "required": [
+            "verdict",
+            "missing_tests",
+            "hidden_assumptions",
+            "residual_risks"
+          ],
+          "additionalProperties": false
+        },
+        "status": {
+          "type": "string",
+          "const": "needs_context"
+        },
+        "blocker": {
+          "type": "object",
+          "properties": {
+            "summary": {
+              "type": "string",
+              "minLength": 1
+            },
+            "recommended_action": {
+              "type": "string",
+              "minLength": 1
+            },
+            "scope_extension_request": {
+              "anyOf": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "schema_version": {
+                      "type": "number",
+                      "const": 1
+                    },
+                    "rationale": {
+                      "type": "string",
+                      "minLength": 1
+                    },
+                    "scope_roots": {
+                      "minItems": 1,
+                      "type": "array",
+                      "items": {
+                        "type": "string",
+                        "minLength": 1
+                      }
+                    },
+                    "repository_effects": {
+                      "type": "array",
+                      "items": {
+                        "type": "string",
+                        "enum": [
+                          "repository_write",
+                          "documentation",
+                          "source_code",
+                          "tests",
+                          "public_api",
+                          "schema",
+                          "dependencies",
+                          "ci",
+                          "release_metadata",
+                          "security_boundary"
+                        ]
+                      }
+                    }
+                  },
+                  "required": [
+                    "schema_version",
+                    "rationale",
+                    "scope_roots",
+                    "repository_effects"
+                  ],
+                  "additionalProperties": false
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "schema_version": {
+                      "type": "number",
+                      "const": 1
+                    },
+                    "rationale": {
+                      "type": "string",
+                      "minLength": 1
+                    },
+                    "scope_roots": {
+                      "type": "array",
+                      "items": {
+                        "type": "string",
+                        "minLength": 1
+                      }
+                    },
+                    "repository_effects": {
+                      "minItems": 1,
+                      "type": "array",
+                      "items": {
+                        "type": "string",
+                        "enum": [
+                          "repository_write",
+                          "documentation",
+                          "source_code",
+                          "tests",
+                          "public_api",
+                          "schema",
+                          "dependencies",
+                          "ci",
+                          "release_metadata",
+                          "security_boundary"
+                        ]
+                      }
+                    }
+                  },
+                  "required": [
+                    "schema_version",
+                    "rationale",
+                    "scope_roots",
+                    "repository_effects"
+                  ],
+                  "additionalProperties": false
+                }
+              ]
+            }
+          },
+          "required": [
+            "summary"
+          ],
+          "additionalProperties": false
+        },
+        "knowledge_request": {
+          "type": "object",
+          "properties": {
+            "schema_version": {
+              "type": "number",
+              "const": 1
+            },
+            "kind": {
+              "type": "string",
+              "const": "knowledge_request"
+            },
+            "query": {
+              "type": "string",
+              "minLength": 1
+            },
+            "reason": {
+              "type": "string",
+              "minLength": 1
+            },
+            "desired_kind": {
+              "type": "string",
+              "enum": [
+                "any",
+                "wiki",
+                "source",
+                "fact",
+                "entity",
+                "edge"
+              ]
+            },
+            "scope": {
+              "type": "string",
+              "enum": [
+                "task_context"
+              ]
+            },
+            "blocking": {
+              "type": "boolean"
+            }
+          },
+          "required": [
+            "schema_version",
+            "kind",
+            "query",
+            "reason",
+            "desired_kind",
+            "scope",
+            "blocking"
+          ],
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "schema_version",
+        "kind",
+        "work_order_id",
+        "summary",
+        "findings",
+        "uncertainty",
+        "status",
+        "knowledge_request"
+      ],
+      "additionalProperties": false
+    },
+    {
+      "type": "object",
+      "properties": {
+        "schema_version": {
+          "type": "number",
+          "const": 2
+        },
+        "kind": {
+          "type": "string",
+          "const": "agent_semantic_result"
+        },
+        "work_order_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "summary": {
+          "type": "string",
+          "minLength": 1
+        },
+        "findings": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "uncertainty": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "task_intent": {
+          "type": "object",
+          "properties": {
+            "task_kind": {
+              "type": "string",
+              "enum": [
+                "analysis",
+                "content",
+                "docs",
+                "code",
+                "release",
+                "ops",
+                "context"
+              ]
+            },
+            "mutation_scope": {
+              "type": "string",
+              "enum": [
+                "none",
+                "docs",
+                "code",
+                "release",
+                "ops",
+                "context"
+              ]
+            },
+            "risk_flags": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "enum": [
+                  "network",
+                  "credentials",
+                  "deploy",
+                  "publish",
+                  "merge",
+                  "security",
+                  "external_system"
+                ]
+              }
+            },
+            "tags": {
+              "minItems": 1,
+              "type": "array",
+              "items": {
+                "type": "string",
+                "minLength": 1
+              }
+            },
+            "blueprint_request": {
+              "type": "string",
+              "enum": [
+                "analysis.light",
+                "content.light",
+                "docs.change",
+                "code.direct",
+                "code.branch_pr",
+                "performance.benchmark",
+                "quality.regression",
+                "context.assimilation",
+                "context.maximum_assimilation",
+                "post_run.improvement_review",
+                "release.strict",
+                "ops.approval"
+              ]
+            },
+            "execution": {
+              "anyOf": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "schema_version": {
+                      "type": "number",
+                      "const": 2
+                    },
+                    "preferred_mode": {
+                      "type": "string",
+                      "enum": [
+                        "direct",
+                        "branch_pr"
+                      ]
+                    },
+                    "scope_roots": {
+                      "type": "array",
+                      "items": {
+                        "type": "string",
+                        "minLength": 1
+                      }
+                    },
+                    "repository_effects": {
+                      "type": "array",
+                      "items": {
+                        "type": "string",
+                        "enum": [
+                          "repository_write",
+                          "documentation",
+                          "source_code",
+                          "tests",
+                          "public_api",
+                          "schema",
+                          "dependencies",
+                          "ci",
+                          "release_metadata",
+                          "security_boundary"
+                        ]
+                      }
+                    },
+                    "external_effects": {
+                      "type": "array",
+                      "items": {
+                        "type": "string",
+                        "enum": [
+                          "network_read",
+                          "external_write",
+                          "credentials",
+                          "publish",
+                          "deploy",
+                          "destructive_git"
+                        ]
+                      }
+                    },
+                    "reversibility": {
+                      "type": "string",
+                      "enum": [
+                        "reversible",
+                        "recovery_required",
+                        "irreversible"
+                      ]
+                    },
+                    "rationale": {
+                      "minItems": 1,
+                      "type": "array",
+                      "items": {
+                        "type": "string",
+                        "minLength": 1
+                      }
+                    },
+                    "requirements_uncertainty": {
+                      "type": "string",
+                      "enum": [
+                        "bounded",
+                        "material"
+                      ]
+                    },
+                    "implementation_uncertainty": {
+                      "type": "string",
+                      "enum": [
+                        "bounded",
+                        "material"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "schema_version",
+                    "preferred_mode",
+                    "scope_roots",
+                    "repository_effects",
+                    "external_effects",
+                    "reversibility",
+                    "rationale",
+                    "requirements_uncertainty",
+                    "implementation_uncertainty"
+                  ],
+                  "additionalProperties": false
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "schema_version": {
+                      "type": "number",
+                      "const": 1
+                    },
+                    "preferred_mode": {
+                      "type": "string",
+                      "enum": [
+                        "direct",
+                        "branch_pr"
+                      ]
+                    },
+                    "scope_roots": {
+                      "type": "array",
+                      "items": {
+                        "type": "string",
+                        "minLength": 1
+                      }
+                    },
+                    "repository_effects": {
+                      "type": "array",
+                      "items": {
+                        "type": "string",
+                        "enum": [
+                          "repository_write",
+                          "documentation",
+                          "source_code",
+                          "tests",
+                          "public_api",
+                          "schema",
+                          "dependencies",
+                          "ci",
+                          "release_metadata",
+                          "security_boundary"
+                        ]
+                      }
+                    },
+                    "external_effects": {
+                      "type": "array",
+                      "items": {
+                        "type": "string",
+                        "enum": [
+                          "network_read",
+                          "external_write",
+                          "credentials",
+                          "publish",
+                          "deploy",
+                          "destructive_git"
+                        ]
+                      }
+                    },
+                    "reversibility": {
+                      "type": "string",
+                      "enum": [
+                        "reversible",
+                        "recovery_required",
+                        "irreversible"
+                      ]
+                    },
+                    "rationale": {
+                      "minItems": 1,
+                      "type": "array",
+                      "items": {
+                        "type": "string",
+                        "minLength": 1
+                      }
+                    },
+                    "uncertainty": {
+                      "type": "string",
+                      "enum": [
+                        "bounded",
+                        "material"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "schema_version",
+                    "preferred_mode",
+                    "scope_roots",
+                    "repository_effects",
+                    "external_effects",
+                    "reversibility",
+                    "rationale",
+                    "uncertainty"
+                  ],
+                  "additionalProperties": false
+                }
+              ]
+            }
+          },
+          "required": [
+            "task_kind",
+            "mutation_scope",
+            "risk_flags",
+            "tags"
+          ],
+          "additionalProperties": false
+        },
+        "task_plan_proposal": {
+          "type": "object",
+          "properties": {
+            "schema_version": {
+              "type": "number",
+              "const": 1
+            },
+            "task_id": {
+              "type": "string",
+              "minLength": 1
+            },
+            "planning_baseline": {
+              "type": "object",
+              "properties": {
+                "schema_version": {
+                  "type": "number",
+                  "const": 1
+                },
+                "digest": {},
+                "git": {
+                  "oneOf": [
+                    {
+                      "type": "object",
+                      "properties": {
+                        "kind": {
+                          "type": "string",
+                          "const": "commit"
+                        },
+                        "sha": {
+                          "type": "string",
+                          "pattern": "^[0-9a-f]{40}$|^[0-9a-f]{64}$"
+                        },
+                        "ref": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
+                        }
+                      },
+                      "required": [
+                        "kind",
+                        "sha",
+                        "ref"
+                      ],
+                      "additionalProperties": false
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "kind": {
+                          "type": "string",
+                          "const": "unborn"
+                        },
+                        "ref": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
+                        }
+                      },
+                      "required": [
+                        "kind",
+                        "ref"
+                      ],
+                      "additionalProperties": false
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "kind": {
+                          "type": "string",
+                          "const": "unavailable"
+                        },
+                        "reason_code": {
+                          "type": "string",
+                          "minLength": 1
+                        },
+                        "detail": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "kind",
+                        "reason_code"
+                      ],
+                      "additionalProperties": false
+                    }
+                  ]
+                },
+                "dirty_paths": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "policy_digest": {
+                  "anyOf": [
+                    {},
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "config_digest": {
+                  "anyOf": [
+                    {},
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "context_digest": {
+                  "anyOf": [
+                    {},
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "task_history_cursor": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "captured_at": {
+                  "type": "string",
+                  "format": "date-time",
+                  "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z|([+-](?:[01]\\d|2[0-3]):[0-5]\\d)))$"
+                }
+              },
+              "required": [
+                "schema_version",
+                "digest",
+                "git",
+                "dirty_paths",
+                "policy_digest",
+                "config_digest",
+                "context_digest",
+                "task_history_cursor",
+                "captured_at"
+              ],
+              "additionalProperties": false
+            },
+            "work_items": {
+              "type": "object",
+              "properties": {
+                "schema_version": {
+                  "type": "number",
+                  "const": 1
+                },
+                "work_items": {
+                  "minItems": 1,
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "id": {
+                        "type": "string",
+                        "minLength": 1
+                      },
+                      "objective": {
+                        "type": "string",
+                        "minLength": 1
+                      },
+                      "depends_on": {
+                        "type": "array",
+                        "items": {
+                          "type": "string",
+                          "minLength": 1
+                        }
+                      },
+                      "required_inputs": {
+                        "type": "array",
+                        "items": {
+                          "type": "string",
+                          "minLength": 1
+                        }
+                      },
+                      "expected_outputs": {
+                        "type": "array",
+                        "items": {
+                          "type": "string",
+                          "minLength": 1
+                        }
+                      },
+                      "scope_roots": {
+                        "type": "array",
+                        "items": {
+                          "type": "string",
+                          "minLength": 1
+                        }
+                      },
+                      "acceptance_criteria": {
+                        "minItems": 1,
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "id": {
+                              "type": "string",
+                              "minLength": 1
+                            },
+                            "description": {
+                              "type": "string",
+                              "minLength": 1
+                            },
+                            "required": {
+                              "type": "boolean"
+                            },
+                            "check_ids": {
+                              "type": "array",
+                              "items": {
+                                "type": "string",
+                                "minLength": 1
+                              }
+                            }
+                          },
+                          "required": [
+                            "id",
+                            "description",
+                            "required",
+                            "check_ids"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "validation": {
+                        "type": "object",
+                        "properties": {
+                          "schema_version": {
+                            "type": "number",
+                            "const": 1
+                          },
+                          "criteria": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "id": {
+                                  "type": "string",
+                                  "minLength": 1
+                                },
+                                "description": {
+                                  "type": "string",
+                                  "minLength": 1
+                                },
+                                "required": {
+                                  "type": "boolean"
+                                },
+                                "check_ids": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string",
+                                    "minLength": 1
+                                  }
+                                }
+                              },
+                              "required": [
+                                "id",
+                                "description",
+                                "required",
+                                "check_ids"
+                              ],
+                              "additionalProperties": false
+                            }
+                          },
+                          "checks": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "id": {
+                                  "type": "string",
+                                  "minLength": 1
+                                },
+                                "kind": {
+                                  "type": "string",
+                                  "enum": [
+                                    "structural",
+                                    "deterministic",
+                                    "semantic",
+                                    "provider"
+                                  ]
+                                },
+                                "required": {
+                                  "type": "boolean"
+                                },
+                                "capability": {
+                                  "type": "string",
+                                  "minLength": 1
+                                },
+                                "command": {
+                                  "type": "string",
+                                  "minLength": 1
+                                },
+                                "timeout_ms": {
+                                  "type": "integer",
+                                  "exclusiveMinimum": 0,
+                                  "maximum": 9007199254740991
+                                }
+                              },
+                              "required": [
+                                "id",
+                                "kind",
+                                "required",
+                                "capability"
+                              ],
+                              "additionalProperties": false
+                            }
+                          },
+                          "evidence_fingerprint": {}
+                        },
+                        "required": [
+                          "schema_version",
+                          "criteria",
+                          "checks",
+                          "evidence_fingerprint"
+                        ],
+                        "additionalProperties": false
+                      },
+                      "context": {
+                        "type": "object",
+                        "properties": {
+                          "required_sources": {
+                            "type": "array",
+                            "items": {
+                              "type": "string",
+                              "minLength": 1
+                            }
+                          },
+                          "optional_sources": {
+                            "type": "array",
+                            "items": {
+                              "type": "string",
+                              "minLength": 1
+                            }
+                          },
+                          "symbol_hints": {
+                            "type": "array",
+                            "items": {
+                              "type": "string",
+                              "minLength": 1
+                            }
+                          },
+                          "max_bytes": {
+                            "type": "integer",
+                            "exclusiveMinimum": 0,
+                            "maximum": 9007199254740991
+                          }
+                        },
+                        "required": [
+                          "required_sources",
+                          "optional_sources",
+                          "symbol_hints",
+                          "max_bytes"
+                        ],
+                        "additionalProperties": false
+                      },
+                      "risk": {
+                        "type": "string",
+                        "enum": [
+                          "low",
+                          "medium",
+                          "high"
+                        ]
+                      },
+                      "capabilities": {
+                        "type": "array",
+                        "items": {
+                          "type": "string",
+                          "minLength": 1
+                        }
+                      },
+                      "resource_claims": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "kind": {
+                              "type": "string",
+                              "enum": [
+                                "path",
+                                "workspace",
+                                "provider_queue",
+                                "exclusive"
+                              ]
+                            },
+                            "resource": {
+                              "type": "string",
+                              "minLength": 1
+                            },
+                            "mode": {
+                              "type": "string",
+                              "enum": [
+                                "read",
+                                "write",
+                                "exclusive"
+                              ]
+                            }
+                          },
+                          "required": [
+                            "kind",
+                            "resource",
+                            "mode"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "optional": {
+                        "type": "boolean"
+                      },
+                      "priority": {
+                        "type": "integer",
+                        "minimum": -9007199254740991,
+                        "maximum": 9007199254740991
+                      }
+                    },
+                    "required": [
+                      "id",
+                      "objective",
+                      "depends_on",
+                      "required_inputs",
+                      "expected_outputs",
+                      "scope_roots",
+                      "acceptance_criteria",
+                      "validation",
+                      "context",
+                      "risk",
+                      "capabilities",
+                      "resource_claims",
+                      "optional",
+                      "priority"
+                    ],
+                    "additionalProperties": false
+                  }
+                }
+              },
+              "required": [
+                "schema_version",
+                "work_items"
+              ],
+              "additionalProperties": false
+            },
+            "assumptions": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "unresolved_questions": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "top_level_validation": {
+              "type": "object",
+              "properties": {
+                "schema_version": {
+                  "type": "number",
+                  "const": 1
+                },
+                "criteria": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "id": {
+                        "type": "string",
+                        "minLength": 1
+                      },
+                      "description": {
+                        "type": "string",
+                        "minLength": 1
+                      },
+                      "required": {
+                        "type": "boolean"
+                      },
+                      "check_ids": {
+                        "type": "array",
+                        "items": {
+                          "type": "string",
+                          "minLength": 1
+                        }
+                      }
+                    },
+                    "required": [
+                      "id",
+                      "description",
+                      "required",
+                      "check_ids"
+                    ],
+                    "additionalProperties": false
+                  }
+                },
+                "checks": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "id": {
+                        "type": "string",
+                        "minLength": 1
+                      },
+                      "kind": {
+                        "type": "string",
+                        "enum": [
+                          "structural",
+                          "deterministic",
+                          "semantic",
+                          "provider"
+                        ]
+                      },
+                      "required": {
+                        "type": "boolean"
+                      },
+                      "capability": {
+                        "type": "string",
+                        "minLength": 1
+                      },
+                      "command": {
+                        "type": "string",
+                        "minLength": 1
+                      },
+                      "timeout_ms": {
+                        "type": "integer",
+                        "exclusiveMinimum": 0,
+                        "maximum": 9007199254740991
+                      }
+                    },
+                    "required": [
+                      "id",
+                      "kind",
+                      "required",
+                      "capability"
+                    ],
+                    "additionalProperties": false
+                  }
+                },
+                "evidence_fingerprint": {}
+              },
+              "required": [
+                "schema_version",
+                "criteria",
+                "checks",
+                "evidence_fingerprint"
+              ],
+              "additionalProperties": false
+            }
+          },
+          "required": [
+            "schema_version",
+            "task_id",
+            "planning_baseline",
+            "work_items",
+            "assumptions",
+            "unresolved_questions",
+            "top_level_validation"
+          ],
+          "additionalProperties": false
+        },
+        "canonical_binding": {
+          "oneOf": [
+            {
+              "type": "object",
+              "properties": {
+                "task_id": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "repository_identity": {
+                  "type": "string",
+                  "pattern": "^sha256:[a-f0-9]{64}$"
+                },
+                "repository_fingerprint": {
+                  "type": "string",
+                  "pattern": "^sha256:[a-f0-9]{64}$"
+                },
+                "plan_revision": {
+                  "type": "integer",
+                  "minimum": 0,
+                  "maximum": 9007199254740991
+                },
+                "plan_digest": {
+                  "type": "string",
+                  "pattern": "^sha256:[a-f0-9]{64}$"
+                },
+                "phase": {
+                  "type": "string",
+                  "const": "planning"
+                }
+              },
+              "required": [
+                "task_id",
+                "repository_identity",
+                "repository_fingerprint",
+                "plan_revision",
+                "plan_digest",
+                "phase"
+              ],
+              "additionalProperties": false
+            },
+            {
+              "type": "object",
+              "properties": {
+                "task_id": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "repository_identity": {
+                  "type": "string",
+                  "pattern": "^sha256:[a-f0-9]{64}$"
+                },
+                "repository_fingerprint": {
+                  "type": "string",
+                  "pattern": "^sha256:[a-f0-9]{64}$"
+                },
+                "plan_revision": {
+                  "type": "integer",
+                  "minimum": 0,
+                  "maximum": 9007199254740991
+                },
+                "plan_digest": {
+                  "type": "string",
+                  "pattern": "^sha256:[a-f0-9]{64}$"
+                },
+                "phase": {
+                  "type": "string",
+                  "const": "implementation"
+                },
+                "work_item_id": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "attempt": {
+                  "type": "integer",
+                  "exclusiveMinimum": 0,
+                  "maximum": 9007199254740991
+                },
+                "claim_id": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "contract_digest": {
+                  "type": "string",
+                  "pattern": "^sha256:[a-f0-9]{64}$"
+                },
+                "authority_digest": {
+                  "type": "string",
+                  "pattern": "^sha256:[a-f0-9]{64}$"
+                }
+              },
+              "required": [
+                "task_id",
+                "repository_identity",
+                "repository_fingerprint",
+                "plan_revision",
+                "plan_digest",
+                "phase",
+                "work_item_id",
+                "attempt",
+                "claim_id",
+                "contract_digest",
+                "authority_digest"
+              ],
+              "additionalProperties": false
+            },
+            {
+              "type": "object",
+              "properties": {
+                "task_id": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "repository_identity": {
+                  "type": "string",
+                  "pattern": "^sha256:[a-f0-9]{64}$"
+                },
+                "repository_fingerprint": {
+                  "type": "string",
+                  "pattern": "^sha256:[a-f0-9]{64}$"
+                },
+                "plan_revision": {
+                  "type": "integer",
+                  "minimum": 0,
+                  "maximum": 9007199254740991
+                },
+                "plan_digest": {
+                  "type": "string",
+                  "pattern": "^sha256:[a-f0-9]{64}$"
+                },
+                "phase": {
+                  "type": "string",
+                  "const": "inspection"
+                },
+                "work_item_id": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "attempt": {
+                  "type": "integer",
+                  "exclusiveMinimum": 0,
+                  "maximum": 9007199254740991
+                },
+                "claim_id": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "contract_digest": {
+                  "type": "string",
+                  "pattern": "^sha256:[a-f0-9]{64}$"
+                },
+                "authority_digest": {
+                  "type": "string",
+                  "pattern": "^sha256:[a-f0-9]{64}$"
+                },
+                "result_digest": {
+                  "type": "string",
+                  "pattern": "^sha256:[a-f0-9]{64}$"
+                }
+              },
+              "required": [
+                "task_id",
+                "repository_identity",
+                "repository_fingerprint",
+                "plan_revision",
+                "plan_digest",
+                "phase",
+                "work_item_id",
+                "attempt",
+                "claim_id",
+                "contract_digest",
+                "authority_digest",
+                "result_digest"
+              ],
+              "additionalProperties": false
+            }
+          ]
+        },
+        "canonical_plan": {
+          "type": "object",
+          "properties": {
+            "work_items": {
+              "minItems": 1,
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "depends_on": {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "minLength": 1
+                    }
+                  },
+                  "required_inputs": {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "minLength": 1
+                    }
+                  },
+                  "expected_outputs": {
+                    "minItems": 1,
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "minLength": 1
+                    }
+                  },
+                  "execution_requirements": {
+                    "type": "object",
+                    "properties": {
+                      "scope_roots": {
+                        "type": "array",
+                        "items": {
+                          "type": "string",
+                          "minLength": 1
+                        }
+                      },
+                      "repository_effects": {
+                        "type": "array",
+                        "items": {
+                          "type": "string",
+                          "minLength": 1
+                        }
+                      },
+                      "external_effects": {
+                        "type": "array",
+                        "items": {
+                          "type": "string",
+                          "minLength": 1
+                        }
+                      },
+                      "capabilities": {
+                        "type": "array",
+                        "items": {
+                          "type": "string",
+                          "minLength": 1
+                        }
+                      },
+                      "resources": {
+                        "type": "array",
+                        "items": {
+                          "type": "string",
+                          "minLength": 1
+                        }
+                      }
+                    },
+                    "required": [
+                      "scope_roots",
+                      "repository_effects",
+                      "external_effects",
+                      "capabilities",
+                      "resources"
+                    ],
+                    "additionalProperties": false
+                  },
+                  "optional": {
+                    "type": "boolean"
+                  },
+                  "contract": {
+                    "type": "object",
+                    "properties": {
+                      "objective": {
+                        "type": "string",
+                        "minLength": 1
+                      },
+                      "acceptance_criteria": {
+                        "minItems": 1,
+                        "type": "array",
+                        "items": {
+                          "type": "string",
+                          "minLength": 1
+                        }
+                      },
+                      "verification_commands": {
+                        "type": "array",
+                        "items": {
+                          "type": "string",
+                          "minLength": 1
+                        }
+                      },
+                      "role": {
+                        "type": "string",
+                        "enum": [
+                          "PLANNER",
+                          "EXECUTOR",
+                          "EVALUATOR"
+                        ]
+                      }
+                    },
+                    "required": [
+                      "objective",
+                      "acceptance_criteria",
+                      "verification_commands",
+                      "role"
+                    ],
+                    "additionalProperties": false
+                  }
+                },
+                "required": [
+                  "id",
+                  "depends_on",
+                  "required_inputs",
+                  "expected_outputs",
+                  "execution_requirements",
+                  "optional",
+                  "contract"
+                ],
+                "additionalProperties": false
+              }
+            }
+          },
+          "required": [
+            "work_items"
+          ],
+          "additionalProperties": false
+        },
+        "canonical_outputs": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "string",
+                "minLength": 1
+              },
+              "kind": {
+                "type": "string",
+                "minLength": 1
+              },
+              "digest": {
+                "type": "string",
+                "pattern": "^sha256:[a-f0-9]{64}$"
+              }
+            },
+            "required": [
+              "id",
+              "kind",
+              "digest"
+            ],
+            "additionalProperties": false
+          }
+        },
+        "plan_refinement": {
+          "type": "object",
+          "properties": {
+            "description": {
+              "type": "string",
+              "minLength": 1
+            },
+            "scope_roots_added": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "minLength": 1
+              }
+            },
+            "outputs_added": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "minLength": 1
+              }
+            },
+            "acceptance_changed": {
+              "type": "boolean"
+            },
+            "risk_changed": {
+              "type": "boolean"
+            },
+            "external_effects_added": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "minLength": 1
+              }
+            },
+            "dependencies_changed": {
+              "type": "boolean"
+            },
+            "architecture_constraints_changed": {
+              "type": "boolean"
+            },
+            "operations": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "enum": [
+                  "split",
+                  "reorder",
+                  "add_test",
+                  "clarify"
+                ]
+              }
+            }
+          },
+          "required": [
+            "description",
+            "scope_roots_added",
+            "outputs_added",
+            "acceptance_changed",
+            "risk_changed",
+            "external_effects_added",
+            "dependencies_changed",
+            "architecture_constraints_changed",
+            "operations"
+          ],
+          "additionalProperties": false
+        },
+        "claimed_checks": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "check": {
+                "type": "string",
+                "minLength": 1
+              },
+              "claimed_status": {
+                "type": "string",
+                "enum": [
+                  "passed",
+                  "failed",
+                  "not_run"
+                ]
+              },
+              "details": {
+                "type": "string",
+                "minLength": 1
+              }
+            },
+            "required": [
+              "check",
+              "claimed_status"
+            ],
+            "additionalProperties": false
+          }
+        },
+        "review": {
+          "type": "object",
+          "properties": {
+            "verdict": {
+              "type": "string",
+              "enum": [
+                "pass",
+                "rework",
+                "blocked",
+                "human_review"
+              ]
+            },
+            "missing_tests": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "hidden_assumptions": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "residual_risks": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "recovery_context": {
+              "type": "string",
+              "minLength": 1
+            }
+          },
+          "required": [
+            "verdict",
+            "missing_tests",
+            "hidden_assumptions",
+            "residual_risks"
+          ],
+          "additionalProperties": false
+        },
+        "status": {
+          "type": "string",
+          "enum": [
+            "completed",
+            "failed"
+          ]
+        },
+        "blocker": {
+          "type": "object",
+          "properties": {
+            "summary": {
+              "type": "string",
+              "minLength": 1
+            },
+            "recommended_action": {
+              "type": "string",
+              "minLength": 1
+            },
+            "scope_extension_request": {
+              "anyOf": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "schema_version": {
+                      "type": "number",
+                      "const": 1
+                    },
+                    "rationale": {
+                      "type": "string",
+                      "minLength": 1
+                    },
+                    "scope_roots": {
+                      "minItems": 1,
+                      "type": "array",
+                      "items": {
+                        "type": "string",
+                        "minLength": 1
+                      }
+                    },
+                    "repository_effects": {
+                      "type": "array",
+                      "items": {
+                        "type": "string",
+                        "enum": [
+                          "repository_write",
+                          "documentation",
+                          "source_code",
+                          "tests",
+                          "public_api",
+                          "schema",
+                          "dependencies",
+                          "ci",
+                          "release_metadata",
+                          "security_boundary"
+                        ]
+                      }
+                    }
+                  },
+                  "required": [
+                    "schema_version",
+                    "rationale",
+                    "scope_roots",
+                    "repository_effects"
+                  ],
+                  "additionalProperties": false
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "schema_version": {
+                      "type": "number",
+                      "const": 1
+                    },
+                    "rationale": {
+                      "type": "string",
+                      "minLength": 1
+                    },
+                    "scope_roots": {
+                      "type": "array",
+                      "items": {
+                        "type": "string",
+                        "minLength": 1
+                      }
+                    },
+                    "repository_effects": {
+                      "minItems": 1,
+                      "type": "array",
+                      "items": {
+                        "type": "string",
+                        "enum": [
+                          "repository_write",
+                          "documentation",
+                          "source_code",
+                          "tests",
+                          "public_api",
+                          "schema",
+                          "dependencies",
+                          "ci",
+                          "release_metadata",
+                          "security_boundary"
+                        ]
+                      }
+                    }
+                  },
+                  "required": [
+                    "schema_version",
+                    "rationale",
+                    "scope_roots",
+                    "repository_effects"
+                  ],
+                  "additionalProperties": false
+                }
+              ]
+            }
+          },
+          "required": [
+            "summary"
+          ],
+          "additionalProperties": false
+        },
+        "knowledge_request": {
+          "type": "object",
+          "properties": {
+            "schema_version": {
+              "type": "number",
+              "const": 1
+            },
+            "kind": {
+              "type": "string",
+              "const": "knowledge_request"
+            },
+            "query": {
+              "type": "string",
+              "minLength": 1
+            },
+            "reason": {
+              "type": "string",
+              "minLength": 1
+            },
+            "desired_kind": {
+              "type": "string",
+              "enum": [
+                "any",
+                "wiki",
+                "source",
+                "fact",
+                "entity",
+                "edge"
+              ]
+            },
+            "scope": {
+              "type": "string",
+              "enum": [
+                "task_context"
+              ]
+            },
+            "blocking": {
+              "type": "boolean"
+            }
+          },
+          "required": [
+            "schema_version",
+            "kind",
+            "query",
+            "reason",
+            "desired_kind",
+            "scope",
+            "blocking"
+          ],
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "schema_version",
+        "kind",
+        "work_order_id",
+        "summary",
+        "findings",
+        "uncertainty",
+        "status"
+      ],
+      "additionalProperties": false
+    }
+  ]
+}

--- a/packages/agentplane/src/adapters/task-backend/kernel-authority-schema.ts
+++ b/packages/agentplane/src/adapters/task-backend/kernel-authority-schema.ts
@@ -45,10 +45,15 @@ export const kernelAuthorityRecordSchema = z.strictObject({
     .nullable(),
   observation: z
     .strictObject({
-      kind: z.enum(["plan_amendment", "repository_implementation"]),
+      kind: z.enum(["plan_amendment", "repository_implementation", "authority_delta"]),
       evidence_digest: digest,
       previous_fingerprint: digest,
       changed_paths: strings,
+      request_digest: digest.optional(),
+      added_scope_roots: strings.optional(),
+      added_repository_effects: strings.optional(),
+      request_task_revision: z.number().int().nonnegative().optional(),
+      repository_evidence_digest: digest.optional(),
     })
     .nullable(),
 });

--- a/packages/agentplane/src/cli/run-cli.core.kernel-transport.test.ts
+++ b/packages/agentplane/src/cli/run-cli.core.kernel-transport.test.ts
@@ -1,5 +1,12 @@
+import { KernelTaskLifecycle } from "../runner/usecases/kernel-task-lifecycle.js";
+import { execFileSync } from "node:child_process";
+import * as finalChecks from "../commands/task/direct-task-verification.js";
+import {
+  acceptKernelInspection,
+  resumeKernelInspection,
+} from "../commands/task/kernel-inspection.js";
 import { AGENT_WORK_ORDER_V2_ZOD_SCHEMA } from "@agentplaneorg/core/schemas";
-import { readFile, writeFile, rm } from "node:fs/promises";
+import { mkdir, readFile, writeFile, rm } from "node:fs/promises";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { TASK_CENTRIC_EXTENSION_KEY, taskKernel as k } from "@agentplaneorg/core/tasks";
@@ -13,7 +20,10 @@ import {
 import { defaultConfig } from "./core-imports.js";
 import { runCli } from "./run-cli.js";
 import { runJson } from "./task-create-planner-intent.testkit.js";
-import { loadCommandContext } from "../commands/shared/task-backend.js";
+import {
+  loadCommandContext,
+  resolveTaskOwnerCommandContext,
+} from "../commands/shared/task-backend.js";
 import {
   requireKernelCommit,
   createKernelRuntime,
@@ -90,6 +100,38 @@ async function installCloudBackend(root: string) {
 installRunCliIntegrationHarness();
 afterEach(() => vi.restoreAllMocks());
 describe("canonical CLI transport", { timeout: 60_000 }, () => {
+  it("keeps canonical observation and WorkOrder roots in the invocation worktree", async () => {
+    const root = await mkGitRepoRootWithCommit();
+    await writeConfig(root, defaultConfig());
+    const taskId = await createTask(root);
+    const git = (args: string[]) =>
+      execFileSync("git", ["-c", "core.hooksPath=/dev/null", ...args], { cwd: root });
+    git(["add", "."]);
+    git(["commit", "-m", "canonical worktree fixture"]);
+    const linked = path.join(root, ".agentplane/worktrees/canonical-context");
+    git(["worktree", "add", "-b", "canonical-context", linked]);
+    const initial = await loadCommandContext({ cwd: linked });
+    const command = await resolveTaskOwnerCommandContext({ ctx: initial, taskId });
+    expect(command.resolvedProject.gitRoot).toBe(initial.resolvedProject.gitRoot);
+    const runtime = await createKernelRuntime({
+      command,
+      task_id: taskId,
+      transport: "host",
+      operation_id: "worktree-fixture",
+    });
+    const before = await runtime.observe();
+    await writeFile(path.join(root, "unrelated-primary.txt"), "primary change");
+    expect((await runtime.observe()).fingerprint).toBe(before.fingerprint);
+    const packet = await runJson(linked, ["task", "advance", taskId, "--agent-json"]);
+    const exchange = packet.exchange as { directory: string };
+    const order = JSON.parse(
+      await readFile(path.join(exchange.directory, "work-order.json"), "utf8"),
+    );
+    expect(order.state_fingerprint.worktree).toBe(initial.resolvedProject.gitRoot);
+    expect(order.canonical_binding.repository_fingerprint).toBe(before.fingerprint);
+    await writeFile(path.join(linked, "local-change.txt"), "local change");
+    expect((await runtime.observe()).fingerprint).not.toBe(before.fingerprint);
+  });
   it.each(["local", "cloud"] as const)(
     "canonical first-write and host lifecycle on %s storage",
     async (backendKind) => {
@@ -263,53 +305,116 @@ describe("canonical CLI transport", { timeout: 60_000 }, () => {
         implementationExchange.result_path,
         "--agent-json",
       ]);
-      expect(accepted.action).toMatchObject({ reason: "kernel_work_item_inspection_required" });
+      expect(accepted.action).toMatchObject({ kind: "agent_episode" });
       const finalRead = await runtime.adapter.read(taskId);
       expect(finalRead.kind).toBe("canonical");
       if (finalRead.kind !== "canonical") throw new Error("Canonical result readback missing");
       expect(finalRead.record.aggregate.work_items.build).toMatchObject({
-        state: "RESULT_RECEIVED",
+        state: "INSPECTING",
         attempt: 1,
       });
       expect(finalRead.task.extensions?.[TASK_CENTRIC_EXTENSION_KEY]).toBeUndefined();
       expect(finalRead.record.aggregate.authority_lineage?.at(-1)?.observation?.kind).toBe(
         "repository_implementation",
       );
-      const item = finalRead.record.aggregate.work_items.build!;
-      // Fixture-only native validation. This is not production artifact qualification.
-      for (const payload of [
-        {
-          kind: "transition_work_item",
-          action: "inspect",
-          work_item_id: "build",
-          claim_id: item.claim_id,
-        },
-        {
-          kind: "record_work_item_validation",
-          work_item_id: "build",
-          validation: {
-            status: "PASSED",
-            identity: {
-              implementation_identity: item.result_digest!,
-              check_id: "fixture",
-              command_digest: k.kernelDigest("test"),
-              toolchain_digest: k.kernelDigest("toolchain"),
-              environment_digest: k.kernelDigest("env"),
-            },
-            evidence_digests: [k.kernelDigest("fixture-log")],
-            observed_at: new Date().toISOString(),
+      await mkdir(path.join(root, "packages/core/schemas"), { recursive: true });
+      await writeFile(path.join(root, "packages/core/schemas/generated.json"), "{}");
+      const delta = await runJson(root, ["task", "advance", taskId, "--agent-json"]);
+      expect(delta.action).toMatchObject({
+        kind: "human_required",
+        reason: "canonical_authority_delta_requires_user",
+        authority_delta: {
+          request: {
+            added_scope_roots: ["packages/core/schemas/generated.json"],
+            added_repository_effects: ["repository_write", "schema"],
           },
         },
-        {
-          kind: "transition_work_item",
-          action: "complete",
-          work_item_id: "build",
-          claim_id: item.claim_id,
+      });
+      const operatorArgv = (delta.action as { operator_action: { argv: string[] } }).operator_action
+        .argv;
+      await runCliSilent([...operatorArgv.slice(1), "--root", root]);
+      const afterDelta = await runtime.adapter.read(taskId);
+      if (afterDelta.kind !== "canonical") throw new Error("Authority delta fixture missing");
+      expect(afterDelta.record.aggregate.current_plan).toEqual(
+        finalRead.record.aggregate.current_plan,
+      );
+      expect(afterDelta.record.aggregate.work_items).toEqual(finalRead.record.aggregate.work_items);
+      expect(afterDelta.record.aggregate.authority_lineage?.at(-1)).toMatchObject({
+        approval_mode: "manual_operator",
+        observation: {
+          kind: "authority_delta",
+          added_scope_roots: ["packages/core/schemas/generated.json"],
         },
-      ] as const)
-        requireKernelCommit(
-          await runtime.lifecycle.apply(await runtime.input(payload, k.kernelDigest(payload))),
-        );
+      });
+      const resumed = await runJson(root, ["task", "advance", taskId, "--agent-json"]);
+      expect(resumed.action).toMatchObject({ kind: "agent_episode" });
+      const item = finalRead.record.aggregate.work_items.build!;
+      const inspectionExchange = resumed.exchange as { directory: string; result_path: string };
+      const inspection = AGENT_WORK_ORDER_V2_ZOD_SCHEMA.parse(
+        JSON.parse(
+          await readFile(path.join(inspectionExchange.directory, "work-order.json"), "utf8"),
+        ),
+      );
+      expect(inspection).toMatchObject({
+        role: "EVALUATOR",
+        authority: { mutation_scope: "none", writable_roots: [] },
+      });
+      expect(inspection.canonical_binding).toMatchObject({
+        phase: "inspection",
+        result_digest: item.result_digest,
+      });
+      const repeatedInspection = await runJson(root, ["task", "advance", taskId, "--agent-json"]);
+      expect(repeatedInspection.exchange).toEqual(resumed.exchange);
+      const review = {
+        schema_version: 2 as const,
+        kind: "agent_semantic_result" as const,
+        work_order_id: inspection.work_order_id,
+        canonical_binding: inspection.canonical_binding,
+        status: "completed" as const,
+        summary: "Independent inspection passed",
+        findings: [],
+        uncertainty: [],
+        review: {
+          verdict: "pass" as const,
+          missing_tests: [],
+          hidden_assumptions: [],
+          residual_risks: [],
+        },
+      };
+      await writeFile(path.join(root, "result.txt"), "changed after inspection");
+      await expect(
+        acceptKernelInspection(command, runtime, inspectionExchange.directory, review),
+      ).rejects.toThrow("stale");
+      await writeFile(path.join(root, "result.txt"), "implementation");
+      const apply = runtime.lifecycle.apply.bind(runtime.lifecycle);
+      const crash = vi.spyOn(runtime.lifecycle, "apply").mockImplementation(async (...args) => {
+        const result = await apply(...args);
+        if (args[0].command.kind === "record_work_item_validation")
+          throw new Error("crash after durable validation");
+        return result;
+      });
+      await expect(
+        acceptKernelInspection(command, runtime, inspectionExchange.directory, review),
+      ).rejects.toThrow("crash after durable validation");
+      crash.mockRestore();
+      const interrupted = await runtime.adapter.read(taskId);
+      if (interrupted.kind !== "canonical") throw new Error("Native validation missing");
+      expect(interrupted.record.aggregate.work_items.build!.state).toBe("VALIDATING");
+      await resumeKernelInspection(command, runtime, interrupted.record, "build");
+
+      const evidence = JSON.parse(
+        await readFile(path.join(inspectionExchange.directory, "validation.json"), "utf8"),
+      );
+      expect(evidence.checks).toMatchObject({
+        status: "passed",
+        checks: [{ command: "node --version", exit_code: 0 }],
+      });
+      await acceptKernelInspection(command, runtime, inspectionExchange.directory, review);
+      expect(
+        JSON.parse(
+          await readFile(path.join(inspectionExchange.directory, "validation.json"), "utf8"),
+        ),
+      ).toEqual(evidence);
       const completed = await runtime.adapter.read(taskId);
       if (completed.kind !== "canonical") throw new Error("Completed fixture missing");
       const refined = structuredClone(semantic.canonical_plan);
@@ -382,8 +487,17 @@ describe("canonical CLI transport", { timeout: 60_000 }, () => {
         result.canonical_plan = { work_items: [{ id: 'build', depends_on: [], required_inputs: [], expected_outputs: ['source'], optional: false,
           execution_requirements: { scope_roots: ['result.txt'], repository_effects: ['source_code'], external_effects: [], capabilities: ['repository_write'], resources: [] },
           contract: { role: 'EXECUTOR', objective: 'Write result.txt', acceptance_criteria: ['Result exists'], verification_commands: ['node --version'] } }] };
+      } else if (order.role === 'EVALUATOR') {
+        assert.equal(order.authority.mutation_scope, 'none');
+        result.review = { verdict: ${backendKind === "cloud" ? "order.canonical_binding.attempt === 1 ? 'rework' : 'pass'" : "'pass'"}, missing_tests: [], hidden_assumptions: [], residual_risks: [] };
       } else {
         assert(order.required_outputs.some(output => output.id === 'output:source'));
+        if (order.canonical_binding.attempt > 1) {
+          const review = order.required_inputs.find(input => input.id.startsWith('review:'));
+          assert(review && review.required);
+          assert.equal(JSON.parse(fs.readFileSync(review.path, 'utf8')).review.verdict, 'rework');
+          assert(order.required_inputs.some(input => input.id.startsWith('checks:') && input.required));
+        }
         fs.writeFileSync('result.txt', 'managed implementation');
         result.canonical_outputs = [{ id: 'source', kind: 'source', digest: 'sha256:' + require('node:crypto').createHash('sha256').update('managed implementation').digest('hex') }];
       }
@@ -419,13 +533,87 @@ describe("canonical CLI transport", { timeout: 60_000 }, () => {
       }
       expect(planned.action).toMatchObject({ kind: "approval_required" });
       await runCliSilent(["task", "plan", "approve", taskId, "--by", "USER", "--root", root]);
+      const command = await loadCommandContext({ cwd: root });
+      const runtime = await createKernelRuntime({
+        command,
+        task_id: taskId,
+        transport: "managed",
+        operation_id: "inspect-completion",
+      });
+      if (backendKind === "local") {
+        const unchanged = await runtime.adapter.read(taskId);
+        if (unchanged.kind !== "canonical") throw new Error("Missing canonical plan");
+        const noProgress = vi.spyOn(KernelTaskLifecycle.prototype, "apply").mockResolvedValue({
+          kind: "committed",
+          record: unchanged.record,
+          receipts: [],
+          replayed: true,
+        } as never);
+        try {
+          const stopped = await runJson(root, ["task", "run", taskId, "--json"]);
+          expect(stopped.action).toMatchObject({
+            kind: "human_required",
+            reason: "canonical_transition_no_progress",
+          });
+          expect(execute).toHaveBeenCalledTimes(1);
+        } finally {
+          noProgress.mockRestore();
+        }
+        const verify = finalChecks.runDirectTaskVerification;
+        let calls = 0;
+        const drift = vi
+          .spyOn(finalChecks, "runDirectTaskVerification")
+          .mockImplementation(async (options) => {
+            const result = await verify(options);
+            if (++calls === 2)
+              await writeFile(path.join(root, "result.txt"), "changed during final validation");
+            return result;
+          });
+        try {
+          await refused(root, ["task", "run", taskId, "--json"], "inputs changed during checks");
+        } finally {
+          drift.mockRestore();
+        }
+        await writeFile(path.join(root, "result.txt"), "managed implementation");
+      } else {
+        const apply = KernelTaskLifecycle.prototype.apply;
+        const crash = vi
+          .spyOn(KernelTaskLifecycle.prototype, "apply")
+          .mockImplementation(async function (...args) {
+            const result = await apply.apply(this, args);
+            if (args[0].command.kind === "record_final_validation")
+              throw new Error("crash after final validation");
+            return result;
+          });
+        try {
+          await refused(root, ["task", "run", taskId, "--json"], "crash after final validation");
+        } finally {
+          crash.mockRestore();
+        }
+        const interrupted = await runtime.adapter.read(taskId);
+        expect(interrupted.kind === "canonical" && interrupted.record.aggregate.state).toBe(
+          "FINAL_VALIDATION",
+        );
+      }
       const implemented = await runJson(root, ["task", "run", taskId, "--json"]);
-      expect(implemented.action).toMatchObject({ reason: "kernel_work_item_inspection_required" });
+      expect(implemented.action).toMatchObject({
+        kind: "terminal",
+        reason: "kernel_task_completed",
+      });
+      const completed = await runtime.adapter.read(taskId);
+      if (completed.kind !== "canonical") throw new Error("Missing completed task");
+      expect(completed.record.aggregate.final_validation?.status).toBe("PASSED");
+      if (backendKind === "cloud")
+        expect(
+          Object.keys(completed.record.aggregate.mutation_receipts).filter((id) =>
+            id.startsWith("final-validation:"),
+          ),
+        ).toHaveLength(2);
       expect(await readFile(path.join(root, "result.txt"), "utf8")).toBe("managed implementation");
-      expect(execute).toHaveBeenCalledTimes(2);
+      expect(execute).toHaveBeenCalledTimes(backendKind === "cloud" ? 5 : 3);
       const again = await runJson(root, ["task", "run", taskId, "--json"]);
-      expect(again.action).toMatchObject({ reason: "kernel_work_item_inspection_required" });
-      expect(execute).toHaveBeenCalledTimes(2);
+      expect(again.action).toMatchObject({ kind: "terminal", reason: "kernel_task_completed" });
+      expect(execute).toHaveBeenCalledTimes(backendKind === "cloud" ? 5 : 3);
     },
   );
 });

--- a/packages/agentplane/src/cli/run-cli.core.kernel-transport.test.ts
+++ b/packages/agentplane/src/cli/run-cli.core.kernel-transport.test.ts
@@ -24,10 +24,7 @@ import {
   loadCommandContext,
   resolveTaskOwnerCommandContext,
 } from "../commands/shared/task-backend.js";
-import {
-  requireKernelCommit,
-  createKernelRuntime,
-} from "../commands/task/kernel-runtime-context.js";
+import { createKernelRuntime } from "../commands/task/kernel-runtime-context.js";
 
 import { makeTaskBackendDouble } from "@agentplane/testkit/task";
 import * as taskBackend from "../backends/task-backend.js";
@@ -121,16 +118,16 @@ describe("canonical CLI transport", { timeout: 60_000 }, () => {
     });
     const before = await runtime.observe();
     await writeFile(path.join(root, "unrelated-primary.txt"), "primary change");
-    expect((await runtime.observe()).fingerprint).toBe(before.fingerprint);
+    expect(await runtime.observe()).toMatchObject({ fingerprint: before.fingerprint });
     const packet = await runJson(linked, ["task", "advance", taskId, "--agent-json"]);
     const exchange = packet.exchange as { directory: string };
-    const order = JSON.parse(
-      await readFile(path.join(exchange.directory, "work-order.json"), "utf8"),
+    const order = AGENT_WORK_ORDER_V2_ZOD_SCHEMA.parse(
+      JSON.parse(await readFile(path.join(exchange.directory, "work-order.json"), "utf8")),
     );
     expect(order.state_fingerprint.worktree).toBe(initial.resolvedProject.gitRoot);
-    expect(order.canonical_binding.repository_fingerprint).toBe(before.fingerprint);
+    expect(order.canonical_binding?.repository_fingerprint).toBe(before.fingerprint);
     await writeFile(path.join(linked, "local-change.txt"), "local change");
-    expect((await runtime.observe()).fingerprint).not.toBe(before.fingerprint);
+    expect(await runtime.observe()).not.toMatchObject({ fingerprint: before.fingerprint });
   });
   it.each(["local", "cloud"] as const)(
     "canonical first-write and host lifecycle on %s storage",
@@ -404,7 +401,7 @@ describe("canonical CLI transport", { timeout: 60_000 }, () => {
 
       const evidence = JSON.parse(
         await readFile(path.join(inspectionExchange.directory, "validation.json"), "utf8"),
-      );
+      ) as { checks: unknown };
       expect(evidence.checks).toMatchObject({
         status: "passed",
         checks: [{ command: "node --version", exit_code: 0 }],
@@ -576,6 +573,8 @@ describe("canonical CLI transport", { timeout: 60_000 }, () => {
         }
         await writeFile(path.join(root, "result.txt"), "managed implementation");
       } else {
+        // The captured method is invoked with its original receiver through apply below.
+        // eslint-disable-next-line @typescript-eslint/unbound-method
         const apply = KernelTaskLifecycle.prototype.apply;
         const crash = vi
           .spyOn(KernelTaskLifecycle.prototype, "apply")

--- a/packages/agentplane/src/cli/run-cli.core.task-advance-effect-recovery.test.ts
+++ b/packages/agentplane/src/cli/run-cli.core.task-advance-effect-recovery.test.ts
@@ -37,10 +37,6 @@ import {
   validateExternalAgentResultEnvelope,
   type ExternalAgentExchange,
 } from "../commands/task/external-agent-exchange.js";
-import {
-  requiresImplementationRecoveryReplacement,
-  requiresPlanningRecoveryReplacement,
-} from "../commands/task/external-agent-supervisor-recovery.js";
 import { blockingImplementationAuthorityViolations } from "../commands/task/external-agent-implementation-authority.js";
 import { defaultConfig } from "./core-imports.js";
 import { runCli } from "./run-cli.js";
@@ -128,53 +124,6 @@ describe("task advance effect recovery", () => {
     exerciseIntegrationEffectRecovery(scenario),
   );
 
-  it("requires replacement when a non-planning result predates an explicit PLANNER reset", () => {
-    const stateFingerprint = `sha256:${"a".repeat(64)}`;
-    const planningFingerprint = `sha256:${"b".repeat(64)}`;
-    expect(
-      requiresPlanningRecoveryReplacement({
-        decision: {
-          workflowStep: {
-            kind: "agent_episode",
-            episode: { purpose: "planning" },
-            preconditionFingerprint: { digest: planningFingerprint },
-          },
-        } as never,
-        exchange: {
-          purpose: "implementation",
-          state_fingerprint: stateFingerprint,
-        } as ExternalAgentExchange,
-      }),
-    ).toBe(true);
-  });
-
-  it.each([
-    ["result_received", true, true],
-    ["result_received", false, false],
-    ["accepted", true, false],
-    ["consumed", true, false],
-  ])("bounds planning replacement for %s with drift=%s", (status, drift, expected) => {
-    const fingerprint = `sha256:${"a".repeat(64)}`;
-    expect(
-      requiresPlanningRecoveryReplacement({
-        decision: {
-          workflowStep: {
-            kind: "agent_episode",
-            episode: { purpose: "planning" },
-            preconditionFingerprint: {
-              digest: drift ? `sha256:${"b".repeat(64)}` : fingerprint,
-            },
-          },
-        } as never,
-        exchange: {
-          purpose: "planning",
-          status,
-          state_fingerprint: fingerprint,
-        } as ExternalAgentExchange,
-      }),
-    ).toBe(expected);
-  });
-
   it("retires a received stale planning result and issues one repeatable fresh episode", async () => {
     const root = await mkGitRepoRootWithCommit();
     const config = defaultConfig();
@@ -243,76 +192,6 @@ describe("task advance effect recovery", () => {
     ]);
     expect(oldResult.code).not.toBe(0);
     expect(oldResult.stderr).toContain("retired");
-  });
-
-  it("requires replacement when plan approval changes pending implementation authority", () => {
-    const taskDigest = `sha256:${"a".repeat(64)}`;
-    const backendDigest = `sha256:${"b".repeat(64)}`;
-    const authorityDigest = `sha256:${"e".repeat(64)}`;
-    const fingerprint = {
-      task_id: "202608171106-XFN696",
-      task_revision: 16,
-      worktree: "/repo/.agentplane/worktrees/task",
-      components: {
-        task: { digest: taskDigest },
-        backend_projection: { digest: backendDigest },
-        provider: { digest: `sha256:${"0".repeat(64)}` },
-        authority: { digest: authorityDigest },
-      },
-    };
-    const decision = {
-      workflowStep: {
-        preconditionFingerprint: {
-          ...fingerprint,
-          task_revision: 19,
-          digest: `sha256:${"c".repeat(64)}`,
-        },
-      },
-    } as never;
-    const exchange = { purpose: "task_worktree_resolution" } as ExternalAgentExchange;
-    const workOrder = { state_fingerprint: fingerprint } as AgentWorkOrderV2;
-
-    expect(
-      requiresImplementationRecoveryReplacement({ decision, exchange, work_order: workOrder }),
-    ).toBe(true);
-    expect(
-      requiresImplementationRecoveryReplacement({
-        decision,
-        exchange: { purpose: "implementation_rework" } as ExternalAgentExchange,
-        work_order: workOrder,
-      }),
-    ).toBe(true);
-    expect(
-      requiresImplementationRecoveryReplacement({
-        decision: {
-          workflowStep: {
-            preconditionFingerprint: {
-              ...fingerprint,
-              digest: `sha256:${"d".repeat(64)}`,
-            },
-          },
-        } as never,
-        exchange,
-        work_order: workOrder,
-      }),
-    ).toBe(false);
-    expect(
-      requiresImplementationRecoveryReplacement({
-        decision: {
-          workflowStep: {
-            preconditionFingerprint: {
-              ...fingerprint,
-              components: {
-                ...fingerprint.components,
-                authority: { digest: `sha256:${"f".repeat(64)}` },
-              },
-            },
-          },
-        } as never,
-        exchange,
-        work_order: workOrder,
-      }),
-    ).toBe(true);
   });
 
   it("lets implementation rework proceed past stale verification failures only", () => {

--- a/packages/agentplane/src/cli/run-cli.core.task-advance-effect-recovery.test.ts
+++ b/packages/agentplane/src/cli/run-cli.core.task-advance-effect-recovery.test.ts
@@ -226,7 +226,7 @@ describe("task advance effect recovery", () => {
     ]);
     expect(replacement.code, replacement.stderr).toBe(0);
     const fresh = JSON.parse(replacement.stdout) as AgentPacket;
-    expect(fresh.action.kind).toBe("agent_episode");
+    expect(fresh).toMatchObject({ action: { kind: "agent_episode" } });
     expect(fresh.transition_id).not.toBe(issued.transition_id);
     expect(fresh.state_fingerprint).not.toBe(issued.state_fingerprint);
     const replay = await readAgentPacket(root, taskId);

--- a/packages/agentplane/src/cli/run-cli.core.task-advance-effect-recovery.test.ts
+++ b/packages/agentplane/src/cli/run-cli.core.task-advance-effect-recovery.test.ts
@@ -148,6 +148,103 @@ describe("task advance effect recovery", () => {
     ).toBe(true);
   });
 
+  it.each([
+    ["result_received", true, true],
+    ["result_received", false, false],
+    ["accepted", true, false],
+    ["consumed", true, false],
+  ])("bounds planning replacement for %s with drift=%s", (status, drift, expected) => {
+    const fingerprint = `sha256:${"a".repeat(64)}`;
+    expect(
+      requiresPlanningRecoveryReplacement({
+        decision: {
+          workflowStep: {
+            kind: "agent_episode",
+            episode: { purpose: "planning" },
+            preconditionFingerprint: {
+              digest: drift ? `sha256:${"b".repeat(64)}` : fingerprint,
+            },
+          },
+        } as never,
+        exchange: {
+          purpose: "planning",
+          status,
+          state_fingerprint: fingerprint,
+        } as ExternalAgentExchange,
+      }),
+    ).toBe(expected);
+  });
+
+  it("retires a received stale planning result and issues one repeatable fresh episode", async () => {
+    const root = await mkGitRepoRootWithCommit();
+    const config = defaultConfig();
+    config.workflow_mode = "branch_pr";
+    await writeConfig(root, config);
+    const taskId = await createTask(root);
+    const issued = await readAgentPacket(root, taskId);
+    const resultPath = await writePlanningResult(issued, "Plan against the original snapshot.");
+    await writeFile(path.join(root, "parallel-change.txt"), "new repository input\n");
+    const rejected = await captureRecoveryCli([
+      "task",
+      "advance",
+      taskId,
+      "--result",
+      resultPath,
+      "--agent-json",
+      "--root",
+      root,
+    ]);
+    expect(rejected.code).not.toBe(0);
+    expect(rejected.stderr).toContain("External-agent result is stale");
+    if (!issued.exchange) throw new Error("expected exchange");
+    const exchangePath = path.join(issued.exchange.directory, "exchange.json");
+    const received = JSON.parse(await readFile(exchangePath, "utf8")) as ExternalAgentExchange;
+    expect(received.status).toBe("result_received");
+    const retired = await captureRecoveryCli([
+      "task",
+      "advance",
+      taskId,
+      "--agent-json",
+      "--root",
+      root,
+    ]);
+    expect(retired.code).not.toBe(0);
+    expect(retired.stderr).toContain("retired the stale result");
+    expect(JSON.parse(await readFile(exchangePath, "utf8"))).toMatchObject({
+      status: "retired",
+      result_digest: received.result_digest,
+      result: received.result,
+    });
+    const replacement = await captureRecoveryCli([
+      "task",
+      "advance",
+      taskId,
+      "--replacement",
+      "--agent-json",
+      "--root",
+      root,
+    ]);
+    expect(replacement.code, replacement.stderr).toBe(0);
+    const fresh = JSON.parse(replacement.stdout) as AgentPacket;
+    expect(fresh.action.kind).toBe("agent_episode");
+    expect(fresh.transition_id).not.toBe(issued.transition_id);
+    expect(fresh.state_fingerprint).not.toBe(issued.state_fingerprint);
+    const replay = await readAgentPacket(root, taskId);
+    expect(replay.transition_id).toBe(fresh.transition_id);
+    const oldResult = await captureRecoveryCli([
+      "task",
+      "advance",
+      taskId,
+      "--result",
+      resultPath,
+      "--agent-json",
+      "--root",
+      root,
+    ]);
+    expect(oldResult.code).not.toBe(0);
+    expect(oldResult.stderr).toContain("retired");
+  });
+
   it("requires replacement when plan approval changes pending implementation authority", () => {
     const taskDigest = `sha256:${"a".repeat(64)}`;
     const backendDigest = `sha256:${"b".repeat(64)}`;

--- a/packages/agentplane/src/cli/run-cli.core.task-advance.evidence-rework.test.ts
+++ b/packages/agentplane/src/cli/run-cli.core.task-advance.evidence-rework.test.ts
@@ -187,6 +187,10 @@ async function completedFixture(initialized = true) {
   if (initialized) {
     expect(completed.extensions?.task_execution_context).toEqual(creationBase);
   }
+  const beforeReviewCommit = await git("git", ["log", "-1", "--format=%s"], { cwd: checkout });
+  expect(beforeReviewCommit.stdout).not.toContain("record external implementation evidence");
+  const pendingEvidence = await git("git", ["status", "--porcelain"], { cwd: checkout });
+  expect(pendingEvidence.stdout).toContain(`.agentplane/tasks/${taskId}/`);
   const reviewOrder = await order(review);
   expect(reviewOrder.role).toBe("EVALUATOR");
   expect(
@@ -203,6 +207,15 @@ async function completedFixture(initialized = true) {
     },
   });
   await resume(checkout, review);
+  const committedChecks = await git(
+    "git",
+    ["show", `HEAD:.agentplane/tasks/${taskId}/supervision/declared-checks.json`],
+    { cwd: checkout },
+  );
+  expect(JSON.parse(committedChecks.stdout).status).toBe("passed");
+  const combinedCommit = await git("git", ["log", "-1", "--format=%s"], { cwd: checkout });
+  expect(combinedCommit.stdout).toContain("record external evaluator result");
+
   // The operator supplies task documentation before a fresh semantic episode.
   expect(
     await runCliSilent([

--- a/packages/agentplane/src/cli/run-cli.core.task-advance.evidence-rework.test.ts
+++ b/packages/agentplane/src/cli/run-cli.core.task-advance.evidence-rework.test.ts
@@ -212,7 +212,7 @@ async function completedFixture(initialized = true) {
     ["show", `HEAD:.agentplane/tasks/${taskId}/supervision/declared-checks.json`],
     { cwd: checkout },
   );
-  expect(JSON.parse(committedChecks.stdout).status).toBe("passed");
+  expect(JSON.parse(committedChecks.stdout)).toMatchObject({ status: "passed" });
   const combinedCommit = await git("git", ["log", "-1", "--format=%s"], { cwd: checkout });
   expect(combinedCommit.stdout).toContain("record external evaluator result");
 

--- a/packages/agentplane/src/cli/run-cli.critical.agent-efficiency-baseline.test.ts
+++ b/packages/agentplane/src/cli/run-cli.critical.agent-efficiency-baseline.test.ts
@@ -226,6 +226,7 @@ describeCritical("critical: v0.7 compatibility and agent-efficiency baselines", 
           "202608301851-5W3XW6",
           "202609030849-925NNG",
           "202609060720-NZXQ0E",
+          "202609071501-VN1FN4",
         ],
         candidate: {
           surface_sha256: "8ba01d347981b2efb96b0a3645140026934f97f42552d88949bddb07ca78e0e4",
@@ -351,9 +352,9 @@ describeCritical("critical: v0.7 compatibility and agent-efficiency baselines", 
           },
           agent_work_order_schema: {
             path: "schemas/agent-work-order-v2.schema.json",
-            sha256: "4f57a53b795c054d112b9126a6a06a69ba4e417e6cf5de1dd5b048f14ae73619",
+            sha256: "59ba5559d26e8f70271d78dca89f78a6f82461f16c711d9c9b8031ec150f97f0",
             comparison: "canonical_json_exact",
-            source_task: "202608291006-255K66",
+            source_task: "202609071501-VN1FN4",
           },
           core_agent_work_order_exports: {
             comparison: "required_named_reexports",
@@ -930,7 +931,7 @@ describeCritical("repository efficiency snapshots", () => {
       const expression = `import { measureRepositoryEfficiency } from ${JSON.stringify(moduleUrl)}; console.log(JSON.stringify(measureRepositoryEfficiency({ repoRoot: ${JSON.stringify(root)} })));`;
       const first = await runNode(["--input-type=module", "-e", expression]);
       expect(first.exitCode).toBe(0);
-      const snapshot = JSON.parse(first.stdout);
+      const snapshot = JSON.parse(first.stdout) as { totals: unknown; tasks: unknown[] };
       expect(snapshot.totals).toMatchObject({
         sampled_tasks: 1,
         tasks_with_usage: 0,

--- a/packages/agentplane/src/cli/run-cli.critical.agent-efficiency-baseline.test.ts
+++ b/packages/agentplane/src/cli/run-cli.critical.agent-efficiency-baseline.test.ts
@@ -902,3 +902,51 @@ describeCritical("critical: v0.7 compatibility and agent-efficiency baselines", 
     TEST_TIMEOUT_MS,
   );
 });
+
+describeCritical("repository efficiency snapshots", () => {
+  it(
+    "binds sampling to Git evidence and preserves unavailable usage",
+    async () => {
+      const root = await makeRepoTempRoot();
+      const git = (...args: string[]) => execFileAsync("git", args, { cwd: root });
+      await git("init");
+      await mkdir(path.join(root, "packages/agentplane"), { recursive: true });
+      await mkdir(path.join(root, ".agentplane/tasks/T1"), { recursive: true });
+      await writeFile(path.join(root, "packages/agentplane/package.json"), "{}\n");
+      await writeFile(path.join(root, ".agentplane/tasks/T1/README.md"), "---\nid: T1\n---\n");
+      await git("add", ".");
+      await git(
+        "-c",
+        "user.name=Test",
+        "-c",
+        "user.email=test@example.invalid",
+        "commit",
+        "-m",
+        "fixture",
+      );
+      const moduleUrl = pathToFileURL(
+        path.join(REPO_ROOT, "scripts/lib/agent-efficiency-repository-snapshot.mjs"),
+      ).href;
+      const expression = `import { measureRepositoryEfficiency } from ${JSON.stringify(moduleUrl)}; console.log(JSON.stringify(measureRepositoryEfficiency({ repoRoot: ${JSON.stringify(root)} })));`;
+      const first = await runNode(["--input-type=module", "-e", expression]);
+      expect(first.exitCode).toBe(0);
+      const snapshot = JSON.parse(first.stdout);
+      expect(snapshot.totals).toMatchObject({
+        sampled_tasks: 1,
+        tasks_with_usage: 0,
+        service_commits: 0,
+        input_tokens: { value: null, tasks_observed: 0 },
+      });
+      expect(snapshot.tasks[0]).toMatchObject({
+        work_items: null,
+        roles: null,
+        prepared_context_bytes: null,
+        delivered_context_bytes: null,
+      });
+      await writeFile(path.join(root, ".agentplane/tasks/T1/README.md"), "uncommitted mutation");
+      const repeated = await runNode(["--input-type=module", "-e", expression]);
+      expect(repeated.stdout).toBe(first.stdout);
+    },
+    TEST_TIMEOUT_MS,
+  );
+});

--- a/packages/agentplane/src/commands/evaluator/evaluator-evidence-store.test.ts
+++ b/packages/agentplane/src/commands/evaluator/evaluator-evidence-store.test.ts
@@ -1,3 +1,8 @@
+import {
+  buildAgentWorkOrderV2ValidFixture,
+  renderAgentSemanticResultSchemaJson,
+} from "@agentplaneorg/core/schemas";
+import { issueKernelExchange } from "../task/kernel-exchange.js";
 import { mkdir, readFile, readdir, rename, rm, symlink, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { mkGitRepoRoot } from "@agentplane/testkit";
@@ -435,4 +440,67 @@ describe("evaluator evidence object store", () => {
       await rm(outsideRoot, { recursive: true, force: true });
     }
   });
+});
+
+it("shares canonical result schemas across new exchanges and preserves historical schema copies", async () => {
+  const root = await mkGitRepoRoot();
+  const command = {
+    resolvedProject: { gitRoot: root },
+    config: { paths: { workflow_dir: ".agentplane/tasks" } },
+    memo: {},
+  } as never;
+  const order = {
+    ...buildAgentWorkOrderV2ValidFixture(),
+    work_order_id: `sha256:${"1".repeat(64)}`,
+  };
+  const first = await issueKernelExchange(command, order, "host");
+  const second = await issueKernelExchange(
+    command,
+    { ...order, work_order_id: `sha256:${"2".repeat(64)}` },
+    "host",
+  );
+  const firstPath = path.resolve(first.exchange.directory, first.exchange.result_schema_ref);
+  const secondPath = path.resolve(second.exchange.directory, second.exchange.result_schema_ref);
+  expect(firstPath).toBe(secondPath);
+  expect(await readFile(firstPath, "utf8")).toBe(renderAgentSemanticResultSchemaJson());
+  expect(await readdir(path.dirname(firstPath))).toHaveLength(1);
+  expect(await readdir(first.exchange.directory)).not.toContain("result-schema.json");
+  const bytes = (await readFile(firstPath)).byteLength;
+  expect(bytes).toBeGreaterThan(1000);
+  expect(
+    (await readFile(path.join(first.exchange.directory, "result-schema-object.json"))).byteLength,
+  ).toBeLessThan(bytes);
+  // An interrupted publication with a durable object and no descriptor reuses the object.
+  await rm(path.join(first.exchange.directory, "result-schema-object.json"));
+  const replay = await issueKernelExchange(command, order, "host");
+  expect(path.resolve(replay.exchange.directory, replay.exchange.result_schema_ref)).toBe(
+    firstPath,
+  );
+  expect(await readdir(path.dirname(firstPath))).toHaveLength(1);
+  const changed = await putEvaluatorEvidenceObject({
+    gitRoot: root,
+    taskQualityRoot: path.join(root, ".agentplane/tasks", order.task.id, "quality"),
+    logicalName: "canonical-result-schema",
+    kind: "result_schema",
+    extension: ".json",
+    mediaType: "application/schema+json",
+    contents: '{"const":"changed schema"}\n',
+  });
+  expect(path.join(root, changed.path)).not.toBe(firstPath);
+  expect(await readdir(path.dirname(firstPath))).toHaveLength(2);
+  expect((await readFile(firstPath)).byteLength).toBe(bytes);
+  // A historical exchange keeps its original copy and never migrates it implicitly.
+  await writeFile(
+    path.join(first.exchange.directory, "result-schema.json"),
+    '{"historical":true}\n',
+  );
+  const historical = await issueKernelExchange(command, order, "host");
+  expect(historical.exchange.result_schema_ref).toBe("result-schema.json");
+  expect(await readFile(path.join(first.exchange.directory, "result-schema.json"), "utf8")).toBe(
+    '{"historical":true}\n',
+  );
+  await writeFile(secondPath, "tampered");
+  await expect(
+    issueKernelExchange(command, { ...order, work_order_id: `sha256:${"2".repeat(64)}` }, "host"),
+  ).rejects.toThrow(/changed after preparation/u);
 });

--- a/packages/agentplane/src/commands/evaluator/evaluator-evidence-store.test.ts
+++ b/packages/agentplane/src/commands/evaluator/evaluator-evidence-store.test.ts
@@ -465,11 +465,13 @@ it("shares canonical result schemas across new exchanges and preserves historica
   expect(await readFile(firstPath, "utf8")).toBe(renderAgentSemanticResultSchemaJson());
   expect(await readdir(path.dirname(firstPath))).toHaveLength(1);
   expect(await readdir(first.exchange.directory)).not.toContain("result-schema.json");
-  const bytes = (await readFile(firstPath)).byteLength;
+  const contents = await readFile(firstPath);
+  const bytes = contents.byteLength;
   expect(bytes).toBeGreaterThan(1000);
-  expect(
-    (await readFile(path.join(first.exchange.directory, "result-schema-object.json"))).byteLength,
-  ).toBeLessThan(bytes);
+  const descriptor = await readFile(
+    path.join(first.exchange.directory, "result-schema-object.json"),
+  );
+  expect(descriptor.byteLength).toBeLessThan(bytes);
   // An interrupted publication with a durable object and no descriptor reuses the object.
   await rm(path.join(first.exchange.directory, "result-schema-object.json"));
   const replay = await issueKernelExchange(command, order, "host");
@@ -488,7 +490,7 @@ it("shares canonical result schemas across new exchanges and preserves historica
   });
   expect(path.join(root, changed.path)).not.toBe(firstPath);
   expect(await readdir(path.dirname(firstPath))).toHaveLength(2);
-  expect((await readFile(firstPath)).byteLength).toBe(bytes);
+  expect(await readFile(firstPath)).toHaveLength(bytes);
   // A historical exchange keeps its original copy and never migrates it implicitly.
   await writeFile(
     path.join(first.exchange.directory, "result-schema.json"),

--- a/packages/agentplane/src/commands/evaluator/evaluator-evidence-store.ts
+++ b/packages/agentplane/src/commands/evaluator/evaluator-evidence-store.ts
@@ -253,7 +253,6 @@ export async function assertEvaluatorPacketCurrent(opts: {
     });
   }
   const names = new Set<string>();
-  const objectPrefix = `${manifest.object_root.replaceAll(/\/+$/gu, "")}/sha256/`;
   for (const artifact of manifest.artifacts) {
     if (names.has(artifact.logical_name)) {
       throw new CliError({
@@ -262,29 +261,12 @@ export async function assertEvaluatorPacketCurrent(opts: {
       });
     }
     names.add(artifact.logical_name);
-    if (!artifact.path.startsWith(objectPrefix)) {
-      throw new CliError({
-        code: "E_VALIDATION",
-        message: `Evaluator packet object is outside its object root: ${artifact.path}`,
-      });
-    }
-    const artifactPath = resolveRepositoryPath(
-      opts.gitRoot,
-      artifact.path,
-      `Evaluator packet artifact ${artifact.logical_name}`,
-    );
-    const bytes = await readStableEvaluatorEvidenceFile({
+    await readEvaluatorEvidenceObject({
       gitRoot: opts.gitRoot,
-      filePath: artifactPath,
-      label: `Evaluator packet artifact ${artifact.logical_name}`,
-      hook: opts.boundaryHook,
+      objectRoot: manifest.object_root,
+      artifact,
+      boundaryHook: opts.boundaryHook,
     });
-    if (bytes.byteLength !== artifact.size_bytes || sha256(bytes) !== artifact.sha256) {
-      throw new CliError({
-        code: "E_VALIDATION",
-        message: `Evaluator packet artifact changed after preparation: ${artifact.path}`,
-      });
-    }
   }
   for (const requiredName of [
     "evaluator-diff",
@@ -313,4 +295,39 @@ export async function assertEvaluatorPacketCurrent(opts: {
     });
   }
   return manifest;
+}
+
+/** Resolve one existing immutable object with the same checks used by evaluator packets. */
+export async function readEvaluatorEvidenceObject(opts: {
+  gitRoot: string;
+  objectRoot: string;
+  artifact: unknown;
+  boundaryHook?: EvaluatorEvidenceBoundaryHook;
+}): Promise<{ artifact: EvaluatorPacketArtifact; bytes: Buffer }> {
+  const artifact = EVALUATOR_PACKET_ARTIFACT_SCHEMA.parse(opts.artifact);
+  const objectPrefix = `${opts.objectRoot.replaceAll(/\/+$/gu, "")}/sha256/`;
+  if (!artifact.path.startsWith(objectPrefix)) {
+    throw new CliError({
+      code: "E_VALIDATION",
+      message: `Evaluator packet object is outside its object root: ${artifact.path}`,
+    });
+  }
+  const artifactPath = resolveRepositoryPath(
+    opts.gitRoot,
+    artifact.path,
+    `Evaluator packet artifact ${artifact.logical_name}`,
+  );
+  const bytes = await readStableEvaluatorEvidenceFile({
+    gitRoot: opts.gitRoot,
+    filePath: artifactPath,
+    label: `Evaluator packet artifact ${artifact.logical_name}`,
+    hook: opts.boundaryHook,
+  });
+  if (bytes.byteLength !== artifact.size_bytes || sha256(bytes) !== artifact.sha256) {
+    throw new CliError({
+      code: "E_VALIDATION",
+      message: `Evaluator packet artifact changed after preparation: ${artifact.path}`,
+    });
+  }
+  return { artifact, bytes };
 }

--- a/packages/agentplane/src/commands/shared/quality-review-target.ts
+++ b/packages/agentplane/src/commands/shared/quality-review-target.ts
@@ -39,7 +39,7 @@ function normalizeWorkflowDir(value: string): string {
   return value.replaceAll("\\", "/").replaceAll(/\/+$/g, "");
 }
 
-function isManagedTaskArtifact(relativePath: string): boolean {
+export function isManagedTaskArtifact(relativePath: string): boolean {
   return (
     relativePath === "README.md" ||
     MANAGED_TASK_ARTIFACT_DIRECTORIES.some((directory) => relativePath.startsWith(directory))

--- a/packages/agentplane/src/commands/shared/task-backend.ts
+++ b/packages/agentplane/src/commands/shared/task-backend.ts
@@ -1,4 +1,5 @@
 import type { ResolvedProject } from "@agentplaneorg/core/project";
+import { TASK_KERNEL_EXTENSION } from "../../adapters/task-backend/kernel-record.js";
 import path from "node:path";
 import type { AgentplaneConfig } from "@agentplaneorg/core/config";
 import { resolveTaskDocUpdatedBy, taskDocToSectionMap } from "@agentplaneorg/core/tasks";
@@ -238,6 +239,11 @@ export async function resolveTaskOwnerCommandContext(opts: {
   ctx: CommandContext;
   taskId: string;
 }): Promise<CommandContext> {
+  const localTask = await opts.ctx.taskBackend.getTask(opts.taskId);
+  // Canonical tasks bind observations and WorkOrders to the invocation checkout.
+  // They have no legacy task branch; their kernel validates state and authority.
+  if (localTask?.extensions && Object.hasOwn(localTask.extensions, TASK_KERNEL_EXTENSION))
+    return opts.ctx;
   const taskBranch = await resolveTaskBranchFromContext({ ctx: opts.ctx, taskId: opts.taskId });
   if (taskBranch) {
     const owner = await resolveAuthoritativeTaskWorktree({

--- a/packages/agentplane/src/commands/task/advance.command.ts
+++ b/packages/agentplane/src/commands/task/advance.command.ts
@@ -59,10 +59,14 @@ export function makeRunTaskAdvanceHandler(deps: {
       });
     }
     const initialCommand = await deps.getContext("task advance", { includeRemote: parsed.remote });
-    const command = await resolveTaskOwnerCommandContext({
-      ctx: initialCommand,
-      taskId: parsed.taskId,
-    });
+    const localSource = await initialCommand.taskBackend.getTask(parsed.taskId);
+    const command =
+      localSource?.extensions && Object.hasOwn(localSource.extensions, TASK_KERNEL_EXTENSION)
+        ? initialCommand
+        : await resolveTaskOwnerCommandContext({
+            ctx: initialCommand,
+            taskId: parsed.taskId,
+          });
     const source = await command.taskBackend.getTask(parsed.taskId);
     if (source?.extensions && Object.hasOwn(source.extensions, TASK_KERNEL_EXTENSION)) {
       if (parsed.workflowRecovery)

--- a/packages/agentplane/src/commands/task/agent-action-packet.test.ts
+++ b/packages/agentplane/src/commands/task/agent-action-packet.test.ts
@@ -1,3 +1,4 @@
+import { buildAgentWorkOrderV2ValidFixture } from "@agentplaneorg/core/schemas";
 import { describe, expect, it } from "vitest";
 
 import { computePlanDigest } from "@agentplaneorg/core/tasks";
@@ -54,9 +55,11 @@ function decision(workflowStep: WorkflowStep): TaskRouteDecision {
 }
 
 function workOrder() {
+  const fixture = buildAgentWorkOrderV2ValidFixture("packet");
   return {
+    ...fixture,
     role: "EXECUTOR",
-    authority: { sandbox: "workspace-write", network: "deny" },
+    authority: { ...fixture.authority, sandbox: "workspace-write", network: "deny" },
     required_inputs: [
       {
         id: "task-document",

--- a/packages/agentplane/src/commands/task/agent-action-packet.ts
+++ b/packages/agentplane/src/commands/task/agent-action-packet.ts
@@ -1,3 +1,9 @@
+import path from "node:path";
+import {
+  buildWorkOrderContextManifest,
+  workOrderContextManifestDigest,
+  WORK_ORDER_CONTEXT_FILENAME,
+} from "../../runner/context/work-order-context.js";
 import { createHash } from "node:crypto";
 
 import type { AgentWorkOrderV2 } from "@agentplaneorg/core/schemas";
@@ -42,6 +48,7 @@ export type AgentActionPacket = {
     reference: string | null;
   };
   context_refs: AgentContextRef[];
+  context_manifest?: { ref: string; digest: string; blocks: number; required: number };
   human_decision_ticket?: HumanDecisionTicket;
   operator_action?: {
     kind: "approve_plan" | "grant_side_effect_authority" | "approve_provider_merge";
@@ -444,6 +451,19 @@ export function buildAgentActionPacket(opts: {
     ...(opts.recovery ? { recovery: opts.recovery } : {}),
   };
 
+  if (packet.exchange) {
+    const manifest = buildWorkOrderContextManifest(
+      opts.work_order,
+      path.resolve(packet.exchange.directory, packet.exchange.work_order_ref),
+    );
+    packet.context_manifest = {
+      ref: path.join(packet.exchange.directory, WORK_ORDER_CONTEXT_FILENAME),
+      digest: workOrderContextManifestDigest(manifest),
+      blocks: manifest.blocks.length,
+      required: manifest.blocks.filter((block) => block.required).length,
+    };
+  }
+  // context_refs is only a preview. The complete manifest remains discoverable at every size.
   while (packet.context_refs.length > 0 && packetBytes(packet) > MAX_AGENT_ACTION_PACKET_BYTES) {
     packet.context_refs.pop();
   }

--- a/packages/agentplane/src/commands/task/branch-task-supervisor-artifact-commit.test.ts
+++ b/packages/agentplane/src/commands/task/branch-task-supervisor-artifact-commit.test.ts
@@ -2,11 +2,17 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
   commit: vi.fn(),
+  status: vi.fn(),
 }));
 
 vi.mock("../guard/impl/commit.js", () => ({ cmdCommit: mocks.commit }));
 
-import { commitBranchSupervisorTaskArtifacts } from "./branch-task-supervisor-artifact-commit.js";
+vi.mock("./direct-task-finalization.js", () => ({ readDirectRepositoryStatus: mocks.status }));
+
+import {
+  canCoalesceVerificationArtifacts,
+  commitBranchSupervisorTaskArtifacts,
+} from "./branch-task-supervisor-artifact-commit.js";
 
 describe("commitBranchSupervisorTaskArtifacts", () => {
   beforeEach(() => {
@@ -28,5 +34,60 @@ describe("commitBranchSupervisorTaskArtifacts", () => {
     });
 
     expect(mocks.commit).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("verification artifact coalescing", () => {
+  const opts = () => ({
+    command: {
+      config: {
+        paths: { workflow_dir: ".agentplane/tasks", tasks_path: ".agentplane/tasks.json" },
+      },
+    } as never,
+    cwd: "/repo",
+    task_id: "TASK",
+    next: {
+      workflowStep: {
+        kind: "agent_episode",
+        episode: { purpose: "quality_review", taskId: "TASK" },
+        blockers: [],
+      },
+      executionPacket: { mustRunFrom: "/repo" },
+    } as never,
+  });
+  it("defers only durable same-task artifacts to the evaluator boundary, including restart", async () => {
+    mocks.status.mockResolvedValue({
+      lines: [
+        " M .agentplane/tasks/TASK/README.md",
+        "?? .agentplane/tasks/TASK/supervision/declared-checks.json",
+      ],
+    });
+    expect(await canCoalesceVerificationArtifacts(opts())).toBe(true);
+    expect(await canCoalesceVerificationArtifacts(opts())).toBe(true);
+  });
+  it.each([
+    [" M source.ts"],
+    ["?? .agentplane/tasks/TASK/foreign.ts"],
+    ["?? unrelated.txt"],
+    [" M .agentplane/tasks/OTHER/README.md"],
+    [" M .agentplane/tasks.json"],
+    [' M ".agentplane/tasks/TASK/quoted file"'],
+    ["R  source.ts -> .agentplane/tasks/TASK/source.ts"],
+  ])("does not defer a checkpoint with foreign or ambiguous changes: %s", async (line) => {
+    mocks.status.mockResolvedValue({ lines: [line] });
+    expect(await canCoalesceVerificationArtifacts(opts())).toBe(false);
+  });
+  it("retains the checkpoint at verification, human or external boundaries and unavailable status", async () => {
+    mocks.status.mockResolvedValue(null);
+    expect(await canCoalesceVerificationArtifacts(opts())).toBe(false);
+    for (const purpose of ["verification", "implementation", "human_required"]) {
+      const input = opts();
+      input.next = {
+        workflowStep: { kind: "agent_episode", episode: { purpose, taskId: "TASK" }, blockers: [] },
+        executionPacket: { mustRunFrom: "/repo" },
+      } as never;
+      mocks.status.mockResolvedValue({ lines: [] });
+      expect(await canCoalesceVerificationArtifacts(input)).toBe(false);
+    }
   });
 });

--- a/packages/agentplane/src/commands/task/branch-task-supervisor-artifact-commit.test.ts
+++ b/packages/agentplane/src/commands/task/branch-task-supervisor-artifact-commit.test.ts
@@ -37,24 +37,25 @@ describe("commitBranchSupervisorTaskArtifacts", () => {
   });
 });
 
+const opts = () => ({
+  command: {
+    config: {
+      paths: { workflow_dir: ".agentplane/tasks", tasks_path: ".agentplane/tasks.json" },
+    },
+  } as never,
+  cwd: "/repo",
+  task_id: "TASK",
+  next: {
+    workflowStep: {
+      kind: "agent_episode",
+      episode: { purpose: "quality_review", taskId: "TASK" },
+      blockers: [],
+    },
+    executionPacket: { mustRunFrom: "/repo" },
+  } as never,
+});
+
 describe("verification artifact coalescing", () => {
-  const opts = () => ({
-    command: {
-      config: {
-        paths: { workflow_dir: ".agentplane/tasks", tasks_path: ".agentplane/tasks.json" },
-      },
-    } as never,
-    cwd: "/repo",
-    task_id: "TASK",
-    next: {
-      workflowStep: {
-        kind: "agent_episode",
-        episode: { purpose: "quality_review", taskId: "TASK" },
-        blockers: [],
-      },
-      executionPacket: { mustRunFrom: "/repo" },
-    } as never,
-  });
   it("defers only durable same-task artifacts to the evaluator boundary, including restart", async () => {
     mocks.status.mockResolvedValue({
       lines: [

--- a/packages/agentplane/src/commands/task/branch-task-supervisor-artifact-commit.ts
+++ b/packages/agentplane/src/commands/task/branch-task-supervisor-artifact-commit.ts
@@ -1,3 +1,7 @@
+import path from "node:path";
+import type { TaskRouteDecision } from "../shared/route-decision-types.js";
+import { isManagedTaskArtifact } from "../shared/quality-review-target.js";
+import { readDirectRepositoryStatus } from "./direct-task-finalization.js";
 import { cmdCommit } from "../guard/impl/commit.js";
 import type { CommandContext } from "../shared/task-backend.js";
 
@@ -47,4 +51,36 @@ export async function commitBranchSupervisorTaskArtifacts(opts: {
   if (exitCode !== 0) {
     throw new Error(`Task artifact commit exited with ${exitCode}.`);
   }
+}
+
+/** Passed checks are already durable. The next evaluator commit can include their artifacts. */
+export async function canCoalesceVerificationArtifacts(opts: {
+  command: CommandContext;
+  cwd: string;
+  task_id: string;
+  next: TaskRouteDecision;
+}): Promise<boolean> {
+  const step = opts.next.workflowStep;
+  if (
+    step.kind !== "agent_episode" ||
+    step.episode.purpose !== "quality_review" ||
+    step.episode.taskId !== opts.task_id ||
+    step.blockers.length > 0 ||
+    !opts.next.executionPacket.mustRunFrom ||
+    path.resolve(opts.next.executionPacket.mustRunFrom) !== path.resolve(opts.cwd)
+  )
+    return false;
+  const status = await readDirectRepositoryStatus(opts.cwd);
+  if (!status) return false;
+  const prefix = `${opts.command.config.paths.workflow_dir.replaceAll("\\", "/").replace(/\/+$/u, "")}/${opts.task_id}/`;
+  return status.lines.every((line) => {
+    // Renames and quoted/ambiguous status paths are not eligible for deferred commits.
+    const relative = line.slice(3).trim();
+    return (
+      !relative.includes(" -> ") &&
+      !relative.startsWith('"') &&
+      relative.startsWith(prefix) &&
+      isManagedTaskArtifact(relative.slice(prefix.length))
+    );
+  });
 }

--- a/packages/agentplane/src/commands/task/branch-task-supervisor-episodes.ts
+++ b/packages/agentplane/src/commands/task/branch-task-supervisor-episodes.ts
@@ -43,6 +43,7 @@ import {
 import { cmdVerifyParsed } from "./verify-record.js";
 import { resolveImplementationVerificationTask } from "./external-agent-implementation-recovery.js";
 import {
+  canCoalesceVerificationArtifacts,
   branchSupervisorArtifactCommitMessage,
   commitBranchSupervisorTaskArtifacts,
 } from "./branch-task-supervisor-artifact-commit.js";
@@ -376,15 +377,24 @@ async function executeBranchVerificationEpisode(opts: {
           quiet: true,
         });
         if (exitCode !== 0) throw new Error(`Verification record exited with ${exitCode}.`);
-        await commitBranchSupervisorTaskArtifacts({
-          command,
-          cwd: checkout,
-          task_id: opts.input.task_id,
-          message: branchSupervisorArtifactCommitMessage(
-            opts.input.task_id,
-            passed ? "verification_pass" : "verification_rework",
-          ),
-        });
+        const coalesce =
+          passed &&
+          (await canCoalesceVerificationArtifacts({
+            command,
+            cwd: checkout,
+            task_id: opts.input.task_id,
+            next: await opts.decide(),
+          }));
+        if (!coalesce)
+          await commitBranchSupervisorTaskArtifacts({
+            command,
+            cwd: checkout,
+            task_id: opts.input.task_id,
+            message: branchSupervisorArtifactCommitMessage(
+              opts.input.task_id,
+              passed ? "verification_pass" : "verification_rework",
+            ),
+          });
         return {
           verification: passed ? "ok" : "needs_rework",
           declared_checks: checks.artifact_path,

--- a/packages/agentplane/src/commands/task/close-shared.unit.test.ts
+++ b/packages/agentplane/src/commands/task/close-shared.unit.test.ts
@@ -96,6 +96,8 @@ describe("task close-shared helper (unit)", () => {
           schema_version: 1,
           state: "unavailable",
           input_tokens: null,
+          cached_input_tokens: null,
+          cached_input_observed_agent_runs: 0,
           output_tokens: null,
           reasoning_tokens: null,
           total_tokens: null,

--- a/packages/agentplane/src/commands/task/external-agent-exchange.ts
+++ b/packages/agentplane/src/commands/task/external-agent-exchange.ts
@@ -1,3 +1,7 @@
+import {
+  buildWorkOrderContextManifest,
+  WORK_ORDER_CONTEXT_FILENAME,
+} from "../../runner/context/work-order-context.js";
 import { createHash } from "node:crypto";
 import { mkdir, readFile } from "node:fs/promises";
 import path from "node:path";
@@ -202,6 +206,11 @@ export async function persistExternalAgentExchangeArtifacts(opts: {
       "utf8",
     ),
   ]);
+  await atomicWriteFile(
+    path.join(opts.paths.directory, WORK_ORDER_CONTEXT_FILENAME),
+    `${JSON.stringify(buildWorkOrderContextManifest(opts.work_order, opts.paths.work_order), null, 2)}\n`,
+    "utf8",
+  );
   await writeExternalAgentExchange(opts.paths.exchange, opts.exchange);
 }
 

--- a/packages/agentplane/src/commands/task/external-agent-implementation-finalization.ts
+++ b/packages/agentplane/src/commands/task/external-agent-implementation-finalization.ts
@@ -2,7 +2,10 @@ import { conflictEvidenceAuthority } from "./external-agent-conflict-application
 import type { AgentSemanticResult, AgentWorkOrderV2 } from "@agentplaneorg/core/schemas";
 import { taskCentricAggregateFromExtensions } from "@agentplaneorg/core/tasks";
 import { CliError } from "../../shared/errors.js";
-import { commitBranchSupervisorTaskArtifacts } from "./branch-task-supervisor-artifact-commit.js";
+import {
+  canCoalesceVerificationArtifacts,
+  commitBranchSupervisorTaskArtifacts,
+} from "./branch-task-supervisor-artifact-commit.js";
 
 import { refreshExternalAgentRoute } from "./external-agent-result-routing.js";
 import type { TaskRouteDecision } from "../shared/route-decision-types.js";
@@ -90,6 +93,20 @@ export async function finishExternalImplementationVerification(opts: {
     opts.command.git.invalidateStatus();
     const currentStatus = await readDirectRepositoryStatus(opts.exchange.checkout);
     if (!hasChangedTaskArtifacts(currentStatus?.lines ?? [], opts.exchange.task_id)) return;
+    if (
+      !opts.conflict &&
+      (await canCoalesceVerificationArtifacts({
+        command: opts.command,
+        cwd: opts.exchange.checkout,
+        task_id: opts.exchange.task_id,
+        next: await refreshExternalAgentRoute({
+          cwd: opts.exchange.checkout,
+          task_id: opts.exchange.task_id,
+          include_remote: false,
+        }),
+      }))
+    )
+      return;
     const evidenceAuthority = opts.conflict
       ? conflictEvidenceAuthority(
           await refreshExternalAgentRoute({

--- a/packages/agentplane/src/commands/task/external-agent-supervisor-recovery.test.ts
+++ b/packages/agentplane/src/commands/task/external-agent-supervisor-recovery.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it } from "vitest";
+import type { AgentWorkOrderV2 } from "@agentplaneorg/core/schemas";
+import type { ExternalAgentExchange } from "./external-agent-exchange.js";
+import {
+  requiresImplementationRecoveryReplacement,
+  requiresPlanningRecoveryReplacement,
+} from "./external-agent-supervisor-recovery.js";
+
+describe("external agent recovery authority", () => {
+  it("requires replacement when a non-planning result predates an explicit PLANNER reset", () => {
+    const stateFingerprint = `sha256:${"a".repeat(64)}`;
+    const planningFingerprint = `sha256:${"b".repeat(64)}`;
+    expect(
+      requiresPlanningRecoveryReplacement({
+        decision: {
+          workflowStep: {
+            kind: "agent_episode",
+            episode: { purpose: "planning" },
+            preconditionFingerprint: { digest: planningFingerprint },
+          },
+        } as never,
+        exchange: {
+          purpose: "implementation",
+          state_fingerprint: stateFingerprint,
+        } as ExternalAgentExchange,
+      }),
+    ).toBe(true);
+  });
+
+  it.each([
+    ["result_received", true, true],
+    ["result_received", false, false],
+    ["accepted", true, false],
+    ["consumed", true, false],
+  ])("bounds planning replacement for %s with drift=%s", (status, drift, expected) => {
+    const fingerprint = `sha256:${"a".repeat(64)}`;
+    expect(
+      requiresPlanningRecoveryReplacement({
+        decision: {
+          workflowStep: {
+            kind: "agent_episode",
+            episode: { purpose: "planning" },
+            preconditionFingerprint: {
+              digest: drift ? `sha256:${"b".repeat(64)}` : fingerprint,
+            },
+          },
+        } as never,
+        exchange: {
+          purpose: "planning",
+          status,
+          state_fingerprint: fingerprint,
+        } as ExternalAgentExchange,
+      }),
+    ).toBe(expected);
+  });
+
+  it("requires replacement when plan approval changes pending implementation authority", () => {
+    const taskDigest = `sha256:${"a".repeat(64)}`;
+    const backendDigest = `sha256:${"b".repeat(64)}`;
+    const authorityDigest = `sha256:${"e".repeat(64)}`;
+    const fingerprint = {
+      task_id: "202608171106-XFN696",
+      task_revision: 16,
+      worktree: "/repo/.agentplane/worktrees/task",
+      components: {
+        task: { digest: taskDigest },
+        backend_projection: { digest: backendDigest },
+        provider: { digest: `sha256:${"0".repeat(64)}` },
+        authority: { digest: authorityDigest },
+      },
+    };
+    const decision = {
+      workflowStep: {
+        preconditionFingerprint: {
+          ...fingerprint,
+          task_revision: 19,
+          digest: `sha256:${"c".repeat(64)}`,
+        },
+      },
+    } as never;
+    const exchange = { purpose: "task_worktree_resolution" } as ExternalAgentExchange;
+    const workOrder = { state_fingerprint: fingerprint } as AgentWorkOrderV2;
+
+    expect(
+      requiresImplementationRecoveryReplacement({ decision, exchange, work_order: workOrder }),
+    ).toBe(true);
+    expect(
+      requiresImplementationRecoveryReplacement({
+        decision,
+        exchange: { purpose: "implementation_rework" } as ExternalAgentExchange,
+        work_order: workOrder,
+      }),
+    ).toBe(true);
+    expect(
+      requiresImplementationRecoveryReplacement({
+        decision: {
+          workflowStep: {
+            preconditionFingerprint: {
+              ...fingerprint,
+              digest: `sha256:${"d".repeat(64)}`,
+            },
+          },
+        } as never,
+        exchange,
+        work_order: workOrder,
+      }),
+    ).toBe(false);
+    expect(
+      requiresImplementationRecoveryReplacement({
+        decision: {
+          workflowStep: {
+            preconditionFingerprint: {
+              ...fingerprint,
+              components: {
+                ...fingerprint.components,
+                authority: { digest: `sha256:${"f".repeat(64)}` },
+              },
+            },
+          },
+        } as never,
+        exchange,
+        work_order: workOrder,
+      }),
+    ).toBe(true);
+  });
+});

--- a/packages/agentplane/src/commands/task/external-agent-supervisor-recovery.ts
+++ b/packages/agentplane/src/commands/task/external-agent-supervisor-recovery.ts
@@ -45,7 +45,7 @@ export function requiresPlanningRecoveryReplacement(opts: {
   return (
     step.kind === "agent_episode" &&
     step.episode.purpose === "planning" &&
-    opts.exchange.purpose !== "planning" &&
+    (opts.exchange.purpose !== "planning" || opts.exchange.status === "result_received") &&
     step.preconditionFingerprint.digest !== opts.exchange.state_fingerprint
   );
 }
@@ -446,7 +446,7 @@ export async function recoverPendingExternalAgentResult(opts: {
       code: "E_RUNTIME",
       message:
         (planningRecoveryRequired
-          ? "The task returned to PLANNER after the pending external-agent result was issued. "
+          ? "The planning state changed after the pending external-agent result was issued. "
           : "The task authority changed after the pending external-agent result was issued. ") +
         `AgentPlane retired the stale result; run: agentplane task advance ${opts.task_id} ` +
         "--replacement --agent-json",

--- a/packages/agentplane/src/commands/task/kernel-advance.ts
+++ b/packages/agentplane/src/commands/task/kernel-advance.ts
@@ -1,6 +1,17 @@
+import { runKernelFinalValidation } from "./kernel-final-validation.js";
+import { verificationChildEnv } from "../shared/pr-meta/verify-log.js";
+import {
+  issueKernelInspection,
+  acceptKernelInspection,
+  resumeKernelInspection,
+} from "./kernel-inspection.js";
 import { canonicalPlanFromProposal } from "./kernel-plan.js";
 import path from "node:path";
-import { taskKernel as k, kernelPlanProposalSchema } from "@agentplaneorg/core/tasks";
+import {
+  repositoryEffectsForPath,
+  taskKernel as k,
+  kernelPlanProposalSchema,
+} from "@agentplaneorg/core/tasks";
 import type { KernelCommandInput } from "../../adapters/task-backend/kernel-backend-adapter.js";
 import type { KernelWorkBinding } from "../../runner/usecases/kernel-task-lifecycle.js";
 import { kernelApprovalReference } from "../../runner/usecases/kernel-authority.js";
@@ -15,6 +26,37 @@ import {
 import { readStableRegularTextNoFollow } from "../../shared/stable-file.js";
 
 type Runtime = Awaited<ReturnType<typeof createKernelRuntime>>;
+
+async function authorityDeltaStop(runtime: Runtime, taskId: string) {
+  const prepared = await runtime.authority.prepareDelta(taskId, repositoryEffectsForPath);
+  return {
+    kind: "human_required" as const,
+    reason: "canonical_authority_delta_requires_user",
+    summary: "Repository changes exceed the approved canonical scope.",
+    authority_delta: prepared,
+    operator_action: {
+      kind: "extend_scope" as const,
+      argv: [
+        "agentplane",
+        "task",
+        "scope",
+        "extend",
+        taskId,
+        ...prepared.request.added_scope_roots.flatMap((root) => ["--scope-root", root]),
+        ...prepared.request.added_repository_effects.flatMap((effect) => [
+          "--repository-effect",
+          effect,
+        ]),
+        "--request-digest",
+        prepared.request_digest,
+        "--state-scope-digest",
+        prepared.request_digest,
+        "--by",
+        "USER",
+      ],
+    },
+  };
+}
 
 async function acceptKernelSemanticResult(
   command: CommandContext,
@@ -43,6 +85,8 @@ async function acceptKernelSemanticResult(
       summary: semantic.summary,
     };
   const binding = workOrder.canonical_binding!;
+  if (binding.phase === "inspection")
+    return (await acceptKernelInspection(command, runtime, directory, semantic)) ?? null;
   const mutationId = `result:${workOrder.work_order_id}`;
   if (saved) await writeKernelArtifact(directory, "received-result.json", semantic);
   if (binding.phase === "planning") {
@@ -108,7 +152,7 @@ async function acceptKernelSemanticResult(
           continuation?.kind !== "repository_implementation" ||
           continuation.changed_paths.some(
             (changed) =>
-              !item.definition.execution_requirements.scope_roots.some(
+              !parent.scope_roots.some(
                 (root) => root === "." || changed === root || changed.startsWith(`${root}/`),
               ),
           )
@@ -180,7 +224,14 @@ export async function advanceCanonicalTask(opts: {
     );
     if (stop) return { schema_version: 1, task_id: opts.task_id, action: stop };
   }
-  for (let step = 0; step < 6; step++) {
+  const visited = new Set<string>();
+  let finalValidation: {
+    fingerprint: string;
+    environment_digest: string;
+    evidence_digest: k.Sha256Digest;
+    plan_digest: string;
+  } | null = null;
+  for (let step = 0; step < 16; step++) {
     const context = await runtime.native.readContext(opts.task_id);
     const current = await runtime.lifecycle.read(opts.task_id, context.repository_fingerprint);
     if (current.read.kind !== "canonical")
@@ -210,6 +261,97 @@ export async function advanceCanonicalTask(opts: {
       };
     }
     const operationId = `${route.reason_code}:${record.digest}:${context.repository_fingerprint}`;
+    const parent = record.aggregate.authority_lineage?.at(-1)?.authority;
+    if (
+      plan?.state === "APPROVED" &&
+      parent &&
+      parent.repository_fingerprint !== context.repository_fingerprint
+    ) {
+      try {
+        requireKernelCommit(await runtime.authority.continue(opts.task_id));
+        continue;
+      } catch (error) {
+        if ((error as { reason_code?: string }).reason_code !== "repository_observation_scope")
+          throw error;
+        return {
+          schema_version: 1,
+          task_id: opts.task_id,
+          action: await authorityDeltaStop(runtime, opts.task_id),
+          canonical_revision: record.aggregate.revision,
+        };
+      }
+    }
+    if (visited.has(operationId))
+      return {
+        schema_version: 1,
+        task_id: opts.task_id,
+        action: { kind: "human_required", reason: "canonical_transition_no_progress" },
+      };
+    visited.add(operationId);
+    if (
+      route.reason_code === "kernel_final_validation_required" ||
+      route.reason_code === "kernel_task_completion_required"
+    ) {
+      if (
+        route.reason_code === "kernel_task_completion_required" &&
+        finalValidation?.fingerprint === context.repository_fingerprint &&
+        finalValidation.environment_digest === k.kernelDigest(verificationChildEnv()) &&
+        finalValidation.plan_digest === plan?.digest &&
+        record.aggregate.final_validation?.evidence_digests.includes(
+          finalValidation.evidence_digest,
+        )
+      ) {
+        const completion = await runtime.input({ kind: "complete_task" }, operationId);
+        if (completion.command.expected_task_revision !== record.aggregate.revision)
+          throw new Error("Canonical task changed before completion");
+        requireKernelCommit(await runtime.lifecycle.apply(completion));
+      } else {
+        const checked = await runKernelFinalValidation(opts.command, runtime, record);
+        if (checked.stop) return { schema_version: 1, task_id: opts.task_id, action: checked.stop };
+        finalValidation = {
+          fingerprint: checked.fingerprint,
+          environment_digest: checked.environment_digest,
+          evidence_digest: checked.evidence_digest,
+          plan_digest: checked.plan_digest,
+        };
+      }
+      continue;
+    }
+
+    if (
+      route.reason_code === "kernel_work_item_validation_resolution_required" &&
+      route.work_item_id
+    ) {
+      const stop = await resumeKernelInspection(opts.command, runtime, record, route.work_item_id);
+      if (stop) return { schema_version: 1, task_id: opts.task_id, action: stop };
+      continue;
+    }
+
+    if (
+      route.work_item_id &&
+      ["kernel_work_item_inspection_required", "kernel_work_item_validation_required"].includes(
+        route.reason_code,
+      )
+    ) {
+      if (route.reason_code === "kernel_work_item_inspection_required") {
+        requireKernelCommit(
+          await runtime.lifecycle.apply(
+            await runtime.input(
+              {
+                kind: "transition_work_item",
+                action: "inspect",
+                work_item_id: route.work_item_id,
+                claim_id: record.aggregate.work_items[route.work_item_id]!.claim_id,
+              },
+              operationId,
+            ),
+          ),
+        );
+        continue;
+      }
+      return issueKernelInspection(opts.command, runtime, record, route.work_item_id);
+    }
+
     if (route.reason_code === "kernel_work_item_materialization_required" && plan) {
       requireKernelCommit(
         await runtime.lifecycle.apply(
@@ -272,17 +414,23 @@ export async function advanceCanonicalTask(opts: {
         context,
         implementation: begun.work_order,
       });
-      return issueKernelExchange(opts.command, order, opts.transport);
+      return issueKernelExchange(opts.command, order, opts.transport, result.record);
     }
     return {
       schema_version: 1,
       task_id: opts.task_id,
       action: {
-        kind: route.reason_code === "kernel_task_completed" ? "terminal" : "external_wait",
+        kind: ["kernel_task_completed", "kernel_task_cancelled"].includes(route.reason_code)
+          ? "terminal"
+          : "external_wait",
         reason: route.reason_code,
       },
       canonical_revision: record.aggregate.revision,
     };
   }
-  throw new Error("Canonical transition budget exhausted");
+  return {
+    schema_version: 1,
+    task_id: opts.task_id,
+    action: { kind: "human_required", reason: "canonical_transition_budget_exhausted" },
+  };
 }

--- a/packages/agentplane/src/commands/task/kernel-exchange.ts
+++ b/packages/agentplane/src/commands/task/kernel-exchange.ts
@@ -7,6 +7,7 @@ import {
   WORK_ORDER_CONTEXT_FILENAME,
   workOrderContextManifestDigest,
 } from "../../runner/context/work-order-context.js";
+import type { KernelValidationEvidence } from "./kernel-inspection.js";
 import { mkdir } from "node:fs/promises";
 import path from "node:path";
 import {
@@ -105,7 +106,7 @@ async function withKernelReworkEvidence(
   const binding = order.canonical_binding;
   if (binding?.phase !== "implementation" || binding.attempt === 1) return order;
   const inputs: AgentWorkOrderV2["required_inputs"] = [];
-  for (const mutationId of Object.keys(record?.aggregate.mutation_receipts ?? {}).sort()) {
+  for (const mutationId of Object.keys(record?.aggregate.mutation_receipts ?? {}).toSorted()) {
     if (!/^validation:sha256:[a-f0-9]{64}$/u.test(mutationId)) continue;
     const name = mutationId.slice("validation:sha256:".length);
     const source = path.join(path.dirname(directory), name);
@@ -127,7 +128,7 @@ async function withKernelReworkEvidence(
       const validationPath = path.join(source, "validation.json");
       const validation = JSON.parse(
         await readStableRegularTextNoFollow(validationPath, "rework validation"),
-      );
+      ) as KernelValidationEvidence;
       if (
         validation.repository_fingerprint !== previous.repository_fingerprint ||
         validation.review_digest !== k.kernelDigest(review) ||
@@ -159,7 +160,7 @@ async function withKernelReworkEvidence(
       if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
     }
   }
-  if (!inputs.length)
+  if (inputs.length === 0)
     throw new Error(
       "Canonical rework requires retained evaluator findings and failed-check evidence",
     );

--- a/packages/agentplane/src/commands/task/kernel-exchange.ts
+++ b/packages/agentplane/src/commands/task/kernel-exchange.ts
@@ -1,3 +1,12 @@
+import {
+  putEvaluatorEvidenceObject,
+  readEvaluatorEvidenceObject,
+} from "../evaluator/evaluator-evidence-store.js";
+import {
+  buildWorkOrderContextManifest,
+  WORK_ORDER_CONTEXT_FILENAME,
+  workOrderContextManifestDigest,
+} from "../../runner/context/work-order-context.js";
 import { mkdir } from "node:fs/promises";
 import path from "node:path";
 import {
@@ -6,6 +15,7 @@ import {
   AGENT_SEMANTIC_RESULT_ZOD_SCHEMA,
   type AgentWorkOrderV2,
 } from "@agentplaneorg/core/schemas";
+import type { KernelRecord } from "../../adapters/task-backend/kernel-record.js";
 import { taskKernel as k } from "@agentplaneorg/core/tasks";
 import {
   readStableRegularTextNoFollow,
@@ -14,7 +24,11 @@ import {
 import { resolveCommandGitCommonDir, type CommandContext } from "../shared/task-backend.js";
 
 /** Immutable native exchange artifacts are evidence, not a second Task aggregate. */
-async function kernelExchangeDirectory(ctx: CommandContext, taskId: string, orderId: string) {
+export async function kernelExchangeDirectory(
+  ctx: CommandContext,
+  taskId: string,
+  orderId: string,
+) {
   if (!/^[A-Za-z0-9_-]+$/u.test(taskId) || !/^sha256:[a-f0-9]{64}$/u.test(orderId))
     throw new Error("Invalid canonical exchange identity");
   return path.join(
@@ -83,30 +97,159 @@ export async function readKernelOrderResult(
   return { directory, workOrder, semantic };
 }
 
+async function withKernelReworkEvidence(
+  order: AgentWorkOrderV2,
+  directory: string,
+  record?: KernelRecord,
+): Promise<AgentWorkOrderV2> {
+  const binding = order.canonical_binding;
+  if (binding?.phase !== "implementation" || binding.attempt === 1) return order;
+  const inputs: AgentWorkOrderV2["required_inputs"] = [];
+  for (const mutationId of Object.keys(record?.aggregate.mutation_receipts ?? {}).sort()) {
+    if (!/^validation:sha256:[a-f0-9]{64}$/u.test(mutationId)) continue;
+    const name = mutationId.slice("validation:sha256:".length);
+    const source = path.join(path.dirname(directory), name);
+    try {
+      const reviewPath = path.join(source, "inspection-result.json");
+      const review = AGENT_SEMANTIC_RESULT_ZOD_SCHEMA.parse(
+        JSON.parse(await readStableRegularTextNoFollow(reviewPath, "rework review")),
+      );
+      const previous = review.canonical_binding;
+      if (
+        previous?.phase !== "inspection" ||
+        previous.task_id !== binding.task_id ||
+        previous.repository_identity !== binding.repository_identity ||
+        previous.contract_digest !== binding.contract_digest ||
+        previous.work_item_id !== binding.work_item_id ||
+        previous.attempt !== binding.attempt - 1
+      )
+        continue;
+      const validationPath = path.join(source, "validation.json");
+      const validation = JSON.parse(
+        await readStableRegularTextNoFollow(validationPath, "rework validation"),
+      );
+      if (
+        validation.repository_fingerprint !== previous.repository_fingerprint ||
+        validation.review_digest !== k.kernelDigest(review) ||
+        validation.result_digest !== previous.result_digest ||
+        validation.checks.status !== "failed"
+      )
+        continue;
+      inputs.push(
+        {
+          id: `review:${name}`,
+          kind: "source_artifact",
+          path: reviewPath,
+          digest: k.kernelDigest(review),
+          description:
+            "Unresolved evaluator findings from the preceding attempt. Digest uses canonical JSON.",
+          required: true,
+        },
+        {
+          id: `checks:${name}`,
+          kind: "source_artifact",
+          path: validationPath,
+          digest: k.kernelDigest(validation),
+          description:
+            "Native failed checks from the preceding attempt. Digest uses canonical JSON.",
+          required: true,
+        },
+      );
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+    }
+  }
+  if (!inputs.length)
+    throw new Error(
+      "Canonical rework requires retained evaluator findings and failed-check evidence",
+    );
+  return AGENT_WORK_ORDER_V2_ZOD_SCHEMA.parse({
+    ...order,
+    required_inputs: [...order.required_inputs, ...inputs],
+  });
+}
+
 export async function issueKernelExchange(
   ctx: CommandContext,
   order: AgentWorkOrderV2,
   transport: "host" | "managed",
+  record?: KernelRecord,
 ) {
   const directory = await kernelExchangeDirectory(ctx, order.task.id, order.work_order_id);
+  order = await withKernelReworkEvidence(order, directory, record);
   await writeKernelArtifact(directory, "transport-owner.json", {
     transport,
     work_order_id: order.work_order_id,
   });
   await writeKernelArtifact(directory, "work-order.json", order);
-  await writeKernelArtifact(
-    directory,
-    "result-schema.json",
-    JSON.parse(renderAgentSemanticResultSchemaJson()),
+  const qualityRoot = path.join(
+    ctx.resolvedProject.gitRoot,
+    ctx.config.paths.workflow_dir,
+    order.task.id,
+    "quality",
   );
+  let resultSchemaRef = "result-schema.json";
+  try {
+    // Historical exchange files retain their original paths and bytes.
+    await readStableRegularTextNoFollow(
+      path.join(directory, resultSchemaRef),
+      "canonical result schema",
+    );
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+    let stored: unknown;
+    try {
+      stored = JSON.parse(
+        await readStableRegularTextNoFollow(
+          path.join(directory, "result-schema-object.json"),
+          "canonical schema descriptor",
+        ),
+      );
+    } catch (missing) {
+      if ((missing as NodeJS.ErrnoException).code !== "ENOENT") throw missing;
+      stored = await putEvaluatorEvidenceObject({
+        gitRoot: ctx.resolvedProject.gitRoot,
+        taskQualityRoot: qualityRoot,
+        logicalName: "canonical-result-schema",
+        kind: "result_schema",
+        extension: ".json",
+        mediaType: "application/schema+json",
+        contents: renderAgentSemanticResultSchemaJson(),
+      });
+      // Publish the descriptor after its object. Interrupted publication reuses verified bytes.
+      await writeKernelArtifact(directory, "result-schema-object.json", stored);
+    }
+    const { artifact } = await readEvaluatorEvidenceObject({
+      gitRoot: ctx.resolvedProject.gitRoot,
+      objectRoot: path
+        .relative(ctx.resolvedProject.gitRoot, path.join(qualityRoot, "objects"))
+        .replaceAll("\\", "/"),
+      artifact: stored,
+    });
+    if (artifact.kind !== "result_schema" || artifact.logical_name !== "canonical-result-schema")
+      throw new Error("Canonical schema descriptor has an invalid identity");
+    resultSchemaRef = path.relative(
+      directory,
+      path.join(ctx.resolvedProject.gitRoot, artifact.path),
+    );
+  }
+  const manifest = buildWorkOrderContextManifest(order, path.join(directory, "work-order.json"));
+  await writeKernelArtifact(directory, WORK_ORDER_CONTEXT_FILENAME, manifest);
   return {
+    context_manifest: {
+      ref: path.join(directory, WORK_ORDER_CONTEXT_FILENAME),
+      digest: workOrderContextManifestDigest(manifest),
+      blocks: manifest.blocks.length,
+      required: manifest.blocks.filter((block) => block.required).length,
+    },
     schema_version: 1,
     task_id: order.task.id,
     transition_id: `tr_${order.work_order_id.slice(7, 39)}`,
     state_fingerprint: order.state_fingerprint.digest,
     action: {
       kind: "agent_episode",
-      instruction: "Perform this canonical WorkOrder and return its typed semantic result.",
+      instruction:
+        "Read the complete context manifest and resolve every required block before semantic work. Validate digests against the referenced WorkOrder. Reload required blocks after context loss. Load optional blocks on demand. Perform this canonical WorkOrder and return its typed semantic result.",
     },
     stop: { reason: "semantic_boundary", resume: "request_fresh_packet" },
     authority: {
@@ -115,14 +258,14 @@ export async function issueKernelExchange(
       network: "deny",
       required: false,
       reference:
-        order.canonical_binding?.phase === "implementation"
+        order.canonical_binding && order.canonical_binding.phase !== "planning"
           ? order.canonical_binding.authority_digest
           : null,
     },
     exchange: {
       directory,
       work_order_ref: "work-order.json",
-      result_schema_ref: "result-schema.json",
+      result_schema_ref: resultSchemaRef,
       result_ref: "result.json",
       result_path: path.join(directory, "result.json"),
       resume_argv: [

--- a/packages/agentplane/src/commands/task/kernel-final-validation.ts
+++ b/packages/agentplane/src/commands/task/kernel-final-validation.ts
@@ -5,7 +5,8 @@ import type { CommandContext } from "../shared/task-backend.js";
 import { verificationChildEnv } from "../shared/pr-meta/verify-log.js";
 import { runDirectTaskVerification } from "./direct-task-verification.js";
 import { kernelExchangeDirectory, writeKernelArtifact } from "./kernel-exchange.js";
-import { createKernelRuntime, requireKernelCommit } from "./kernel-runtime-context.js";
+import type { createKernelRuntime } from "./kernel-runtime-context.js";
+import { requireKernelCommit } from "./kernel-runtime-context.js";
 
 type Runtime = Awaited<ReturnType<typeof createKernelRuntime>>;
 
@@ -32,7 +33,7 @@ export async function runKernelFinalValidation(
             record.aggregate.work_items[definition.id]?.state === "COMPLETED",
         )
         .flatMap((definition) => {
-          const contract = record.documents!.contracts[definition.contract_digest ?? ""];
+          const contract = record.documents!.contracts[String(definition.contract_digest ?? "")];
           if (!contract) throw new Error("Canonical final validation contract is missing");
           return contract.verification_commands;
         }),
@@ -70,10 +71,11 @@ export async function runKernelFinalValidation(
     allow_empty: true,
   });
   const current = await runtime.adapter.read(taskId);
+  const observed = await runtime.observe();
   if (
     current.kind !== "canonical" ||
     current.record.digest !== record.digest ||
-    (await runtime.observe()).fingerprint !== binding.repository_fingerprint ||
+    observed.fingerprint !== binding.repository_fingerprint ||
     k.kernelDigest(verificationChildEnv()) !== environmentDigest
   )
     throw new Error("Canonical final validation inputs changed during checks");

--- a/packages/agentplane/src/commands/task/kernel-final-validation.ts
+++ b/packages/agentplane/src/commands/task/kernel-final-validation.ts
@@ -1,0 +1,117 @@
+import { randomUUID } from "node:crypto";
+import { taskKernel as k } from "@agentplaneorg/core/tasks";
+import type { KernelRecord } from "../../adapters/task-backend/kernel-record.js";
+import type { CommandContext } from "../shared/task-backend.js";
+import { verificationChildEnv } from "../shared/pr-meta/verify-log.js";
+import { runDirectTaskVerification } from "./direct-task-verification.js";
+import { kernelExchangeDirectory, writeKernelArtifact } from "./kernel-exchange.js";
+import { createKernelRuntime, requireKernelCommit } from "./kernel-runtime-context.js";
+
+type Runtime = Awaited<ReturnType<typeof createKernelRuntime>>;
+
+/** Native final checks never infer success from an agent result or an earlier WorkItem. */
+export async function runKernelFinalValidation(
+  command: CommandContext,
+  runtime: Runtime,
+  record: KernelRecord,
+) {
+  const taskId = record.aggregate.id;
+  const plan = record.aggregate.current_plan;
+  if (plan?.state !== "APPROVED" || !record.documents)
+    throw new Error("Canonical final validation requires an approved plan and contracts");
+  const context = await runtime.native.readContext(taskId);
+  const { authority } = await runtime.authority.resolve(taskId);
+  if (authority.repository_fingerprint !== context.repository_fingerprint)
+    throw new Error("Canonical final validation authority is stale");
+  const commands = [
+    ...new Set(
+      plan.work_items
+        .filter(
+          (definition) =>
+            !definition.optional ||
+            record.aggregate.work_items[definition.id]?.state === "COMPLETED",
+        )
+        .flatMap((definition) => {
+          const contract = record.documents!.contracts[definition.contract_digest ?? ""];
+          if (!contract) throw new Error("Canonical final validation contract is missing");
+          return contract.verification_commands;
+        }),
+    ),
+  ];
+  // Retain only a digest of the check environment, never its values. No check cache spans invocations.
+  const environmentDigest = k.kernelDigest(verificationChildEnv());
+  const binding = {
+    task_id: taskId,
+    plan_digest: plan.digest,
+    repository_fingerprint: context.repository_fingerprint,
+    authority_digest: authority.digest,
+    commands,
+    environment_digest: environmentDigest,
+    work_items: Object.fromEntries(
+      Object.entries(record.aggregate.work_items).map(([id, item]) => [
+        id,
+        { state: item.state, result_digest: item.result_digest, validation: item.validation },
+      ]),
+    ),
+  };
+  const directory = await kernelExchangeDirectory(
+    command,
+    taskId,
+    k.kernelDigest({ binding, revision: record.aggregate.revision, attempt: randomUUID() }),
+  );
+  await writeKernelArtifact(directory, "final-validation-inputs.json", binding);
+  const checks = await runDirectTaskVerification({
+    command,
+    task: { verify: [] },
+    task_id: taskId,
+    cwd: command.resolvedProject.gitRoot,
+    additional_only: true,
+    additional_commands: commands.map((check) => ({ command: check })),
+    allow_empty: true,
+  });
+  const current = await runtime.adapter.read(taskId);
+  if (
+    current.kind !== "canonical" ||
+    current.record.digest !== record.digest ||
+    (await runtime.observe()).fingerprint !== binding.repository_fingerprint ||
+    k.kernelDigest(verificationChildEnv()) !== environmentDigest
+  )
+    throw new Error("Canonical final validation inputs changed during checks");
+  const evidence = { binding, checks };
+  await writeKernelArtifact(directory, "final-validation.json", evidence);
+  if (checks.status !== "passed")
+    return {
+      stop: {
+        kind: "human_required",
+        reason: "canonical_final_checks_failed",
+        summary: checks.reason,
+        evidence: directory,
+      },
+    };
+  const validation: k.ValidationRecord = {
+    status: "PASSED",
+    identity: {
+      implementation_identity: binding.repository_fingerprint,
+      check_id: "canonical-final-contracts",
+      command_digest: k.kernelDigest(commands),
+      environment_digest: environmentDigest,
+      toolchain_digest: k.kernelDigest(checks.checks.map((check) => check.runtime ?? null)),
+    },
+    evidence_digests: [k.kernelDigest(evidence)],
+    observed_at: context.occurred_at,
+  };
+  const input = await runtime.input(
+    { kind: "record_final_validation", validation },
+    `final-validation:${k.kernelDigest(evidence)}:${record.aggregate.revision}`,
+  );
+  if (input.command.expected_task_revision !== record.aggregate.revision)
+    throw new Error("Canonical final validation task changed before persistence");
+  await writeKernelArtifact(directory, "final-validation-command.json", input);
+  requireKernelCommit(await runtime.lifecycle.apply(input));
+  return {
+    fingerprint: binding.repository_fingerprint,
+    environment_digest: environmentDigest,
+    evidence_digest: k.kernelDigest(evidence),
+    plan_digest: plan.digest,
+  };
+}

--- a/packages/agentplane/src/commands/task/kernel-inspection.ts
+++ b/packages/agentplane/src/commands/task/kernel-inspection.ts
@@ -5,10 +5,12 @@ import {
   type AgentSemanticResult,
 } from "@agentplaneorg/core/schemas";
 import { taskKernel as k, type KernelEpisodeBinding } from "@agentplaneorg/core/tasks";
+import type { KernelCommandInput } from "../../adapters/task-backend/kernel-backend-adapter.js";
 import type { KernelRecord } from "../../adapters/task-backend/kernel-record.js";
 import type { CommandContext } from "../shared/task-backend.js";
 import { readStableRegularTextNoFollow } from "../../shared/stable-file.js";
-import { createKernelRuntime, requireKernelCommit } from "./kernel-runtime-context.js";
+import type { createKernelRuntime } from "./kernel-runtime-context.js";
+import { requireKernelCommit } from "./kernel-runtime-context.js";
 import { buildKernelStateFingerprint } from "./kernel-work-order.js";
 import {
   issueKernelExchange,
@@ -18,6 +20,13 @@ import {
 import { runDirectTaskVerification } from "./direct-task-verification.js";
 
 type Runtime = Awaited<ReturnType<typeof createKernelRuntime>>;
+export type KernelValidationEvidence = {
+  repository_fingerprint: string;
+  result_digest: string;
+  review_digest: string;
+  checks: Awaited<ReturnType<typeof runDirectTaskVerification>>;
+};
+
 type InspectionBinding = Extract<KernelEpisodeBinding, { phase: "inspection" }>;
 
 export async function issueKernelInspection(
@@ -28,7 +37,7 @@ export async function issueKernelInspection(
 ) {
   const item = record.aggregate.work_items[workItemId];
   const plan = record.aggregate.current_plan;
-  const contract = record.documents?.contracts[item?.definition.contract_digest ?? ""];
+  const contract = record.documents?.contracts[String(item?.definition.contract_digest ?? "")];
   if (
     !item?.claim_id ||
     !item.result_digest ||
@@ -55,14 +64,14 @@ export async function issueKernelInspection(
   let resultPath: string | undefined;
   for (const mutationId of Object.keys(record.aggregate.mutation_receipts)
     .filter((id) => /^result:sha256:[a-f0-9]{64}$/u.test(id))
-    .reverse()) {
+    .toReversed()) {
     const directory = await kernelExchangeDirectory(
       command,
       record.aggregate.id,
       mutationId.slice("result:".length),
     );
     const candidate = path.join(directory, "received-result.json");
-    const semantic = JSON.parse(
+    const semantic: unknown = JSON.parse(
       await readStableRegularTextNoFollow(candidate, "canonical received result"),
     );
     if (k.kernelDigest(semantic) === item.result_digest) {
@@ -183,8 +192,7 @@ export async function acceptKernelInspection(
   const context = await runtime.native.readContext(binding.task_id);
   const plan = read.record.aggregate.current_plan;
   if (
-    !item ||
-    item.result_digest !== binding.result_digest ||
+    item?.result_digest !== binding.result_digest ||
     item.attempt !== binding.attempt ||
     item.claim_id !== binding.claim_id ||
     item.definition.contract_digest !== binding.contract_digest ||
@@ -205,18 +213,13 @@ export async function acceptKernelInspection(
       reason: "canonical_inspection_requires_attention",
       summary: semantic.summary,
     };
-  const contract = read.record.documents!.contracts[binding.contract_digest]!;
+  const contract = read.record.documents!.contracts[String(binding.contract_digest)]!;
   const evidencePath = path.join(directory, "validation.json");
-  let evidence: {
-    repository_fingerprint: string;
-    result_digest: string;
-    review_digest: string;
-    checks: Awaited<ReturnType<typeof runDirectTaskVerification>>;
-  };
+  let evidence: KernelValidationEvidence;
   try {
     evidence = JSON.parse(
       await readStableRegularTextNoFollow(evidencePath, "canonical validation"),
-    );
+    ) as KernelValidationEvidence;
   } catch (error) {
     if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
     const checks =
@@ -244,7 +247,8 @@ export async function acceptKernelInspection(
       review_digest: k.kernelDigest(semantic),
       checks,
     };
-    if ((await runtime.observe()).fingerprint !== binding.repository_fingerprint)
+    const observed = await runtime.observe();
+    if (observed.fingerprint !== binding.repository_fingerprint)
       throw new Error("Canonical repository changed during validation");
     await writeKernelArtifact(directory, "validation.json", evidence);
   }
@@ -280,11 +284,11 @@ export async function acceptKernelInspection(
   };
   // Save the native command input before CAS. A restart replays the same observation timestamp.
   const inputPath = path.join(directory, "validation-command.json");
-  let input;
+  let input: KernelCommandInput;
   try {
     input = JSON.parse(
       await readStableRegularTextNoFollow(inputPath, "canonical validation command"),
-    );
+    ) as KernelCommandInput;
   } catch (error) {
     if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
     input = await runtime.input(
@@ -322,14 +326,11 @@ export async function resumeKernelInspection(
   workItemId: string,
 ) {
   const item = record.aggregate.work_items[workItemId];
-  if (
-    !item?.validation ||
-    item.validation.identity.check_id !== "canonical-contract-and-inspection"
-  )
+  if (item?.validation?.identity.check_id !== "canonical-contract-and-inspection")
     return { kind: "human_required", reason: "canonical_native_validation_evidence_required" };
   for (const mutationId of Object.keys(record.aggregate.mutation_receipts)
     .filter((id) => /^validation:sha256:[a-f0-9]{64}$/u.test(id))
-    .reverse()) {
+    .toReversed()) {
     const directory = await kernelExchangeDirectory(
       command,
       record.aggregate.id,

--- a/packages/agentplane/src/commands/task/kernel-inspection.ts
+++ b/packages/agentplane/src/commands/task/kernel-inspection.ts
@@ -1,0 +1,354 @@
+import path from "node:path";
+import {
+  AGENT_WORK_ORDER_V2_ZOD_SCHEMA,
+  AGENT_SEMANTIC_RESULT_ZOD_SCHEMA,
+  type AgentSemanticResult,
+} from "@agentplaneorg/core/schemas";
+import { taskKernel as k, type KernelEpisodeBinding } from "@agentplaneorg/core/tasks";
+import type { KernelRecord } from "../../adapters/task-backend/kernel-record.js";
+import type { CommandContext } from "../shared/task-backend.js";
+import { readStableRegularTextNoFollow } from "../../shared/stable-file.js";
+import { createKernelRuntime, requireKernelCommit } from "./kernel-runtime-context.js";
+import { buildKernelStateFingerprint } from "./kernel-work-order.js";
+import {
+  issueKernelExchange,
+  writeKernelArtifact,
+  kernelExchangeDirectory,
+} from "./kernel-exchange.js";
+import { runDirectTaskVerification } from "./direct-task-verification.js";
+
+type Runtime = Awaited<ReturnType<typeof createKernelRuntime>>;
+type InspectionBinding = Extract<KernelEpisodeBinding, { phase: "inspection" }>;
+
+export async function issueKernelInspection(
+  command: CommandContext,
+  runtime: Runtime,
+  record: KernelRecord,
+  workItemId: string,
+) {
+  const item = record.aggregate.work_items[workItemId];
+  const plan = record.aggregate.current_plan;
+  const contract = record.documents?.contracts[item?.definition.contract_digest ?? ""];
+  if (
+    !item?.claim_id ||
+    !item.result_digest ||
+    !contract ||
+    plan?.state !== "APPROVED" ||
+    item.state !== "INSPECTING"
+  )
+    throw new Error("Canonical inspection requires a bound received result");
+  const { authority, context } = await runtime.authority.resolve(record.aggregate.id, workItemId);
+  const binding: InspectionBinding = {
+    phase: "inspection",
+    task_id: record.aggregate.id,
+    repository_identity: context.repository_identity,
+    repository_fingerprint: context.repository_fingerprint,
+    plan_revision: plan.revision,
+    plan_digest: plan.digest,
+    work_item_id: workItemId,
+    attempt: item.attempt,
+    claim_id: item.claim_id,
+    contract_digest: item.definition.contract_digest!,
+    authority_digest: authority.digest,
+    result_digest: item.result_digest,
+  };
+  let resultPath: string | undefined;
+  for (const mutationId of Object.keys(record.aggregate.mutation_receipts)
+    .filter((id) => /^result:sha256:[a-f0-9]{64}$/u.test(id))
+    .reverse()) {
+    const directory = await kernelExchangeDirectory(
+      command,
+      record.aggregate.id,
+      mutationId.slice("result:".length),
+    );
+    const candidate = path.join(directory, "received-result.json");
+    const semantic = JSON.parse(
+      await readStableRegularTextNoFollow(candidate, "canonical received result"),
+    );
+    if (k.kernelDigest(semantic) === item.result_digest) {
+      resultPath = candidate;
+      break;
+    }
+  }
+  if (!resultPath) throw new Error("Canonical received implementation evidence missing");
+  const order = AGENT_WORK_ORDER_V2_ZOD_SCHEMA.parse({
+    schema_version: 2,
+    kind: "agent_work_order",
+    work_order_id: k.kernelDigest({ binding, revision: record.aggregate.revision }),
+    role: "EVALUATOR",
+    task: {
+      id: record.aggregate.id,
+      revision: record.aggregate.revision,
+      work_item_id: workItemId,
+      objective: `Independently inspect the implementation: ${contract.objective}`,
+      acceptance_criteria: contract.acceptance_criteria.map((description, index) => ({
+        id: `criterion-${index + 1}`,
+        description,
+        required: true,
+      })),
+      unresolved_questions: [],
+    },
+    canonical_binding: binding,
+    state_fingerprint: buildKernelStateFingerprint({
+      command,
+      record,
+      context,
+      authority_digest: authority.digest,
+    }),
+    state_fingerprint_policy: {
+      required_components: ["task", "git", "backend_projection", "policy", "authority"],
+      provider: { required: false, unavailable: "allow_if_unchanged" },
+    },
+    authority: {
+      mutation_scope: "none",
+      writable_roots: [],
+      protected_paths: ["."],
+      allowed_tool_classes: ["repository_read", "git_read", "report_result", "report_blocker"],
+      network: "deny",
+      external_side_effects: [],
+      sandbox: "read-only",
+      expires_at: authority.expires_at,
+    },
+    context_intent: {
+      purpose:
+        "Inspect source and output evidence against the approved contract. Return a review verdict. Do not modify implementation or claim native verification. The controller executes the approved checks independently.",
+      required_knowledge_ref_digests: [],
+      require_prepared_evidence: false,
+    },
+    knowledge_refs: [],
+    prepared_evidence: [],
+    required_inputs: [
+      {
+        id: "implementation-result",
+        kind: "source_artifact",
+        path: resultPath,
+        digest: item.result_digest,
+        description:
+          "Native-accepted implementation result and evidence references. Digest uses canonical JSON.",
+        required: true,
+      },
+      ...item.output_manifests.map((manifest) => ({
+        id: manifest.id,
+        kind: "source_artifact",
+        description: manifest.kind,
+        digest: manifest.digest,
+        required: true,
+      })),
+    ],
+    required_outputs: [
+      {
+        id: "review",
+        kind: "semantic_result",
+        description:
+          "Return AgentSemanticResult v2 with the exact canonical_binding and review. Use pass, rework, blocked or human_review. Include findings and residual risks.",
+        required: true,
+      },
+    ],
+    verification_intent: {
+      requirements: contract.verification_commands.map((check, index) => ({
+        id: `check-${index + 1}`,
+        description: check,
+        required: true,
+        observed_by: "agentplane",
+      })),
+      require_execution_receipt: true,
+    },
+    semantic_result_schema: "agentplane.agent_semantic_result.v2",
+    stop_rules: [
+      "Perform only independent inspection.",
+      "Do not invoke lifecycle commands or modify repository files.",
+      "Return the exact canonical_binding and a review verdict.",
+    ],
+  });
+  return issueKernelExchange(
+    command,
+    order,
+    context.actor.transport === "managed" ? "managed" : "host",
+  );
+}
+
+/** Reviewer claims never become observed check results. Only this native runner records validation. */
+export async function acceptKernelInspection(
+  command: CommandContext,
+  runtime: Runtime,
+  directory: string,
+  semantic: AgentSemanticResult,
+) {
+  const binding = semantic.canonical_binding;
+  if (binding?.phase !== "inspection" || !semantic.review)
+    throw new Error("Canonical inspection review required");
+  const read = await runtime.adapter.read(binding.task_id);
+  if (read.kind !== "canonical") throw new Error("Canonical Task unavailable");
+  const item = read.record.aggregate.work_items[binding.work_item_id];
+  const context = await runtime.native.readContext(binding.task_id);
+  const plan = read.record.aggregate.current_plan;
+  if (
+    !item ||
+    item.result_digest !== binding.result_digest ||
+    item.attempt !== binding.attempt ||
+    item.claim_id !== binding.claim_id ||
+    item.definition.contract_digest !== binding.contract_digest ||
+    plan?.digest !== binding.plan_digest ||
+    plan.revision !== binding.plan_revision ||
+    context.repository_fingerprint !== binding.repository_fingerprint ||
+    !["INSPECTING", "VALIDATING", "COMPLETED", "REWORK_READY"].includes(item.state)
+  )
+    throw new Error("Canonical inspection result is stale");
+  const resolved = await runtime.authority.resolve(binding.task_id, binding.work_item_id);
+  if (resolved.authority.digest !== binding.authority_digest)
+    throw new Error("Canonical inspection authority changed");
+  await writeKernelArtifact(directory, "inspection-result.json", semantic);
+  if (item.state === "COMPLETED" || item.state === "REWORK_READY") return;
+  if (semantic.review.verdict === "blocked" || semantic.review.verdict === "human_review")
+    return {
+      kind: "human_required",
+      reason: "canonical_inspection_requires_attention",
+      summary: semantic.summary,
+    };
+  const contract = read.record.documents!.contracts[binding.contract_digest]!;
+  const evidencePath = path.join(directory, "validation.json");
+  let evidence: {
+    repository_fingerprint: string;
+    result_digest: string;
+    review_digest: string;
+    checks: Awaited<ReturnType<typeof runDirectTaskVerification>>;
+  };
+  try {
+    evidence = JSON.parse(
+      await readStableRegularTextNoFollow(evidencePath, "canonical validation"),
+    );
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+    const checks =
+      semantic.review.verdict === "pass"
+        ? await runDirectTaskVerification({
+            command,
+            task: { verify: [] },
+            task_id: binding.task_id,
+            cwd: command.resolvedProject.gitRoot,
+            additional_only: true,
+            additional_commands: contract.verification_commands.map((check) => ({
+              command: check,
+            })),
+            allow_empty: true,
+          })
+        : {
+            status: "failed" as const,
+            artifact_path: "",
+            checks: [],
+            reason: "Independent inspection requires rework",
+          };
+    evidence = {
+      repository_fingerprint: binding.repository_fingerprint,
+      result_digest: binding.result_digest,
+      review_digest: k.kernelDigest(semantic),
+      checks,
+    };
+    if ((await runtime.observe()).fingerprint !== binding.repository_fingerprint)
+      throw new Error("Canonical repository changed during validation");
+    await writeKernelArtifact(directory, "validation.json", evidence);
+  }
+  if (
+    evidence.repository_fingerprint !== binding.repository_fingerprint ||
+    evidence.result_digest !== binding.result_digest ||
+    evidence.review_digest !== k.kernelDigest(semantic)
+  )
+    throw new Error("Canonical validation evidence binding mismatch");
+  const validation: k.ValidationRecord = {
+    status:
+      evidence.checks.status === "passed"
+        ? "PASSED"
+        : evidence.checks.status === "unsupported"
+          ? "BLOCKED"
+          : "FAILED",
+    identity: {
+      implementation_identity: binding.result_digest,
+      check_id: "canonical-contract-and-inspection",
+      command_digest: k.kernelDigest(contract.verification_commands),
+      toolchain_digest: k.kernelDigest(
+        evidence.checks.checks.map((check) => check.runtime ?? null),
+      ),
+      environment_digest: k.kernelDigest({
+        repository: binding.repository_fingerprint,
+        platform: process.platform,
+        arch: process.arch,
+        node: process.version,
+      }),
+    },
+    evidence_digests: [k.kernelDigest(evidence), k.kernelDigest(semantic)],
+    observed_at: context.occurred_at,
+  };
+  // Save the native command input before CAS. A restart replays the same observation timestamp.
+  const inputPath = path.join(directory, "validation-command.json");
+  let input;
+  try {
+    input = JSON.parse(
+      await readStableRegularTextNoFollow(inputPath, "canonical validation command"),
+    );
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+    input = await runtime.input(
+      { kind: "record_work_item_validation", work_item_id: binding.work_item_id, validation },
+      `validation:${semantic.work_order_id}`,
+    );
+    await writeKernelArtifact(directory, "validation-command.json", input);
+  }
+  requireKernelCommit(await runtime.lifecycle.apply(input));
+  if (validation.status === "BLOCKED")
+    return {
+      kind: "human_required",
+      reason: "canonical_validation_infrastructure",
+      summary: evidence.checks.reason,
+    };
+  requireKernelCommit(
+    await runtime.lifecycle.apply(
+      await runtime.input(
+        {
+          kind: "transition_work_item",
+          action: validation.status === "PASSED" ? "complete" : "rework",
+          work_item_id: binding.work_item_id,
+          claim_id: binding.claim_id,
+        },
+        `validation-resolution:${semantic.work_order_id}`,
+      ),
+    ),
+  );
+}
+
+export async function resumeKernelInspection(
+  command: CommandContext,
+  runtime: Runtime,
+  record: KernelRecord,
+  workItemId: string,
+) {
+  const item = record.aggregate.work_items[workItemId];
+  if (
+    !item?.validation ||
+    item.validation.identity.check_id !== "canonical-contract-and-inspection"
+  )
+    return { kind: "human_required", reason: "canonical_native_validation_evidence_required" };
+  for (const mutationId of Object.keys(record.aggregate.mutation_receipts)
+    .filter((id) => /^validation:sha256:[a-f0-9]{64}$/u.test(id))
+    .reverse()) {
+    const directory = await kernelExchangeDirectory(
+      command,
+      record.aggregate.id,
+      mutationId.slice("validation:".length),
+    );
+    const semantic = AGENT_SEMANTIC_RESULT_ZOD_SCHEMA.parse(
+      JSON.parse(
+        await readStableRegularTextNoFollow(
+          path.join(directory, "inspection-result.json"),
+          "canonical saved inspection",
+        ),
+      ),
+    );
+    if (
+      semantic.canonical_binding?.phase === "inspection" &&
+      semantic.canonical_binding.work_item_id === workItemId &&
+      item.validation.evidence_digests.includes(k.kernelDigest(semantic))
+    )
+      return acceptKernelInspection(command, runtime, directory, semantic);
+  }
+  throw new Error("Canonical native validation evidence is missing");
+}

--- a/packages/agentplane/src/commands/task/kernel-run.ts
+++ b/packages/agentplane/src/commands/task/kernel-run.ts
@@ -144,7 +144,7 @@ async function executeKernelPacket(
       record: current.record,
       context: await runtime.native.readContext(taskId),
       authority_digest:
-        workOrder.canonical_binding?.phase === "implementation"
+        workOrder.canonical_binding && workOrder.canonical_binding.phase !== "planning"
           ? workOrder.canonical_binding.authority_digest
           : null,
     });

--- a/packages/agentplane/src/commands/task/scope-extend.ts
+++ b/packages/agentplane/src/commands/task/scope-extend.ts
@@ -4,6 +4,7 @@ import {
   executionGrantForContextFromExtensions,
   rebaseExecutionGrantScope,
   type TaskRepositoryEffect,
+  repositoryEffectsForPath,
 } from "@agentplaneorg/core/tasks";
 
 import type { TaskData } from "../../backends/task-backend.js";
@@ -27,6 +28,8 @@ import {
 } from "../shared/task-scope-extension-request.js";
 import { loadCommandContext, type CommandContext } from "../shared/task-backend.js";
 import { resolveLogicalRepositoryIdentity } from "./execution-authority-context.js";
+import { TASK_KERNEL_EXTENSION } from "../../adapters/task-backend/kernel-record.js";
+import { createKernelRuntime, requireKernelCommit } from "./kernel-runtime-context.js";
 
 const output = createCliEmitter();
 
@@ -186,6 +189,50 @@ export async function cmdTaskScopeExtend(opts: {
   quiet?: boolean;
 }): Promise<number> {
   try {
+    const canonical = await opts.ctx.taskBackend.getTask(opts.taskId);
+    if (canonical?.extensions && Object.hasOwn(canonical.extensions, TASK_KERNEL_EXTENSION)) {
+      if (opts.by !== "USER")
+        throw new CliError({
+          code: "E_VALIDATION",
+          message: "Canonical authority delta requires explicit --by USER authority.",
+        });
+      if (
+        (opts.stateScopeDigest ?? opts.stateFingerprint) !== opts.requestDigest ||
+        !/^sha256:[0-9a-f]{64}$/u.test(opts.requestDigest)
+      )
+        throw new CliError({
+          code: "E_VALIDATION",
+          message: "Canonical authority delta state scope must equal its exact request digest.",
+        });
+      const runtime = await createKernelRuntime({
+        command: opts.ctx,
+        task_id: opts.taskId,
+        transport: "manual",
+        operation_id: `authority-delta:${opts.requestDigest}`,
+        approval: {
+          kind: "manual_operator",
+          actor_id: opts.by,
+          invocation_id: opts.requestDigest,
+        },
+      });
+      requireKernelCommit(
+        await runtime.authority.approveDelta({
+          task_id: opts.taskId,
+          scope_roots: opts.scopeRoots,
+          repository_effects: opts.repositoryEffects,
+          request_digest: opts.requestDigest as `sha256:${string}`,
+          repositoryEffects: repositoryEffectsForPath,
+        }),
+      );
+      if (!opts.quiet)
+        emitCommandResult(output, {
+          kind: "success",
+          action: "canonical authority scope extended",
+          target: opts.taskId,
+          details: `request=${opts.requestDigest}`,
+        });
+      return 0;
+    }
     const routeCommand = opts.ctx;
     const decision = await buildTaskRouteDecision({
       ctx: routeCommand,

--- a/packages/agentplane/src/commands/task/task-token-usage.test.ts
+++ b/packages/agentplane/src/commands/task/task-token-usage.test.ts
@@ -39,6 +39,7 @@ function completeAgent(opts: {
   usage?: {
     input_tokens: number;
     output_tokens: number;
+    cached_input_tokens?: number;
     visible_output_tokens?: number;
     reasoning_tokens?: number;
     total_tokens: number;
@@ -63,6 +64,35 @@ function completeAgent(opts: {
 }
 
 describe("completed task token usage projection", () => {
+  it("distinguishes observed zero cached input from missing cache telemetry", () => {
+    const create = (cached?: number) =>
+      projectTaskTokenUsage({
+        journal: completeAgent({
+          journal: journal(),
+          role: "EXECUTOR",
+          fingerprint: fingerprintA,
+          usage: {
+            input_tokens: 10,
+            output_tokens: 2,
+            total_tokens: 12,
+            ...(cached === undefined ? {} : { cached_input_tokens: cached }),
+          },
+        }),
+      });
+    expect(create()).toMatchObject({
+      cached_input_tokens: null,
+      cached_input_observed_agent_runs: 0,
+    });
+    expect(create(0)).toMatchObject({
+      cached_input_tokens: 0,
+      cached_input_observed_agent_runs: 1,
+    });
+    expect(create(7)).toMatchObject({
+      cached_input_tokens: 7,
+      cached_input_observed_agent_runs: 1,
+    });
+  });
+
   it("aggregates executor and evaluator provider telemetry exactly once", () => {
     const executor = completeAgent({
       journal: journal(),
@@ -103,6 +133,8 @@ describe("completed task token usage projection", () => {
     ).toEqual({
       schema_version: 1,
       state: "observed",
+      cached_input_tokens: null,
+      cached_input_observed_agent_runs: 0,
       input_tokens: 15,
       output_tokens: 6,
       reasoning_tokens: 7,

--- a/packages/agentplane/src/commands/task/task-token-usage.test.ts
+++ b/packages/agentplane/src/commands/task/task-token-usage.test.ts
@@ -63,22 +63,23 @@ function completeAgent(opts: {
   });
 }
 
+const create = (cached?: number) =>
+  projectTaskTokenUsage({
+    journal: completeAgent({
+      journal: journal(),
+      role: "EXECUTOR",
+      fingerprint: fingerprintA,
+      usage: {
+        input_tokens: 10,
+        output_tokens: 2,
+        total_tokens: 12,
+        ...(cached === undefined ? {} : { cached_input_tokens: cached }),
+      },
+    }),
+  });
+
 describe("completed task token usage projection", () => {
   it("distinguishes observed zero cached input from missing cache telemetry", () => {
-    const create = (cached?: number) =>
-      projectTaskTokenUsage({
-        journal: completeAgent({
-          journal: journal(),
-          role: "EXECUTOR",
-          fingerprint: fingerprintA,
-          usage: {
-            input_tokens: 10,
-            output_tokens: 2,
-            total_tokens: 12,
-            ...(cached === undefined ? {} : { cached_input_tokens: cached }),
-          },
-        }),
-      });
     expect(create()).toMatchObject({
       cached_input_tokens: null,
       cached_input_observed_agent_runs: 0,

--- a/packages/agentplane/src/commands/task/task-token-usage.ts
+++ b/packages/agentplane/src/commands/task/task-token-usage.ts
@@ -17,6 +17,8 @@ function unavailableTaskTokenUsage(opts: {
   return {
     schema_version: 1,
     state: "unavailable",
+    cached_input_tokens: null,
+    cached_input_observed_agent_runs: 0,
     input_tokens: null,
     output_tokens: null,
     reasoning_tokens: null,
@@ -66,6 +68,11 @@ export function projectTaskTokenUsage(opts: {
   return {
     schema_version: 1,
     state: fullyObserved ? "observed" : "partial",
+    cached_input_tokens:
+      (usage.cached_input_observed_agent_runs ?? 0) > 0
+        ? (usage.cached_input_tokens ?? null)
+        : null,
+    cached_input_observed_agent_runs: usage.cached_input_observed_agent_runs ?? 0,
     input_tokens: usage.input_tokens,
     output_tokens: hasCompleteBreakdown ? (usage.visible_output_tokens ?? null) : null,
     reasoning_tokens: hasCompleteBreakdown ? (usage.reasoning_tokens ?? null) : null,

--- a/packages/agentplane/src/harness/token-accounting.test.ts
+++ b/packages/agentplane/src/harness/token-accounting.test.ts
@@ -43,7 +43,8 @@ describe("harness/token-accounting", () => {
       },
     });
     const first = applyTokenUsageEvent(createTokenAccumulator(), event(7));
-    const restored = JSON.parse(JSON.stringify(first.state));
+    const serialized = JSON.stringify(first.state);
+    const restored = JSON.parse(serialized) as typeof first.state;
     const duplicate = applyTokenUsageEvent(restored, event());
     expect(duplicate.state.global).toMatchObject({ totalTokens: 15, cachedInputTokens: 7 });
     const advancedWithoutCache = applyTokenUsageEvent(duplicate.state, event(undefined, 16));

--- a/packages/agentplane/src/harness/token-accounting.test.ts
+++ b/packages/agentplane/src/harness/token-accounting.test.ts
@@ -28,6 +28,29 @@ describe("harness/token-accounting", () => {
     expect(second.state.global.totalTokens).toBe(15);
   });
 
+  it("keeps absolute cache accounting idempotent across restart and partial duplicates", () => {
+    const event = (cachedInputTokens?: number, totalTokens = 15) => ({
+      threadId: "t1",
+      payload: {
+        tokenUsage: {
+          total: {
+            inputTokens: 10,
+            outputTokens: totalTokens - 10,
+            totalTokens,
+            ...(cachedInputTokens === undefined ? {} : { cachedInputTokens }),
+          },
+        },
+      },
+    });
+    const first = applyTokenUsageEvent(createTokenAccumulator(), event(7));
+    const restored = JSON.parse(JSON.stringify(first.state));
+    const duplicate = applyTokenUsageEvent(restored, event());
+    expect(duplicate.state.global).toMatchObject({ totalTokens: 15, cachedInputTokens: 7 });
+    const advancedWithoutCache = applyTokenUsageEvent(duplicate.state, event(undefined, 16));
+    expect(advancedWithoutCache.state.global.cachedInputTokens).toBeNull();
+    expect(applyTokenUsageEvent(duplicate.state, event(11)).accepted).toBe(false);
+  });
+
   it("supports codex info.total_token_usage payload", () => {
     const state = createTokenAccumulator();
     const next = applyTokenUsageEvent(state, {

--- a/packages/agentplane/src/harness/token-accounting.ts
+++ b/packages/agentplane/src/harness/token-accounting.ts
@@ -2,6 +2,7 @@ type TokenTotals = {
   inputTokens: number;
   outputTokens: number;
   totalTokens: number;
+  cachedInputTokens: number | null;
 };
 
 export type TokenUsageEvent = {
@@ -18,11 +19,15 @@ const ZERO_TOTALS: TokenTotals = {
   inputTokens: 0,
   outputTokens: 0,
   totalTokens: 0,
+  cachedInputTokens: null,
 };
 
 function safeInt(value: unknown): number | null {
-  if (typeof value === "number" && Number.isFinite(value)) return Math.trunc(value);
-  if (typeof value === "string" && /^\d+$/.test(value)) return Number.parseInt(value, 10);
+  if (typeof value === "number" && Number.isSafeInteger(value) && value >= 0) return value;
+  if (typeof value === "string" && /^\d+$/.test(value)) {
+    const parsed = Number(value);
+    return Number.isSafeInteger(parsed) ? parsed : null;
+  }
   return null;
 }
 
@@ -36,7 +41,12 @@ function extractAbsoluteTotals(payload: Record<string, unknown>): TokenTotals | 
       const output = safeInt(totalObj.outputTokens);
       const all = safeInt(totalObj.totalTokens);
       if (input !== null && output !== null && all !== null) {
-        return { inputTokens: input, outputTokens: output, totalTokens: all };
+        return {
+          inputTokens: input,
+          outputTokens: output,
+          totalTokens: all,
+          cachedInputTokens: safeInt(totalObj.cachedInputTokens),
+        };
       }
     }
   }
@@ -50,7 +60,12 @@ function extractAbsoluteTotals(payload: Record<string, unknown>): TokenTotals | 
       const output = safeInt(usage.output_tokens);
       const all = safeInt(usage.total_tokens);
       if (input !== null && output !== null && all !== null) {
-        return { inputTokens: input, outputTokens: output, totalTokens: all };
+        return {
+          inputTokens: input,
+          outputTokens: output,
+          totalTokens: all,
+          cachedInputTokens: safeInt(usage.cached_input_tokens),
+        };
       }
     }
   }
@@ -65,6 +80,11 @@ function mergeGlobal(byThread: Record<string, TokenTotals>): TokenTotals {
     global.outputTokens += totals.outputTokens;
     global.totalTokens += totals.totalTokens;
   }
+  const cached = Object.values(byThread).map((totals) => totals.cachedInputTokens ?? null);
+  global.cachedInputTokens =
+    cached.length > 0 && cached.every((value) => value !== null)
+      ? cached.reduce<number>((sum, value) => sum + (value ?? 0), 0)
+      : null;
   return global;
 }
 
@@ -85,10 +105,22 @@ export function applyTokenUsageEvent(
   }
 
   const prev = state.byThread[event.threadId] ?? { ...ZERO_TOTALS };
-  if (absolute.totalTokens < prev.totalTokens) {
+  if (
+    absolute.totalTokens < prev.totalTokens ||
+    absolute.inputTokens < prev.inputTokens ||
+    absolute.outputTokens < prev.outputTokens ||
+    absolute.totalTokens < absolute.inputTokens + absolute.outputTokens ||
+    (absolute.cachedInputTokens !== null &&
+      (absolute.cachedInputTokens > absolute.inputTokens ||
+        (prev.cachedInputTokens != null && absolute.cachedInputTokens < prev.cachedInputTokens)))
+  ) {
     return { state, accepted: false };
   }
 
+  // Partial duplicate notifications can omit cache telemetry already observed at this total.
+  if (absolute.cachedInputTokens === null && absolute.totalTokens === prev.totalTokens) {
+    absolute.cachedInputTokens = prev.cachedInputTokens ?? null;
+  }
   const nextByThread = {
     ...state.byThread,
     [event.threadId]: absolute,

--- a/packages/agentplane/src/runner/adapters/codex-result-transport.test.ts
+++ b/packages/agentplane/src/runner/adapters/codex-result-transport.test.ts
@@ -180,6 +180,37 @@ describe("Codex supervisor semantic result transport", () => {
     });
   });
 
+  it("retains optional cache telemetry without charging cached input twice", () => {
+    const collector = createCodexResultEventCollector();
+    const event = {
+      type: "turn.completed",
+      usage: {
+        input_tokens: 100,
+        cached_input_tokens: 70,
+        output_tokens: 20,
+        reasoning_output_tokens: 0,
+      },
+    };
+    collector.observeStdoutLine(JSON.stringify(event));
+    expect(collector.readUsage()).toMatchObject({ cached_input_tokens: 70, total_tokens: 120 });
+  });
+
+  it("rejects cache counts exceeding observed input", () => {
+    const collector = createCodexResultEventCollector();
+    collector.observeStdoutLine(
+      JSON.stringify({
+        type: "turn.completed",
+        usage: {
+          input_tokens: 10,
+          cached_input_tokens: 11,
+          output_tokens: 0,
+          reasoning_output_tokens: 0,
+        },
+      }),
+    );
+    expect(() => collector.readUsage()).toThrow(/malformed cached input/u);
+  });
+
   it("rejects malformed completed-turn usage instead of recording zero", () => {
     const collector = createCodexResultEventCollector();
     collector.observeStdoutLine(

--- a/packages/agentplane/src/runner/adapters/codex-result-transport.ts
+++ b/packages/agentplane/src/runner/adapters/codex-result-transport.ts
@@ -243,6 +243,8 @@ export type CodexProviderUsage = {
   /** Budget-charged output, including reasoning tokens. */
   output_tokens: number;
   total_tokens: number;
+  cached_input_tokens?: number;
+  prepared_context_bytes?: number;
   visible_output_tokens?: number;
   reasoning_tokens?: number;
 };
@@ -279,6 +281,13 @@ function readCodexProviderUsage(providerEvent: Record<string, unknown>): CodexPr
   if (input === null || output === null || reasoning === null) {
     throw new Error("Codex turn completion contains malformed provider usage.");
   }
+  const cached =
+    providerEvent.usage.cached_input_tokens === undefined
+      ? undefined
+      : nonNegativeInteger(providerEvent.usage.cached_input_tokens);
+  if (cached === null || (cached !== undefined && cached > input)) {
+    throw new Error("Codex turn completion contains malformed cached input usage.");
+  }
   const chargedOutput = output + reasoning;
   const minimumTotal = input + chargedOutput;
   const reportedTotal =
@@ -292,6 +301,7 @@ function readCodexProviderUsage(providerEvent: Record<string, unknown>): CodexPr
     throw new Error("Codex turn completion total token usage is lower than its components.");
   }
   return {
+    ...(cached === undefined ? {} : { cached_input_tokens: cached }),
     input_tokens: input,
     output_tokens: chargedOutput,
     total_tokens: reportedTotal ?? minimumTotal,

--- a/packages/agentplane/src/runner/adapters/codex.test.ts
+++ b/packages/agentplane/src/runner/adapters/codex.test.ts
@@ -290,13 +290,14 @@ describe("CodexRunnerAdapter", () => {
     expect(result.stdout_summary).not.toMatch(CYRILLIC_RE);
     expect(result.metrics?.stdout_bytes).toBeGreaterThan(0);
     expect(result.metrics?.duration_ms).toBeGreaterThanOrEqual(0);
-    expect(readCodexProviderUsageForResult(result)).toEqual({
+    expect(readCodexProviderUsageForResult(result)).toMatchObject({
       input_tokens: 100,
       output_tokens: 50,
       total_tokens: 150,
       visible_output_tokens: 30,
       reasoning_tokens: 20,
     });
+    expect(readCodexProviderUsageForResult(result)?.prepared_context_bytes).toBeGreaterThan(0);
     const state = JSON.parse(await readFile(invocation.state_path, "utf8")) as {
       status: string;
       prepared_metadata?: { bundle_bytes: number; bundle_sha256: string };

--- a/packages/agentplane/src/runner/adapters/codex.ts
+++ b/packages/agentplane/src/runner/adapters/codex.ts
@@ -33,6 +33,7 @@ import {
   materializeCodexResultTransport,
   recordCodexProviderUsageForResult,
   renderCodexResultOutputSchemaJson,
+  type CodexProviderUsage,
 } from "./codex-result-transport.js";
 import { readValidatedPreparedRunnerStdin } from "./prepared-input.js";
 
@@ -52,7 +53,7 @@ function readOptionalCodexAgentMessage(
 
 function readOptionalCodexUsage(
   collector: ReturnType<typeof createCodexResultEventCollector>,
-): { input_tokens: number; output_tokens: number; total_tokens: number } | null {
+): CodexProviderUsage | null {
   try {
     return collector.readUsage();
   } catch {
@@ -161,12 +162,13 @@ export class CodexRunnerAdapter implements RunnerAdapter {
   async execute(invocation: RunnerInvocation): Promise<RunnerResult> {
     const executionInvocation = structuredClone(invocation);
     const resultEventCollector = createCodexResultEventCollector();
+    let preparedContextBytes: number | undefined;
     const result = await executeSupervisedRunnerAdapter({
       invocation: executionInvocation,
       assertInvocation: assertCodexInvocation,
       observeStdoutLine: (rawLine) => resultEventCollector.observeStdoutLine(rawLine),
-      readStdinText: async (input) =>
-        await readValidatedPreparedRunnerStdin({
+      readStdinText: async (input) => {
+        const stdin = await readValidatedPreparedRunnerStdin({
           invocation: input,
           require_bootstrap: true,
           optional_inputs: input.output_schema_path
@@ -178,7 +180,10 @@ export class CodexRunnerAdapter implements RunnerAdapter {
                 },
               ]
             : [],
-        }),
+        });
+        preparedContextBytes = Buffer.byteLength(stdin, "utf8");
+        return stdin;
+      },
       materializeResult: async ({ invocation: input, processResult }) => {
         if (
           processResult.exit_code !== 0 ||
@@ -284,7 +289,13 @@ export class CodexRunnerAdapter implements RunnerAdapter {
       },
     });
     const providerUsage = readOptionalCodexUsage(resultEventCollector);
-    if (providerUsage) recordCodexProviderUsageForResult(result, providerUsage);
+    if (providerUsage)
+      recordCodexProviderUsageForResult(result, {
+        ...providerUsage,
+        ...(preparedContextBytes === undefined
+          ? {}
+          : { prepared_context_bytes: preparedContextBytes }),
+      });
     return result;
   }
 }

--- a/packages/agentplane/src/runner/adapters/prepared-input.ts
+++ b/packages/agentplane/src/runner/adapters/prepared-input.ts
@@ -1,10 +1,9 @@
 import { resolveWorkOrderContextBlocks } from "../context/work-order-context.js";
-import type { RunnerContextBundle } from "../types.js";
+import type { RunnerContextBundle, RunnerInvocation } from "../types.js";
 import { createHash } from "node:crypto";
 
 import { createRunnerInvocationSnapshot } from "../artifacts.js";
 import { readStableRegularFileNoFollow } from "../stable-file.js";
-import type { RunnerInvocation } from "../types.js";
 
 class RunnerPreparedInputError extends Error {
   readonly code = "RUNNER_PREPARED_INPUT";

--- a/packages/agentplane/src/runner/adapters/prepared-input.ts
+++ b/packages/agentplane/src/runner/adapters/prepared-input.ts
@@ -1,3 +1,5 @@
+import { resolveWorkOrderContextBlocks } from "../context/work-order-context.js";
+import type { RunnerContextBundle } from "../types.js";
 import { createHash } from "node:crypto";
 
 import { createRunnerInvocationSnapshot } from "../artifacts.js";
@@ -86,6 +88,16 @@ export async function readValidatedPreparedRunnerStdin(opts: {
     expected_bytes: preparedInput.bundle_bytes,
     expected_sha256: preparedInput.bundle_sha256,
   });
+
+  const parsedBundle = JSON.parse(bundle.toString("utf8")) as RunnerContextBundle;
+  if (parsedBundle.work_order) {
+    if (!parsedBundle.semantic_context)
+      throw preparedInputError("required context manifest is missing");
+    resolveWorkOrderContextBlocks({
+      order: parsedBundle.work_order,
+      manifest: parsedBundle.semantic_context,
+    });
+  }
 
   if (!opts.invocation.bootstrap_path && opts.require_bootstrap) {
     throw preparedInputError("required bootstrap_path is missing");

--- a/packages/agentplane/src/runner/artifacts.ts
+++ b/packages/agentplane/src/runner/artifacts.ts
@@ -1,3 +1,4 @@
+import { buildWorkOrderContextManifest } from "./context/work-order-context.js";
 import { localRuntimeEvidence, withPreferredRuntimePath } from "../shared/runtime-env.js";
 import { createHash } from "node:crypto";
 import { mkdir } from "node:fs/promises";
@@ -154,6 +155,11 @@ export async function writePreparedRunnerArtifacts(opts: {
 }): Promise<RunnerRunState> {
   const paths = opts.bundle.execution.artifact_paths;
   await mkdir(paths.run_dir, { recursive: true });
+  if (opts.bundle.work_order)
+    opts.bundle.semantic_context = buildWorkOrderContextManifest(
+      opts.bundle.work_order,
+      `${paths.bundle_path}#/work_order`,
+    );
   const bundleText = `${JSON.stringify(opts.bundle, null, 2)}\n`;
   const bootstrapText = opts.bootstrap_markdown
     ? ensureTrailingNewline(opts.bootstrap_markdown)

--- a/packages/agentplane/src/runner/context/task-context.test.ts
+++ b/packages/agentplane/src/runner/context/task-context.test.ts
@@ -1,3 +1,8 @@
+import { buildAgentWorkOrderV2ValidFixture } from "@agentplaneorg/core/schemas";
+import {
+  buildWorkOrderContextManifest,
+  resolveWorkOrderContextBlocks,
+} from "./work-order-context.js";
 import { mkdir, writeFile } from "node:fs/promises";
 import path from "node:path";
 import {
@@ -415,5 +420,67 @@ describe("assembleRunnerTaskContext", () => {
     expect(verificationSection).toMatchObject({ name: "Verification", required: false });
     expect(verificationSection?.text).toContain("Formal lifecycle record");
     expect(assembled.task.compaction.sections.truncated).toBe(true);
+  });
+});
+
+describe("lossless WorkOrder context selection", () => {
+  it("keeps oversized discovery manifests complete and optional history out of required loading", () => {
+    const order = buildAgentWorkOrderV2ValidFixture("context-selection");
+    order.required_inputs = Array.from({ length: 500 }, (_, index) => ({
+      id: `history-${index}`,
+      kind: "source_artifact",
+      description: "Optional full historical log",
+      path: `logs/${index}.txt`,
+      required: index === 499,
+    }));
+    const manifest = buildWorkOrderContextManifest(order, "/run/work-order.json");
+    expect(Buffer.byteLength(JSON.stringify(manifest))).toBeGreaterThan(8192);
+    expect(manifest.blocks.filter((block) => block.id.startsWith("input:"))).toHaveLength(500);
+    const selected = resolveWorkOrderContextBlocks({ order, manifest });
+    expect(selected.some((block) => block.id === "input:history-499")).toBe(true);
+    expect(selected.some((block) => block.id === "input:history-0")).toBe(false);
+    expect(
+      resolveWorkOrderContextBlocks({ order, manifest, optional_ids: ["input:history-0"] }).some(
+        (block) => block.id === "input:history-0",
+      ),
+    ).toBe(true);
+    expect(() =>
+      resolveWorkOrderContextBlocks({
+        order,
+        manifest: { ...manifest, blocks: manifest.blocks.slice(0, -1) },
+      }),
+    ).toThrow(/incomplete or stale/u);
+    expect(() =>
+      resolveWorkOrderContextBlocks({
+        order: { ...order, task: { ...order.task, objective: "Changed" } },
+        manifest,
+      }),
+    ).toThrow(/incomplete or stale/u);
+  });
+
+  it("reloads all required blocks after context loss and binds reuse to source and role", () => {
+    const order = buildAgentWorkOrderV2ValidFixture("context-restart");
+    const manifest = buildWorkOrderContextManifest(order, "/run/work-order.json");
+    const initial = resolveWorkOrderContextBlocks({ order, manifest });
+    const retained = {
+      source_digest: manifest.source_digest,
+      blocks: new Map(initial.map((block) => [block.id, block.digest])),
+    };
+    expect(resolveWorkOrderContextBlocks({ order, manifest, retained })).toEqual([]);
+    expect(resolveWorkOrderContextBlocks({ order, manifest })).toEqual(initial);
+    const evaluator = {
+      ...order,
+      role: "EVALUATOR" as const,
+      prepared_evidence: order.prepared_evidence.map((evidence) => ({
+        ...evidence,
+        role: "EVALUATOR" as const,
+      })),
+    };
+    const evaluationManifest = buildWorkOrderContextManifest(evaluator, "/run/work-order.json");
+    expect(evaluationManifest.source_digest).not.toBe(manifest.source_digest);
+    expect(
+      resolveWorkOrderContextBlocks({ order: evaluator, manifest: evaluationManifest, retained })
+        .length,
+    ).toBeGreaterThan(0);
   });
 });

--- a/packages/agentplane/src/runner/context/work-order-context.ts
+++ b/packages/agentplane/src/runner/context/work-order-context.ts
@@ -60,27 +60,24 @@ export function buildWorkOrderContextManifest(
     order.state_fingerprint_policy,
   );
   add("planning", "planning_context", "/planning_context", order.planning_context);
-  order.required_inputs.forEach((input, index) =>
-    add(`input:${input.id}`, input.kind, `/required_inputs/${index}`, input, input.required),
-  );
-  order.knowledge_refs.forEach((input, index) =>
+  for (const [index, input] of order.required_inputs.entries())
+    add(`input:${input.id}`, input.kind, `/required_inputs/${index}`, input, input.required);
+  for (const [index, input] of order.knowledge_refs.entries())
     add(
       `knowledge:${index}`,
       "knowledge_ref",
       `/knowledge_refs/${index}`,
       input,
       order.context_intent.required_knowledge_ref_digests.includes(input.digest),
-    ),
-  );
-  order.prepared_evidence.forEach((input, index) =>
+    );
+  for (const [index, input] of order.prepared_evidence.entries())
     add(
       `evidence:${index}`,
       "prepared_evidence",
       `/prepared_evidence/${index}`,
       input,
       input.role === order.role,
-    ),
-  );
+    );
   return {
     schema_version: 1,
     kind: "agentplane.work_order_context",
@@ -107,20 +104,18 @@ export function resolveWorkOrderContextBlocks(opts: {
   const expected = buildWorkOrderContextManifest(opts.order, opts.manifest.source_ref);
   if (digest(expected) !== digest(opts.manifest))
     throw new Error("WorkOrder context manifest is incomplete or stale");
-  const requested = new Set(opts.optional_ids ?? []);
+  const requested = new Set(opts.optional_ids);
   if ([...requested].some((id) => !expected.blocks.some((block) => block.id === id)))
     throw new Error("Requested context block is not in the complete manifest");
   return expected.blocks
     .filter((block) => block.required || requested.has(block.id))
     .flatMap((block) => {
-      const content = block.pointer
-        .split("/")
-        .slice(1)
-        .reduce<unknown>((value, key) => {
-          if (!value || typeof value !== "object" || !Object.hasOwn(value, key))
-            throw new Error(`Required context block missing: ${block.id}`);
-          return (value as Record<string, unknown>)[key];
-        }, opts.order);
+      let content: unknown = opts.order;
+      for (const key of block.pointer.split("/").slice(1)) {
+        if (!content || typeof content !== "object" || !Object.hasOwn(content, key))
+          throw new Error(`Required context block missing: ${block.id}`);
+        content = (content as Record<string, unknown>)[key];
+      }
       if (digest(content) !== block.digest)
         throw new Error(`Required context block changed: ${block.id}`);
       if (

--- a/packages/agentplane/src/runner/context/work-order-context.ts
+++ b/packages/agentplane/src/runner/context/work-order-context.ts
@@ -1,0 +1,133 @@
+import { createHash } from "node:crypto";
+import { canonicalizeJson } from "@agentplaneorg/core/tasks";
+import { validateAgentWorkOrderV2, type AgentWorkOrderV2 } from "@agentplaneorg/core/schemas";
+
+export const WORK_ORDER_CONTEXT_FILENAME = "work-order-context.json";
+const serialize = (value: unknown) => JSON.stringify(canonicalizeJson(value));
+const digest = (value: unknown) =>
+  `sha256:${createHash("sha256").update(serialize(value)).digest("hex")}`;
+
+export type WorkOrderContextManifest = {
+  schema_version: 1;
+  kind: "agentplane.work_order_context";
+  work_order_id: string;
+  role: AgentWorkOrderV2["role"];
+  work_item_id: string | null;
+  source_ref: string;
+  source_digest: string;
+  blocks: {
+    id: string;
+    type: string;
+    pointer: string;
+    ref: string;
+    digest: string;
+    bytes: number;
+    required: boolean;
+  }[];
+};
+
+/** References select exact values from the existing WorkOrder. No second content store is created. */
+export function buildWorkOrderContextManifest(
+  order: AgentWorkOrderV2,
+  sourceRef: string,
+): WorkOrderContextManifest {
+  order = validateAgentWorkOrderV2(order);
+  const blocks: WorkOrderContextManifest["blocks"] = [];
+  const add = (id: string, type: string, pointer: string, value: unknown, required = true) => {
+    if (value === undefined) return;
+    blocks.push({
+      id,
+      type,
+      pointer,
+      ref: `${sourceRef}${sourceRef.includes("#") ? "" : "#"}${pointer}`,
+      digest: digest(value),
+      bytes: Buffer.byteLength(serialize(value)),
+      required,
+    });
+  };
+  add("objective", "objective_and_acceptance", "/task", order.task);
+  add("authority", "authority_and_scope", "/authority", order.authority);
+  add("constraints", "context_constraints", "/context_intent", order.context_intent);
+  add("stops", "stop_rules", "/stop_rules", order.stop_rules);
+  add("verification", "verification_contract", "/verification_intent", order.verification_intent);
+  add("outputs", "output_contract", "/required_outputs", order.required_outputs);
+  add("binding", "canonical_binding", "/canonical_binding", order.canonical_binding);
+  add("fingerprint", "state_fingerprint", "/state_fingerprint", order.state_fingerprint);
+  add(
+    "fingerprint-policy",
+    "state_fingerprint_policy",
+    "/state_fingerprint_policy",
+    order.state_fingerprint_policy,
+  );
+  add("planning", "planning_context", "/planning_context", order.planning_context);
+  order.required_inputs.forEach((input, index) =>
+    add(`input:${input.id}`, input.kind, `/required_inputs/${index}`, input, input.required),
+  );
+  order.knowledge_refs.forEach((input, index) =>
+    add(
+      `knowledge:${index}`,
+      "knowledge_ref",
+      `/knowledge_refs/${index}`,
+      input,
+      order.context_intent.required_knowledge_ref_digests.includes(input.digest),
+    ),
+  );
+  order.prepared_evidence.forEach((input, index) =>
+    add(
+      `evidence:${index}`,
+      "prepared_evidence",
+      `/prepared_evidence/${index}`,
+      input,
+      input.role === order.role,
+    ),
+  );
+  return {
+    schema_version: 1,
+    kind: "agentplane.work_order_context",
+    work_order_id: order.work_order_id,
+    role: order.role,
+    work_item_id: order.task.work_item_id ?? null,
+    source_ref: sourceRef,
+    source_digest: digest(order),
+    blocks,
+  };
+}
+
+export function workOrderContextManifestDigest(manifest: WorkOrderContextManifest): string {
+  return digest(manifest);
+}
+
+/** Retention is explicit process-local knowledge. A fresh process supplies no retained block set. */
+export function resolveWorkOrderContextBlocks(opts: {
+  order: AgentWorkOrderV2;
+  manifest: WorkOrderContextManifest;
+  optional_ids?: readonly string[];
+  retained?: { source_digest: string; blocks: ReadonlyMap<string, string> };
+}) {
+  const expected = buildWorkOrderContextManifest(opts.order, opts.manifest.source_ref);
+  if (digest(expected) !== digest(opts.manifest))
+    throw new Error("WorkOrder context manifest is incomplete or stale");
+  const requested = new Set(opts.optional_ids ?? []);
+  if ([...requested].some((id) => !expected.blocks.some((block) => block.id === id)))
+    throw new Error("Requested context block is not in the complete manifest");
+  return expected.blocks
+    .filter((block) => block.required || requested.has(block.id))
+    .flatMap((block) => {
+      const content = block.pointer
+        .split("/")
+        .slice(1)
+        .reduce<unknown>((value, key) => {
+          if (!value || typeof value !== "object" || !Object.hasOwn(value, key))
+            throw new Error(`Required context block missing: ${block.id}`);
+          return (value as Record<string, unknown>)[key];
+        }, opts.order);
+      if (digest(content) !== block.digest)
+        throw new Error(`Required context block changed: ${block.id}`);
+      if (
+        opts.retained?.source_digest === expected.source_digest &&
+        opts.retained.blocks.get(block.id) === block.digest
+      )
+        return [];
+      return [{ ...block, content }];
+    });
+}

--- a/packages/agentplane/src/runner/observation/git-snapshot.test.ts
+++ b/packages/agentplane/src/runner/observation/git-snapshot.test.ts
@@ -1,8 +1,9 @@
-import { chmod, mkdir, mkdtemp, rm, symlink, unlink, writeFile } from "node:fs/promises";
+import { chmod, mkdir, mkdtemp, realpath, rm, symlink, unlink, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import * as snapshots from "./git-snapshot.js";
 
 import { gitEnv } from "@agentplaneorg/core/git";
 import { execFileAsync } from "@agentplaneorg/core/process";
@@ -21,6 +22,7 @@ import { observeKernelRepository, kernelRepositoryChangedPaths } from "./kernel-
 const tempRoots: string[] = [];
 
 afterEach(async () => {
+  vi.restoreAllMocks();
   await Promise.all(tempRoots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
 });
 
@@ -319,6 +321,189 @@ describe("canonical implementation identity", () => {
       repository_identity: identity,
       operational_paths: [".agentplane/tasks", ".agentplane/tasks.json"],
     });
+
+  async function addSubmodule(root: string, source: string, name = "module"): Promise<string> {
+    await git(root, ["-c", "protocol.file.allow=always", "submodule", "add", "-q", source, name]);
+    await git(root, ["commit", "-qm", "add submodule"]);
+    return path.join(root, name);
+  }
+
+  it("separates expected gitlink identity from actual clean HEAD", async () => {
+    const source = await createRepository();
+    const root = await createRepository();
+    const module = await addSubmodule(root, source);
+    const expected = await git(module, ["rev-parse", "HEAD"]);
+    const clean = await observe(root);
+    expect(clean.files.find((file) => file.path === "module")).toMatchObject({
+      kind: "submodule",
+      expected_gitlink_sha: expected,
+      actual_head_sha: expected,
+      initialized: true,
+      tracked_dirty: false,
+      untracked_dirty: false,
+    });
+    expect((await observe(root)).fingerprint).toBe(clean.fingerprint);
+    await git(module, [
+      "-c",
+      "user.name=AgentPlane",
+      "-c",
+      "user.email=agentplane@example.com",
+      "commit",
+      "--allow-empty",
+      "-qm",
+      "different HEAD",
+    ]);
+    const different = await observe(root);
+    expect(different.files.find((file) => file.path === "module")).toMatchObject({
+      expected_gitlink_sha: expected,
+      actual_head_sha: await git(module, ["rev-parse", "HEAD"]),
+      tracked_dirty: false,
+      untracked_dirty: false,
+    });
+    expect(kernelRepositoryChangedPaths(clean, different)).toEqual(["module"]);
+    await git(root, ["add", "module"]);
+    const staged = await observe(root);
+    expect(staged.fingerprint).not.toBe(different.fingerprint);
+    await git(root, ["commit", "-qm", "record gitlink"]);
+    expect((await observe(root)).fingerprint).toBe(staged.fingerprint);
+  });
+
+  it("fingerprints repeated tracked, hidden and untracked submodule writes", async () => {
+    const root = await createRepository();
+    const module = await addSubmodule(root, await createRepository());
+    const clean = await observe(root);
+    await writeRepoFile(module, "tracked.txt", "dirty");
+    const dirty = await observe(root);
+    expect(dirty.files.find((file) => file.path === "module")).toMatchObject({
+      tracked_dirty: true,
+      untracked_dirty: false,
+    });
+    expect(kernelRepositoryChangedPaths(clean, dirty)).toEqual(["module"]);
+    await writeRepoFile(module, "tracked.txt", "different dirty");
+    const repeated = await observe(root);
+    expect(repeated.fingerprint).not.toBe(dirty.fingerprint);
+    await git(module, ["update-index", "--assume-unchanged", "tracked.txt"]);
+    const hidden = await observe(root);
+    await writeRepoFile(module, "tracked.txt", "hidden dirty");
+    expect((await observe(root)).fingerprint).not.toBe(hidden.fingerprint);
+    await writeRepoFile(module, "untracked.txt", "first");
+    const untracked = await observe(root);
+    expect(untracked.files.find((file) => file.path === "module")).toMatchObject({
+      untracked_dirty: true,
+    });
+    await writeRepoFile(module, "untracked.txt", "second");
+    expect((await observe(root)).fingerprint).not.toBe(untracked.fingerprint);
+  });
+
+  it("represents uninitialized submodules without claiming an observed working tree", async () => {
+    const root = await createRepository();
+    const module = await addSubmodule(root, await createRepository());
+    const initialized = await observe(root);
+    const expected = await git(module, ["rev-parse", "HEAD"]);
+    await git(root, ["submodule", "deinit", "-f", "--", "module"]);
+    const empty = await observe(root);
+    expect(empty.files.find((file) => file.path === "module")).toEqual({
+      path: "module",
+      kind: "submodule",
+      expected_gitlink_sha: expected,
+      actual_head_sha: null,
+      initialized: false,
+      tracked_dirty: null,
+      untracked_dirty: null,
+      working_state: null,
+    });
+    expect(kernelRepositoryChangedPaths(initialized, empty)).toEqual(["module"]);
+    await rm(module, { recursive: true });
+    expect((await observe(root)).fingerprint).toBe(empty.fingerprint);
+    await git(root, [
+      "-c",
+      "protocol.file.allow=always",
+      "submodule",
+      "update",
+      "--init",
+      "module",
+    ]);
+    expect((await observe(root)).fingerprint).toBe(initialized.fingerprint);
+  });
+
+  it("recursively observes nested submodule checkout and content changes", async () => {
+    const source = await createRepository();
+    await addSubmodule(source, await createRepository(), "nested");
+    const root = await createRepository();
+    const module = await addSubmodule(root, source);
+    const uninitialized = await observe(root);
+    await git(root, [
+      "-c",
+      "protocol.file.allow=always",
+      "submodule",
+      "update",
+      "--init",
+      "--recursive",
+    ]);
+    const initialized = await observe(root);
+    expect(initialized.fingerprint).not.toBe(uninitialized.fingerprint);
+    await writeRepoFile(path.join(module, "nested"), "tracked.txt", "nested change");
+    const dirty = await observe(root);
+    expect(kernelRepositoryChangedPaths(initialized, dirty)).toEqual(["module"]);
+    await writeRepoFile(path.join(module, "nested"), "tracked.txt", "another nested change");
+    expect((await observe(root)).fingerprint).not.toBe(dirty.fingerprint);
+  });
+
+  it("fails closed for populated uninitialized paths and invalid Git metadata", async () => {
+    const root = await createRepository();
+    const module = await addSubmodule(root, await createRepository());
+    await git(root, ["submodule", "deinit", "-f", "--", "module"]);
+    await writeRepoFile(module, "unknown.txt", "unobserved content");
+    await expect(observe(root)).rejects.toMatchObject({
+      reason_code: "uninitialized_submodule_has_content",
+    });
+    await writeRepoFile(module, ".git", "gitdir: missing-git-directory\n");
+    await expect(observe(root)).rejects.toThrow();
+  });
+
+  it("rejects symlink submodule checkouts and respects explicitly excluded submodules", async () => {
+    const root = await createRepository();
+    const source = await createRepository();
+    const module = await addSubmodule(root, source);
+    const excluded = await observeKernelRepository({
+      repository_root: root,
+      repository_identity: identity,
+      operational_paths: ["module"],
+    });
+    expect(excluded.files.some((file) => file.path === "module")).toBe(false);
+    await writeRepoFile(module, "tracked.txt", "excluded change");
+    expect(
+      (
+        await observeKernelRepository({
+          repository_root: root,
+          repository_identity: identity,
+          operational_paths: ["module"],
+        })
+      ).fingerprint,
+    ).toBe(excluded.fingerprint);
+    await rm(module, { recursive: true });
+    await symlink(source, module);
+    await expect(observe(root)).rejects.toThrow();
+  });
+
+  it("refuses a submodule that changes between the two complete observations", async () => {
+    const root = await createRepository();
+    const module = await addSubmodule(root, await createRepository());
+    const canonicalModule = await realpath(module);
+    const capture = snapshots.captureGitSnapshot;
+    let changed = false;
+    vi.spyOn(snapshots, "captureGitSnapshot").mockImplementation(async (input) => {
+      const snapshot = await capture(input);
+      if (!changed && input.repository_root === canonicalModule) {
+        changed = true;
+        await writeRepoFile(module, "tracked.txt", "concurrent change");
+      }
+      return snapshot;
+    });
+    await expect(observe(root)).rejects.toMatchObject({
+      reason_code: "repository_changed_during_observation",
+    });
+  });
 
   it("keeps content identity across staging, commits and native evidence writes", async () => {
     const root = await createRepository();

--- a/packages/agentplane/src/runner/observation/git-snapshot.test.ts
+++ b/packages/agentplane/src/runner/observation/git-snapshot.test.ts
@@ -313,6 +313,12 @@ describe("Git execution snapshot observation", () => {
   });
 });
 
+async function addSubmodule(root: string, source: string, name = "module"): Promise<string> {
+  await git(root, ["-c", "protocol.file.allow=always", "submodule", "add", "-q", source, name]);
+  await git(root, ["commit", "-qm", "add submodule"]);
+  return path.join(root, name);
+}
+
 describe("canonical implementation identity", () => {
   const identity = k.kernelDigest("logical-repository");
   const observe = (root: string) =>
@@ -321,12 +327,6 @@ describe("canonical implementation identity", () => {
       repository_identity: identity,
       operational_paths: [".agentplane/tasks", ".agentplane/tasks.json"],
     });
-
-  async function addSubmodule(root: string, source: string, name = "module"): Promise<string> {
-    await git(root, ["-c", "protocol.file.allow=always", "submodule", "add", "-q", source, name]);
-    await git(root, ["commit", "-qm", "add submodule"]);
-    return path.join(root, name);
-  }
 
   it("separates expected gitlink identity from actual clean HEAD", async () => {
     const source = await createRepository();
@@ -342,7 +342,7 @@ describe("canonical implementation identity", () => {
       tracked_dirty: false,
       untracked_dirty: false,
     });
-    expect((await observe(root)).fingerprint).toBe(clean.fingerprint);
+    expect(await observe(root)).toMatchObject({ fingerprint: clean.fingerprint });
     await git(module, [
       "-c",
       "user.name=AgentPlane",
@@ -365,7 +365,7 @@ describe("canonical implementation identity", () => {
     const staged = await observe(root);
     expect(staged.fingerprint).not.toBe(different.fingerprint);
     await git(root, ["commit", "-qm", "record gitlink"]);
-    expect((await observe(root)).fingerprint).toBe(staged.fingerprint);
+    expect(await observe(root)).toMatchObject({ fingerprint: staged.fingerprint });
   });
 
   it("fingerprints repeated tracked, hidden and untracked submodule writes", async () => {
@@ -385,14 +385,14 @@ describe("canonical implementation identity", () => {
     await git(module, ["update-index", "--assume-unchanged", "tracked.txt"]);
     const hidden = await observe(root);
     await writeRepoFile(module, "tracked.txt", "hidden dirty");
-    expect((await observe(root)).fingerprint).not.toBe(hidden.fingerprint);
+    expect(await observe(root)).not.toMatchObject({ fingerprint: hidden.fingerprint });
     await writeRepoFile(module, "untracked.txt", "first");
     const untracked = await observe(root);
     expect(untracked.files.find((file) => file.path === "module")).toMatchObject({
       untracked_dirty: true,
     });
     await writeRepoFile(module, "untracked.txt", "second");
-    expect((await observe(root)).fingerprint).not.toBe(untracked.fingerprint);
+    expect(await observe(root)).not.toMatchObject({ fingerprint: untracked.fingerprint });
   });
 
   it("represents uninitialized submodules without claiming an observed working tree", async () => {
@@ -414,7 +414,7 @@ describe("canonical implementation identity", () => {
     });
     expect(kernelRepositoryChangedPaths(initialized, empty)).toEqual(["module"]);
     await rm(module, { recursive: true });
-    expect((await observe(root)).fingerprint).toBe(empty.fingerprint);
+    expect(await observe(root)).toMatchObject({ fingerprint: empty.fingerprint });
     await git(root, [
       "-c",
       "protocol.file.allow=always",
@@ -423,7 +423,7 @@ describe("canonical implementation identity", () => {
       "--init",
       "module",
     ]);
-    expect((await observe(root)).fingerprint).toBe(initialized.fingerprint);
+    expect(await observe(root)).toMatchObject({ fingerprint: initialized.fingerprint });
   });
 
   it("recursively observes nested submodule checkout and content changes", async () => {
@@ -446,7 +446,7 @@ describe("canonical implementation identity", () => {
     const dirty = await observe(root);
     expect(kernelRepositoryChangedPaths(initialized, dirty)).toEqual(["module"]);
     await writeRepoFile(path.join(module, "nested"), "tracked.txt", "another nested change");
-    expect((await observe(root)).fingerprint).not.toBe(dirty.fingerprint);
+    expect(await observe(root)).not.toMatchObject({ fingerprint: dirty.fingerprint });
   });
 
   it("fails closed for populated uninitialized paths and invalid Git metadata", async () => {
@@ -473,14 +473,12 @@ describe("canonical implementation identity", () => {
     expect(excluded.files.some((file) => file.path === "module")).toBe(false);
     await writeRepoFile(module, "tracked.txt", "excluded change");
     expect(
-      (
-        await observeKernelRepository({
-          repository_root: root,
-          repository_identity: identity,
-          operational_paths: ["module"],
-        })
-      ).fingerprint,
-    ).toBe(excluded.fingerprint);
+      await observeKernelRepository({
+        repository_root: root,
+        repository_identity: identity,
+        operational_paths: ["module"],
+      }),
+    ).toMatchObject({ fingerprint: excluded.fingerprint });
     await rm(module, { recursive: true });
     await symlink(source, module);
     await expect(observe(root)).rejects.toThrow();

--- a/packages/agentplane/src/runner/observation/kernel-repository.ts
+++ b/packages/agentplane/src/runner/observation/kernel-repository.ts
@@ -77,7 +77,8 @@ async function observeSubmodule(
     throw error;
   });
   if (marker === null) {
-    if ((await readdir(root)).length === 0) return uninitialized();
+    const entries = await readdir(root);
+    if (entries.length === 0) return uninitialized();
     unavailable("uninitialized_submodule_has_content");
   }
   if (!marker.isFile() && !marker.isDirectory()) unavailable("invalid_submodule_git_directory");

--- a/packages/agentplane/src/runner/observation/kernel-repository.ts
+++ b/packages/agentplane/src/runner/observation/kernel-repository.ts
@@ -1,17 +1,34 @@
-import { compareText } from "./git-snapshot/common.js";
+import { lstat, readdir, realpath } from "node:fs/promises";
+import path from "node:path";
+import { compareText, repositoryPath } from "./git-snapshot/common.js";
 import { taskKernel as k } from "@agentplaneorg/core/tasks";
 import { captureGitSnapshot, type GitSnapshot } from "./git-snapshot.js";
+import type { GitIndexEntry, GitPathFingerprint } from "./git-snapshot/model.js";
+
+type KernelSubmoduleObservation = Readonly<{
+  path: string;
+  kind: "submodule";
+  expected_gitlink_sha: string;
+  actual_head_sha: string | null;
+  initialized: boolean;
+  tracked_dirty: boolean | null;
+  untracked_dirty: boolean | null;
+  working_state: KernelRepositoryObservation | null;
+}>;
 
 export type KernelRepositoryObservation = Readonly<{
   schema_version: 1;
   repository_identity: k.Sha256Digest;
   excluded_paths: readonly string[];
-  files: readonly Readonly<{
-    path: string;
-    kind: "file" | "symlink";
-    executable: boolean;
-    content_digest: k.Sha256Digest;
-  }>[];
+  files: readonly (
+    | Readonly<{
+        path: string;
+        kind: "file" | "symlink";
+        executable: boolean;
+        content_digest: k.Sha256Digest;
+      }>
+    | KernelSubmoduleObservation
+  )[];
   fingerprint: k.Sha256Digest;
 }>;
 
@@ -22,44 +39,117 @@ function unavailable(reason: string): never {
   });
 }
 
-/** Content identity excludes native operational paths, never HEAD or index lifecycle state. */
-function projectKernelRepository(
+async function observeSubmodule(
+  snapshot: GitSnapshot,
+  gitlink: GitIndexEntry,
+  entry: GitPathFingerprint,
+  repositoryIdentity: k.Sha256Digest,
+  ancestors: ReadonlySet<string>,
+): Promise<KernelSubmoduleObservation> {
+  const base = {
+    path: gitlink.path,
+    kind: "submodule" as const,
+    expected_gitlink_sha: gitlink.object_id,
+  };
+  const uninitialized = (): KernelSubmoduleObservation => ({
+    ...base,
+    actual_head_sha: null,
+    initialized: false,
+    tracked_dirty: null,
+    untracked_dirty: null,
+    working_state: null,
+  });
+  if (entry.kind === "missing") return uninitialized();
+  if (entry.kind !== "directory" || entry.error) unavailable("invalid_submodule_checkout");
+  const root = repositoryPath(snapshot.repository_root, gitlink.path);
+  const canonicalRoot = await realpath(root);
+  const relativeRoot = path.relative(await realpath(snapshot.repository_root), canonicalRoot);
+  if (
+    !relativeRoot ||
+    relativeRoot === ".." ||
+    relativeRoot.startsWith(`..${path.sep}`) ||
+    path.isAbsolute(relativeRoot)
+  )
+    unavailable("submodule_checkout_escapes_repository");
+  if (ancestors.has(canonicalRoot)) unavailable("recursive_submodule_checkout");
+  const marker = await lstat(path.join(root, ".git")).catch((error: unknown) => {
+    if ((error as NodeJS.ErrnoException)?.code === "ENOENT") return null;
+    throw error;
+  });
+  if (marker === null) {
+    if ((await readdir(root)).length === 0) return uninitialized();
+    unavailable("uninitialized_submodule_has_content");
+  }
+  if (!marker.isFile() && !marker.isDirectory()) unavailable("invalid_submodule_git_directory");
+  const prefix = `${gitlink.path}/`;
+  const child = await captureGitSnapshot({
+    repository_root: canonicalRoot,
+    excluded_roots: snapshot.excluded_paths
+      .filter((excluded) => excluded.startsWith(prefix))
+      .map((excluded) => excluded.slice(prefix.length)),
+    fingerprint_tracked_paths: true,
+  });
+  const workingState = await projectKernelRepository(
+    child,
+    repositoryIdentity,
+    new Set([...ancestors, canonicalRoot]),
+  );
+  if (!child.head_commit) unavailable("submodule_head_unavailable");
+  return {
+    ...base,
+    actual_head_sha: child.head_commit,
+    initialized: true,
+    tracked_dirty: child.status_entries.some((status) => status.index_status !== "?"),
+    untracked_dirty: child.status_entries.some((status) => status.index_status === "?"),
+    working_state: workingState,
+  };
+}
+
+/** Native lifecycle commits do not change file identity. A gitlink also binds its checkout HEAD. */
+async function projectKernelRepository(
   snapshot: GitSnapshot,
   repositoryIdentity: k.Sha256Digest,
-): KernelRepositoryObservation {
+  ancestors: ReadonlySet<string>,
+): Promise<KernelRepositoryObservation> {
   if (snapshot.state !== "available" || snapshot.errors.length > 0)
     unavailable("git_observation_failed");
   if (snapshot.index_entries.some((entry) => entry.stage !== 0)) unavailable("unmerged_index");
-  // A gitlink alone cannot prove its checkout contents. Fail closed until observed by a submodule adapter.
-  if (snapshot.index_entries.some((entry) => entry.mode === "160000"))
-    unavailable("submodule_observation_required");
+  const gitlinks = new Map(
+    snapshot.index_entries
+      .filter((entry) => entry.mode === "160000")
+      .map((entry) => [entry.path, entry]),
+  );
   const observed = new Set(snapshot.path_fingerprints.map((entry) => entry.path));
   if (snapshot.index_entries.some((entry) => !observed.has(entry.path)))
     unavailable("tracked_content_not_observed");
-  const files = snapshot.path_fingerprints
-    .filter((entry) => entry.kind !== "missing")
-    .map((entry) => {
-      if (
-        (entry.kind !== "file" && entry.kind !== "symlink") ||
-        !entry.sha256 ||
-        !/^sha256:[0-9a-f]{64}$/u.test(entry.sha256) ||
-        entry.mode === null ||
-        entry.error
-      )
-        unavailable("unsupported_path_observation");
-      return {
-        path: entry.path,
-        kind: entry.kind,
-        executable: entry.kind === "file" && (entry.mode & 0o111) !== 0,
-        content_digest: entry.sha256 as k.Sha256Digest,
-      };
-    })
-    .toSorted((a, b) => compareText(a.path, b.path));
+  const files: KernelRepositoryObservation["files"][number][] = [];
+  for (const entry of snapshot.path_fingerprints) {
+    const gitlink = gitlinks.get(entry.path);
+    if (gitlink) {
+      files.push(await observeSubmodule(snapshot, gitlink, entry, repositoryIdentity, ancestors));
+      continue;
+    }
+    if (entry.kind === "missing") continue;
+    if (
+      (entry.kind !== "file" && entry.kind !== "symlink") ||
+      !entry.sha256 ||
+      !/^sha256:[0-9a-f]{64}$/u.test(entry.sha256) ||
+      entry.mode === null ||
+      entry.error
+    )
+      unavailable("unsupported_path_observation");
+    files.push({
+      path: entry.path,
+      kind: entry.kind,
+      executable: entry.kind === "file" && (entry.mode & 0o111) !== 0,
+      content_digest: entry.sha256 as k.Sha256Digest,
+    });
+  }
   const contents = {
     schema_version: 1 as const,
     repository_identity: repositoryIdentity,
     excluded_paths: snapshot.excluded_paths.toSorted(),
-    files,
+    files: files.toSorted((a, b) => compareText(a.path, b.path)),
   };
   return { ...contents, fingerprint: k.kernelDigest(contents) };
 }
@@ -78,6 +168,7 @@ export async function observeKernelRepository(opts: {
         fingerprint_tracked_paths: true,
       }),
       opts.repository_identity,
+      new Set([await realpath(opts.repository_root)]),
     );
   const before = await capture();
   const after = await capture();

--- a/packages/agentplane/src/runner/phase-tools/dispatch.test.ts
+++ b/packages/agentplane/src/runner/phase-tools/dispatch.test.ts
@@ -71,11 +71,15 @@ async function preparePhaseToolRun(
   });
   if (!grant) throw new Error("Expected a phase-tool grant.");
   bundle.execution.phase_tools = grant.manifest;
-  opts.mutate_after_grant?.(bundle);
   await writePreparedRunnerArtifacts({
     bundle,
     created_at: ISSUED_AT.toISOString(),
   });
+  if (opts.mutate_after_grant) {
+    // Simulate persisted artifact tampering after the validated preparation boundary.
+    opts.mutate_after_grant(bundle);
+    await writeFile(bundle.execution.artifact_paths.bundle_path, JSON.stringify(bundle));
+  }
   return { root, run_dir: runDir, bundle, grant };
 }
 

--- a/packages/agentplane/src/runner/types/context.ts
+++ b/packages/agentplane/src/runner/types/context.ts
@@ -1,3 +1,4 @@
+import type { WorkOrderContextManifest } from "../context/work-order-context.js";
 import type {
   EvaluatorSkepticismLevel,
   RunnerTraceConfig,
@@ -203,6 +204,7 @@ export type RunnerContextBundle = {
   playbook?: RunnerExecutionPlaybookContract;
   /** Canonical V2 work order for the semantic episode; optional for v1 bundles. */
   work_order?: AgentWorkOrderV2;
+  semantic_context?: WorkOrderContextManifest;
   /** Canonical V2 preparation projection paired with `work_order`; optional for v1 bundles. */
   work_order_preparation?: AgentWorkOrderPreparationView;
   /** Internal typed route source retained for runner state-fingerprint observation. */

--- a/packages/agentplane/src/runner/usecases/kernel-authority.test.ts
+++ b/packages/agentplane/src/runner/usecases/kernel-authority.test.ts
@@ -192,6 +192,8 @@ async function fixture(
   };
 }
 
+const effects = (path: string) => (path.startsWith("schemas/") ? ["schema"] : ["source_code"]);
+
 describe("canonical native authority", () => {
   it.each(["manual_operator", "signed_user_receipt", "host_user_decision"] as const)(
     "persists exact %s approval and delegates without USER provenance",
@@ -378,7 +380,6 @@ describe("canonical native authority", () => {
       evidence_digest: k.kernelDigest("schema-observation"),
       changed_paths: ["schemas/generated.json", "src/implementation.ts"],
     });
-    const effects = (path: string) => (path.startsWith("schemas/") ? ["schema"] : ["source_code"]);
     const prepared = await f.resolver.prepareDelta(f.taskId, effects);
     expect(prepared.request).toMatchObject({
       parent_authority_digest: parent.digest,

--- a/packages/agentplane/src/runner/usecases/kernel-authority.test.ts
+++ b/packages/agentplane/src/runner/usecases/kernel-authority.test.ts
@@ -364,6 +364,95 @@ describe("canonical native authority", () => {
     expect(read.record.aggregate.authority_lineage).toHaveLength(2);
   });
 
+  it("admits only an exact native USER-approved authority delta", async () => {
+    const f = await fixture();
+    await f.resolver.approve(f.taskId);
+    const afterPlanApproval = await f.adapter.read(f.taskId);
+    if (afterPlanApproval.kind !== "canonical") throw new Error(afterPlanApproval.kind);
+    const approvedPlan = afterPlanApproval.record.aggregate.current_plan;
+    const { authority: parent } = await f.resolver.resolve(f.taskId);
+    f.values.repository_fingerprint = k.kernelDigest("schema-sync");
+    f.setObservation({
+      kind: "repository_implementation",
+      previous_fingerprint: parent.repository_fingerprint,
+      evidence_digest: k.kernelDigest("schema-observation"),
+      changed_paths: ["schemas/generated.json", "src/implementation.ts"],
+    });
+    const effects = (path: string) => (path.startsWith("schemas/") ? ["schema"] : ["source_code"]);
+    const prepared = await f.resolver.prepareDelta(f.taskId, effects);
+    expect(prepared.request).toMatchObject({
+      parent_authority_digest: parent.digest,
+      added_scope_roots: ["schemas/generated.json"],
+      added_repository_effects: ["schema"],
+    });
+    f.setApproval({
+      kind: "manual_operator",
+      actor_id: "USER",
+      invocation_id: prepared.request_digest,
+    });
+    await expect(
+      f.resolver.approveDelta({
+        task_id: f.taskId,
+        scope_roots: ["schemas"],
+        repository_effects: ["schema"],
+        request_digest: prepared.request_digest,
+        repositoryEffects: effects,
+      }),
+    ).rejects.toThrow("authority_delta_request_mismatch");
+    await expect(
+      f.resolver.approveDelta({
+        task_id: f.taskId,
+        scope_roots: prepared.request.added_scope_roots,
+        repository_effects: prepared.request.added_repository_effects,
+        request_digest: k.kernelDigest("stale"),
+        repositoryEffects: effects,
+      }),
+    ).rejects.toThrow("authority_delta_request_mismatch");
+    expect(
+      await f.resolver.approveDelta({
+        task_id: f.taskId,
+        scope_roots: prepared.request.added_scope_roots,
+        repository_effects: prepared.request.added_repository_effects,
+        request_digest: prepared.request_digest,
+        repositoryEffects: effects,
+      }),
+    ).toMatchObject({ kind: "committed" });
+    const read = await f.adapter.read(f.taskId);
+    if (read.kind !== "canonical") throw new Error(read.kind);
+    expect(k.canonicalAuthorityIssues(read.record.aggregate)).toEqual([]);
+    expect(read.record.aggregate.current_plan).toEqual(approvedPlan);
+    expect(read.record.aggregate.work_items).toEqual({});
+    await expect(f.resolver.resolve(f.taskId)).resolves.toMatchObject({
+      authority: { repository_fingerprint: f.values.repository_fingerprint },
+    });
+    expect(read.record.aggregate.authority_lineage?.at(-1)).toMatchObject({
+      approval_mode: "manual_operator",
+      observation: {
+        kind: "authority_delta",
+        request_digest: prepared.request_digest,
+        added_scope_roots: ["schemas/generated.json"],
+      },
+      authority: {
+        scope_roots: ["schemas/generated.json", "src"],
+        repository_effects: ["repository_write", "schema"],
+        provenance: {
+          kind: "USER",
+          parent_authority_digest: parent.digest,
+          evidence_digest: parent.provenance.evidence_digest,
+        },
+      },
+    });
+    await expect(
+      f.resolver.approveDelta({
+        task_id: f.taskId,
+        scope_roots: prepared.request.added_scope_roots,
+        repository_effects: prepared.request.added_repository_effects,
+        request_digest: prepared.request_digest,
+        repositoryEffects: effects,
+      }),
+    ).rejects.toThrow();
+  });
+
   it("requires a new native decision for material expansion and rejects changed policy or expiry", async () => {
     const f = await fixture();
     f.values.ceiling = { ...f.values.ceiling, scope_roots: ["different"] };

--- a/packages/agentplane/src/runner/usecases/kernel-authority.ts
+++ b/packages/agentplane/src/runner/usecases/kernel-authority.ts
@@ -422,7 +422,9 @@ export class KernelAuthorityResolver {
       repository_evidence_digest: observation.evidence_digest,
       changed_paths: uniqueSorted(observation.changed_paths),
       added_scope_roots: outside,
-      added_repository_effects: uniqueSorted(outside.flatMap(repositoryEffects)),
+      added_repository_effects: uniqueSorted(
+        outside.flatMap((changed) => repositoryEffects(changed)),
+      ),
     };
     return { request, request_digest: k.kernelDigest(request) };
   }
@@ -445,7 +447,7 @@ export class KernelAuthorityResolver {
       invalid("authority_delta_request_mismatch");
     const { context, aggregate } = await this.context(opts.task_id);
     const parent = aggregate.authority_lineage?.at(-1)?.authority;
-    if (!parent || parent.digest !== prepared.request.parent_authority_digest)
+    if (parent?.digest !== prepared.request.parent_authority_digest)
       invalid("authority_delta_parent_changed");
     const approval = await this.native.readApproval(opts.task_id);
     if (

--- a/packages/agentplane/src/runner/usecases/kernel-authority.ts
+++ b/packages/agentplane/src/runner/usecases/kernel-authority.ts
@@ -52,6 +52,33 @@ export function kernelApprovalReference(context: NativeAuthorityContext, plan: k
   });
 }
 
+export type KernelAuthorityDeltaRequest = Readonly<{
+  task_id: string;
+  task_revision: number;
+  plan_revision: number;
+  plan_digest: k.Sha256Digest;
+  parent_authority_digest: k.Sha256Digest;
+  repository_identity: k.Sha256Digest;
+  previous_fingerprint: k.Sha256Digest;
+  repository_fingerprint: k.Sha256Digest;
+  repository_evidence_digest: k.Sha256Digest;
+  changed_paths: readonly string[];
+  added_scope_roots: readonly string[];
+  added_repository_effects: readonly string[];
+}>;
+
+function uniqueSorted(values: readonly string[]) {
+  return [...new Set(values)].toSorted();
+}
+
+function authorityDeltaApprovalEvidence(input: {
+  task_id: string;
+  request_digest: k.Sha256Digest;
+  actor_id: string;
+}) {
+  return k.kernelDigest({ kind: "canonical_authority_delta_approval", ...input });
+}
+
 /** One production authority resolver. Callers supply task identity, never a grant or USER claim. */
 export class KernelAuthorityResolver {
   constructor(
@@ -270,6 +297,23 @@ export class KernelAuthorityResolver {
       invalid("native_policy_changed");
   }
 
+  private assertLineageCeiling(aggregate: k.TaskAggregate, context: NativeAuthorityContext) {
+    const records = aggregate.authority_lineage ?? [];
+    const first = records[0]?.authority;
+    const latest = records.at(-1)?.authority;
+    if (!first || !latest || k.canonicalAuthorityIssues(aggregate).length > 0)
+      invalid("canonical_authority_lineage_invalid");
+    this.assertCeiling(first, context);
+    this.assertCeiling(latest, {
+      ...context,
+      ceiling: {
+        ...context.ceiling,
+        scope_roots: latest.scope_roots,
+        repository_effects: latest.repository_effects,
+      },
+    });
+  }
+
   async resolve(
     taskId: string,
     workItemId?: string,
@@ -279,7 +323,7 @@ export class KernelAuthorityResolver {
     if (!stored) invalid("canonical_authority_missing");
     const authority = kernelAuthoritySchema.parse(stored);
     assertUnexpired(authority, freshTime(context));
-    this.assertCeiling(authority, context);
+    this.assertLineageCeiling(aggregate, context);
     if (
       aggregate.current_plan?.state !== "APPROVED" ||
       authority.plan_revision !== aggregate.current_plan.revision ||
@@ -303,7 +347,7 @@ export class KernelAuthorityResolver {
     const plan = aggregate.current_plan;
     if (!parent || plan?.state !== "APPROVED") invalid("canonical_authority_missing");
     assertUnexpired(parent, freshTime(context));
-    this.assertCeiling(parent, context);
+    this.assertLineageCeiling(aggregate, context);
     const observation = await this.native.observeContinuation(taskId, parent);
     if (!observation) invalid("native_observation_required");
     const contents = {
@@ -342,5 +386,129 @@ export class KernelAuthorityResolver {
       mutation_id: context.mutation_id,
     };
     return this.adapter.execute(input);
+  }
+
+  async prepareDelta(
+    taskId: string,
+    repositoryEffects: (path: string) => readonly string[],
+  ): Promise<{ request: KernelAuthorityDeltaRequest; request_digest: k.Sha256Digest }> {
+    const { context, aggregate } = await this.context(taskId);
+    const parent = aggregate.authority_lineage?.at(-1)?.authority;
+    const plan = aggregate.current_plan;
+    if (!parent || plan?.state !== "APPROVED") invalid("canonical_authority_missing");
+    assertUnexpired(parent, freshTime(context));
+    this.assertLineageCeiling(aggregate, context);
+    const observation = await this.native.observeContinuation(taskId, parent);
+    if (observation?.kind !== "repository_implementation")
+      invalid("native_repository_observation_required");
+    const outside = uniqueSorted(
+      observation.changed_paths.filter(
+        (changed) =>
+          !parent.scope_roots.some(
+            (root) => root === "." || changed === root || changed.startsWith(`${root}/`),
+          ),
+      ),
+    );
+    if (outside.length === 0) invalid("authority_delta_not_required");
+    const request: KernelAuthorityDeltaRequest = {
+      task_id: taskId,
+      task_revision: aggregate.revision,
+      plan_revision: plan.revision,
+      plan_digest: plan.digest,
+      parent_authority_digest: parent.digest,
+      repository_identity: context.repository_identity,
+      previous_fingerprint: parent.repository_fingerprint,
+      repository_fingerprint: context.repository_fingerprint,
+      repository_evidence_digest: observation.evidence_digest,
+      changed_paths: uniqueSorted(observation.changed_paths),
+      added_scope_roots: outside,
+      added_repository_effects: uniqueSorted(outside.flatMap(repositoryEffects)),
+    };
+    return { request, request_digest: k.kernelDigest(request) };
+  }
+
+  async approveDelta(opts: {
+    task_id: string;
+    scope_roots: readonly string[];
+    repository_effects: readonly string[];
+    request_digest: k.Sha256Digest;
+    repositoryEffects: (path: string) => readonly string[];
+  }) {
+    const prepared = await this.prepareDelta(opts.task_id, opts.repositoryEffects);
+    if (
+      prepared.request_digest !== opts.request_digest ||
+      JSON.stringify(prepared.request.added_scope_roots) !==
+        JSON.stringify(uniqueSorted(opts.scope_roots)) ||
+      JSON.stringify(prepared.request.added_repository_effects) !==
+        JSON.stringify(uniqueSorted(opts.repository_effects))
+    )
+      invalid("authority_delta_request_mismatch");
+    const { context, aggregate } = await this.context(opts.task_id);
+    const parent = aggregate.authority_lineage?.at(-1)?.authority;
+    if (!parent || parent.digest !== prepared.request.parent_authority_digest)
+      invalid("authority_delta_parent_changed");
+    const approval = await this.native.readApproval(opts.task_id);
+    if (
+      approval?.kind !== "manual_operator" ||
+      !approval.invocation_id ||
+      !/^USER(?::[A-Za-z0-9._@-]+)?$/u.test(approval.actor_id)
+    )
+      invalid("explicit_manual_operator_required");
+    if (approval.invocation_id !== prepared.request_digest)
+      invalid("authority_delta_approval_binding");
+    const approvalEvidence = authorityDeltaApprovalEvidence({
+      task_id: opts.task_id,
+      request_digest: prepared.request_digest,
+      actor_id: approval.actor_id,
+    });
+    const scopeRoots = uniqueSorted([...parent.scope_roots, ...prepared.request.added_scope_roots]);
+    const repositoryEffects = uniqueSorted([
+      ...parent.repository_effects,
+      ...prepared.request.added_repository_effects,
+    ]);
+    const contents = {
+      ...parent,
+      repository_fingerprint: context.repository_fingerprint,
+      scope_roots: scopeRoots,
+      repository_effects: repositoryEffects,
+      provenance: {
+        kind: "USER" as const,
+        actor_id: approval.actor_id,
+        evidence_digest: parent.provenance.evidence_digest,
+        parent_authority_digest: parent.digest,
+      },
+    };
+    const record = kernelAuthorityRecordSchema.parse({
+      authority: { ...contents, digest: k.authorityDigest(contents) },
+      approval_mode: approval.kind,
+      observation: {
+        kind: "authority_delta",
+        evidence_digest: approvalEvidence,
+        previous_fingerprint: parent.repository_fingerprint,
+        changed_paths: prepared.request.changed_paths,
+        request_digest: prepared.request_digest,
+        added_scope_roots: prepared.request.added_scope_roots,
+        added_repository_effects: prepared.request.added_repository_effects,
+        request_task_revision: prepared.request.task_revision,
+        repository_evidence_digest: prepared.request.repository_evidence_digest,
+      },
+    });
+    await this.assertFresh(context, parent.expires_at);
+    return this.adapter.execute({
+      command: {
+        kind: "approve_authority_delta",
+        task_id: opts.task_id,
+        expected_task_revision: aggregate.revision,
+        expected_state_fingerprint: context.repository_fingerprint,
+        parent_authority_digest: parent.digest,
+        request_digest: prepared.request_digest,
+        record,
+      },
+      actor: { ...context.actor, id: approval.actor_id, kind: "USER" },
+      authority: null,
+      repository_fingerprint: context.repository_fingerprint,
+      occurred_at: context.occurred_at,
+      mutation_id: context.mutation_id,
+    });
   }
 }

--- a/packages/agentplane/src/runner/usecases/kernel-task-lifecycle.test.ts
+++ b/packages/agentplane/src/runner/usecases/kernel-task-lifecycle.test.ts
@@ -1,3 +1,5 @@
+import { runKernelFinalValidation } from "../../commands/task/kernel-final-validation.js";
+import * as finalChecks from "../../commands/task/direct-task-verification.js";
 import { mkdtemp, readFile, rm } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
@@ -472,3 +474,66 @@ describe("canonical lifecycle application service", () => {
     expect(await f.read()).toEqual(before);
   });
 });
+
+it.each(["source", "task", "failed-check"])(
+  "does not persist final success after %s changes",
+  async (scenario) => {
+    const root = await mkdtemp(path.join(os.tmpdir(), "agentplane-kernel-final-checks-"));
+    roots.push(root);
+    const fingerprint = k.kernelDigest("source");
+    const record = {
+      digest: k.kernelDigest("record"),
+      aggregate: {
+        id: "FINAL",
+        revision: 1,
+        current_plan: { state: "APPROVED", digest: k.kernelDigest("plan"), work_items: [] },
+        work_items: {},
+      },
+      documents: { contracts: {} },
+    };
+    const apply = vi.fn();
+    const runtime = {
+      native: { readContext: () => Promise.resolve({ repository_fingerprint: fingerprint }) },
+      authority: {
+        resolve: () =>
+          Promise.resolve({
+            authority: { repository_fingerprint: fingerprint, digest: k.kernelDigest("authority") },
+          }),
+      },
+      adapter: {
+        read: () =>
+          Promise.resolve({
+            kind: "canonical",
+            record: scenario === "task" ? { ...record, digest: k.kernelDigest("changed") } : record,
+          }),
+      },
+      observe: () =>
+        Promise.resolve({
+          fingerprint: scenario === "source" ? k.kernelDigest("changed source") : fingerprint,
+        }),
+      lifecycle: { apply },
+      input: vi.fn(),
+    };
+    vi.spyOn(finalChecks, "runDirectTaskVerification").mockResolvedValue({
+      status: scenario === "failed-check" ? "failed" : "passed",
+      checks: [],
+      artifact_path: "checks.json",
+      reason: scenario === "failed-check" ? "failed check" : null,
+    });
+    const invocation = runKernelFinalValidation(
+      {
+        resolvedProject: { gitRoot: root },
+        memo: { gitCommonDir: Promise.resolve(path.join(root, ".git")) },
+      } as never,
+      runtime as never,
+      record as never,
+    );
+    if (scenario === "failed-check")
+      await expect(invocation).resolves.toMatchObject({
+        stop: { kind: "human_required", reason: "canonical_final_checks_failed" },
+      });
+    else await expect(invocation).rejects.toThrow("inputs changed during checks");
+    expect(apply).not.toHaveBeenCalled();
+    expect(runtime.input).not.toHaveBeenCalled();
+  },
+);

--- a/packages/agentplane/src/runner/usecases/task-run-blueprint.test.ts
+++ b/packages/agentplane/src/runner/usecases/task-run-blueprint.test.ts
@@ -110,7 +110,9 @@ describe("runner blueprint guards", () => {
     expect(bootstrap).not.toContain("- route_exact_argv:");
     expect(bootstrap).not.toContain("- route_stale_state_check:");
     expect(bootstrap).not.toContain("- route_requires_provider_action:");
-    expect(bootstrap).toContain("complete provider-facing projection");
+    expect(bootstrap).toContain(
+      "complete context manifest preserves all required constraints and input references",
+    );
   });
 
   it("renders configured evaluator skepticism into the runner bootstrap", () => {

--- a/packages/agentplane/src/runner/usecases/task-run-bootstrap.result-examples.test.ts
+++ b/packages/agentplane/src/runner/usecases/task-run-bootstrap.result-examples.test.ts
@@ -206,11 +206,13 @@ describe("runner bootstrap result examples", () => {
         id: "semantic-check",
         description: "Confirm the semantic projection preserves the user objective.",
         required: true,
+        observed_by: "agentplane",
       },
       {
         id: "supervisor-check",
         description: "Run agentplane task brief TASK-1 --json.",
         required: true,
+        observed_by: "agentplane",
       },
     ];
     bundle.work_order = workOrder;
@@ -270,6 +272,10 @@ it("reduces fixed prompt baselines while preserving semantic inputs", () => {
     const bundle = makeRunnerContextBundle({ runId: "prompt-size" });
     bundle.work_order = buildAgentWorkOrderV2ValidFixture("prompt-size");
     bundle.work_order.role = role;
+    bundle.work_order.prepared_evidence = bundle.work_order.prepared_evidence.map((evidence) => ({
+      ...evidence,
+      role,
+    }));
     const bootstrap = renderTaskRunnerBootstrap(bundle);
     // Measured before compaction on ca07204ee with these fixed fixtures.
     const baseline = role === "EXECUTOR" ? 8590 : 9196;
@@ -292,4 +298,21 @@ it("reduces fixed prompt baselines while preserving semantic inputs", () => {
     bundle.work_order.task.objective = literal;
     expect(renderTaskRunnerBootstrap(bundle)).toContain(literal);
   }
+});
+
+it("keeps optional full logs discoverable without copying them into the initial prompt", () => {
+  const bundle = makeRunnerContextBundle({ runId: "optional-context" });
+  const order = buildAgentWorkOrderV2ValidFixture("optional-context");
+  bundle.work_order = order;
+  order.required_inputs.push({
+    id: "successful-history",
+    kind: "source_artifact",
+    description: "full-successful-log".repeat(200),
+    path: "logs/success.json",
+    required: false,
+  });
+  const bootstrap = renderTaskRunnerBootstrap(bundle);
+  expect(bootstrap).not.toContain("full-successful-log");
+  expect(bootstrap).toContain("manifest_ref");
+  expect(bootstrap).toContain("Reload after restart or context loss");
 });

--- a/packages/agentplane/src/runner/usecases/task-run-bootstrap.ts
+++ b/packages/agentplane/src/runner/usecases/task-run-bootstrap.ts
@@ -1,4 +1,8 @@
 import {
+  buildWorkOrderContextManifest,
+  workOrderContextManifestDigest,
+} from "../context/work-order-context.js";
+import {
   AGENT_SEMANTIC_RESULT_STATUS_VALUES,
   type AgentSemanticResult,
 } from "@agentplaneorg/core/schemas";
@@ -162,6 +166,7 @@ function semanticWorkOrderProjection(bundle: RunnerContextBundle): Record<string
     (requirement) => !semanticTextHasProcessChoreography(requirement.description),
   );
   const requiredInputs = workOrder.required_inputs.filter((input) => {
+    if (!input.required) return false;
     if (input.kind === "task_document" || input.kind === "policy_module") return false;
     if (input.kind !== "source_artifact") return true;
     const source = input.path ?? "";
@@ -181,6 +186,17 @@ function semanticWorkOrderProjection(bundle: RunnerContextBundle): Record<string
     (toolClass) => toolClass !== "workspace_write" || effectiveWritableRoots.length > 0,
   );
   return {
+    context_discovery: {
+      manifest_ref: `${bundle.execution.artifact_paths.bundle_path}#/semantic_context`,
+      manifest_digest: workOrderContextManifestDigest(
+        buildWorkOrderContextManifest(
+          workOrder,
+          `${bundle.execution.artifact_paths.bundle_path}#/work_order`,
+        ),
+      ),
+      required_loading:
+        "Read every required block before semantic work. Validate its digest. Reload after restart or context loss. Read optional blocks only on demand.",
+    },
     work_order_id: workOrder.work_order_id,
     ...(workOrder.canonical_binding ? { canonical_binding: workOrder.canonical_binding } : {}),
     role: workOrder.role,
@@ -199,8 +215,12 @@ function semanticWorkOrderProjection(bundle: RunnerContextBundle): Record<string
       required_knowledge_ref_digests: workOrder.context_intent.required_knowledge_ref_digests,
       require_prepared_evidence: workOrder.context_intent.require_prepared_evidence,
     },
-    knowledge_refs: workOrder.knowledge_refs,
-    prepared_evidence: workOrder.prepared_evidence,
+    knowledge_refs: workOrder.knowledge_refs.filter((ref) =>
+      workOrder.context_intent.required_knowledge_ref_digests.includes(ref.digest),
+    ),
+    prepared_evidence: workOrder.prepared_evidence.filter(
+      (evidence) => evidence.role === workOrder.role,
+    ),
     required_inputs: requiredInputs,
     required_outputs: workOrder.required_outputs,
     semantic_checks: semanticVerificationRequirements.map((requirement) => ({
@@ -248,7 +268,7 @@ export function renderTaskRunnerBootstrap(
     "# agentplane runner bootstrap",
     "",
     "- Use only the supplied context, writable roots, and declared tools.",
-    "- Do not inspect internal orchestration artifacts or invoke undeclared interfaces.",
+    "- Read only declared context references and source artifacts. Do not invoke undeclared interfaces.",
     "- Assume sibling runners may be executing concurrently. Keep writes inside the task scope, avoid broad refactors or shared policy edits, and report possible write conflicts in the typed result instead of resolving them speculatively.",
     "",
     `- target: ${targetLabel}`,
@@ -257,7 +277,7 @@ export function renderTaskRunnerBootstrap(
     `- writable_roots: ${JSON.stringify(writeScope?.writable_roots ?? [])}`,
     `- protected_paths: ${JSON.stringify(writeScope?.protected_paths ?? [])}`,
     "",
-    "The content below is the complete provider-facing projection for this episode.",
+    "The projection below starts this episode. The complete context manifest preserves all required constraints and input references. References do not grant authority.",
     "For file-edit tools that do not accept cwd/workdir, use absolute paths under writable_roots; stop before writing when no writable root is granted.",
     "Treat protected_paths as forbidden even when the native sandbox permits them.",
     "",

--- a/packages/agentplane/src/runner/usecases/task-run-context.integration.test.ts
+++ b/packages/agentplane/src/runner/usecases/task-run-context.integration.test.ts
@@ -475,7 +475,9 @@ describe("context task runner integration", () => {
       plannerProviderPrompt,
       evaluatorProviderPrompt,
     ]) {
-      expect(providerPrompt).toContain("complete provider-facing projection");
+      expect(providerPrompt).toContain(
+        "complete context manifest preserves all required constraints and input references",
+      );
       expect(providerPrompt).toContain("MUST NOT commit secrets, credentials, or private keys.");
       expect(providerPrompt).toContain(
         "MUST NOT access outside-repo files without explicit user approval.",

--- a/packages/core/schemas/agent-work-order-v2.schema.json
+++ b/packages/core/schemas/agent-work-order-v2.schema.json
@@ -1038,6 +1038,76 @@
             "authority_digest"
           ],
           "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "properties": {
+            "task_id": {
+              "type": "string",
+              "minLength": 1
+            },
+            "repository_identity": {
+              "type": "string",
+              "pattern": "^sha256:[a-f0-9]{64}$"
+            },
+            "repository_fingerprint": {
+              "type": "string",
+              "pattern": "^sha256:[a-f0-9]{64}$"
+            },
+            "plan_revision": {
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 9007199254740991
+            },
+            "plan_digest": {
+              "type": "string",
+              "pattern": "^sha256:[a-f0-9]{64}$"
+            },
+            "phase": {
+              "type": "string",
+              "const": "inspection"
+            },
+            "work_item_id": {
+              "type": "string",
+              "minLength": 1
+            },
+            "attempt": {
+              "type": "integer",
+              "exclusiveMinimum": 0,
+              "maximum": 9007199254740991
+            },
+            "claim_id": {
+              "type": "string",
+              "minLength": 1
+            },
+            "contract_digest": {
+              "type": "string",
+              "pattern": "^sha256:[a-f0-9]{64}$"
+            },
+            "authority_digest": {
+              "type": "string",
+              "pattern": "^sha256:[a-f0-9]{64}$"
+            },
+            "result_digest": {
+              "type": "string",
+              "pattern": "^sha256:[a-f0-9]{64}$"
+            }
+          },
+          "required": [
+            "task_id",
+            "repository_identity",
+            "repository_fingerprint",
+            "plan_revision",
+            "plan_digest",
+            "phase",
+            "work_item_id",
+            "attempt",
+            "claim_id",
+            "contract_digest",
+            "authority_digest",
+            "result_digest"
+          ],
+          "additionalProperties": false
         }
       ]
     },

--- a/packages/core/schemas/task-readme-frontmatter.schema.json
+++ b/packages/core/schemas/task-readme-frontmatter.schema.json
@@ -715,6 +715,23 @@
           "type": "string",
           "enum": ["observed", "partial", "unavailable"]
         },
+        "cached_input_tokens": {
+          "anyOf": [
+            {
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 9007199254740991
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "cached_input_observed_agent_runs": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 9007199254740991
+        },
         "input_tokens": {
           "anyOf": [
             {

--- a/packages/core/schemas/tasks-export.schema.json
+++ b/packages/core/schemas/tasks-export.schema.json
@@ -491,6 +491,23 @@
                 "type": "string",
                 "enum": ["observed", "partial", "unavailable"]
               },
+              "cached_input_tokens": {
+                "anyOf": [
+                  {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 9007199254740991
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "cached_input_observed_agent_runs": {
+                "type": "integer",
+                "minimum": 0,
+                "maximum": 9007199254740991
+              },
               "input_tokens": {
                 "anyOf": [
                   {

--- a/packages/core/src/runner/agent-semantic-result.test.ts
+++ b/packages/core/src/runner/agent-semantic-result.test.ts
@@ -47,6 +47,35 @@ describe("agent semantic result contract", () => {
       expect(listAgentSemanticResultSchemaErrors(invalid)).not.toEqual([]);
   });
 
+  it("keeps inspection review separate from implementation outputs and native validation", () => {
+    const digest = `sha256:${"a".repeat(64)}`;
+    const value = {
+      ...AGENT_SEMANTIC_RESULT_V2_VALID_FIXTURE,
+      canonical_binding: {
+        phase: "inspection",
+        task_id: "T-inspection",
+        repository_identity: digest,
+        repository_fingerprint: digest,
+        plan_revision: 1,
+        plan_digest: digest,
+        work_item_id: "build",
+        attempt: 1,
+        claim_id: "claim",
+        contract_digest: digest,
+        authority_digest: digest,
+        result_digest: digest,
+      },
+      review: { verdict: "pass", missing_tests: [], hidden_assumptions: [], residual_risks: [] },
+    };
+    expect(listAgentSemanticResultSchemaErrors(value)).toEqual([]);
+    for (const changed of [
+      { ...value, review: undefined },
+      { ...value, canonical_outputs: [{ id: "source", kind: "source", digest }] },
+      { ...value, canonical_binding: { ...value.canonical_binding, result_digest: "invalid" } },
+    ])
+      expect(listAgentSemanticResultSchemaErrors(changed)).not.toEqual([]);
+  });
+
   it("accepts the generated v2 fixture", async () => {
     const fixturePath = path.join(
       process.cwd(),

--- a/packages/core/src/runner/agent-semantic-result.ts
+++ b/packages/core/src/runner/agent-semantic-result.ts
@@ -260,11 +260,15 @@ export const AGENT_SEMANTIC_RESULT_ZOD_SCHEMA = z
     if (
       (!binding && (value.canonical_plan || value.canonical_outputs)) ||
       (binding && (value.task_intent || value.task_plan_proposal || value.plan_refinement)) ||
-      (binding?.phase === "planning" && value.canonical_outputs) ||
-      (binding?.phase === "implementation" && value.canonical_plan) ||
+      (binding?.phase !== "implementation" && value.canonical_outputs) ||
+      (binding?.phase !== "planning" && value.canonical_plan) ||
       (binding &&
         value.status === "completed" &&
-        !(binding.phase === "planning" ? value.canonical_plan : value.canonical_outputs))
+        !(binding.phase === "planning"
+          ? value.canonical_plan
+          : binding.phase === "inspection"
+            ? value.review
+            : value.canonical_outputs))
     )
       ctx.addIssue({
         code: "custom",

--- a/packages/core/src/runner/agent-work-order.ts
+++ b/packages/core/src/runner/agent-work-order.ts
@@ -239,9 +239,13 @@ export const AGENT_WORK_ORDER_V2_ZOD_SCHEMA = z
     if (
       value.canonical_binding &&
       (value.canonical_binding.task_id !== value.task.id ||
-        (value.canonical_binding.phase === "implementation" &&
+        (value.canonical_binding.phase !== "planning" &&
           value.canonical_binding.work_item_id !== value.task.work_item_id) ||
-        (value.canonical_binding.phase === "planning" && value.role !== "PLANNER"))
+        (value.canonical_binding.phase === "planning" && value.role !== "PLANNER") ||
+        (value.canonical_binding.phase === "inspection" &&
+          (value.role !== "EVALUATOR" ||
+            value.authority.mutation_scope !== "none" ||
+            value.authority.writable_roots.length > 0)))
     )
       ctx.addIssue({
         code: "custom",

--- a/packages/core/src/runner/supervisor-execution-episode.test.ts
+++ b/packages/core/src/runner/supervisor-execution-episode.test.ts
@@ -253,6 +253,51 @@ describe("SupervisorExecutionEpisodeJournal", () => {
     });
   });
 
+  it("persists cache coverage and per-role usage once across journal reloads", () => {
+    const prepared = start({ journal: journal() });
+    if (prepared.status !== "started") throw new Error("expected episode");
+    const completed = completeSupervisorExecutionEpisode({
+      journal: prepared.journal,
+      operation_key: prepared.operation_key,
+      result: { status: "ok" },
+      usage: {
+        input_tokens: 10,
+        output_tokens: 5,
+        total_tokens: 15,
+        cached_input_tokens: 0,
+        prepared_context_bytes: 42,
+      },
+      now: NOW,
+    });
+    const reloaded = validateSupervisorExecutionEpisodeJournal(
+      JSON.parse(JSON.stringify(completed)),
+    );
+    expect(reloaded.usage).toMatchObject({
+      cached_input_tokens: 0,
+      cached_input_observed_agent_runs: 1,
+      prepared_context_bytes: 42,
+      prepared_context_observed_agent_runs: 1,
+    });
+    expect(reloaded.operations.at(-1)).toMatchObject({
+      role: "EXECUTOR",
+      usage: {
+        input_tokens: 10,
+        cached_input_tokens: 0,
+        prepared_context_bytes: 42,
+      },
+    });
+    expect(() =>
+      completeSupervisorExecutionEpisode({
+        journal: reloaded,
+        operation_key: prepared.operation_key,
+        result: {},
+        usage: { input_tokens: 10 },
+        now: NOW,
+      }),
+    ).toThrow(/intent-recorded/u);
+    expect(reloaded.usage.input_tokens).toBe(10);
+  });
+
   it("tracks output-breakdown provenance independently from primary token telemetry", () => {
     const primaryOnly = start({ journal: journal() });
     if (primaryOnly.status !== "started") throw new Error("expected primary-only episode");

--- a/packages/core/src/runner/supervisor-execution-episode.test.ts
+++ b/packages/core/src/runner/supervisor-execution-episode.test.ts
@@ -269,9 +269,8 @@ describe("SupervisorExecutionEpisodeJournal", () => {
       },
       now: NOW,
     });
-    const reloaded = validateSupervisorExecutionEpisodeJournal(
-      JSON.parse(JSON.stringify(completed)),
-    );
+    const serialized = JSON.stringify(completed);
+    const reloaded = validateSupervisorExecutionEpisodeJournal(JSON.parse(serialized));
     expect(reloaded.usage).toMatchObject({
       cached_input_tokens: 0,
       cached_input_observed_agent_runs: 1,

--- a/packages/core/src/runner/supervisor-execution-episode.ts
+++ b/packages/core/src/runner/supervisor-execution-episode.ts
@@ -71,6 +71,10 @@ export const SUPERVISOR_EXECUTION_USAGE_ZOD_SCHEMA = z
     input_tokens: NON_NEGATIVE_INTEGER,
     output_tokens: NON_NEGATIVE_INTEGER,
     total_tokens: NON_NEGATIVE_INTEGER,
+    cached_input_tokens: NON_NEGATIVE_INTEGER.optional(),
+    cached_input_observed_agent_runs: NON_NEGATIVE_INTEGER.optional(),
+    prepared_context_bytes: NON_NEGATIVE_INTEGER.optional(),
+    prepared_context_observed_agent_runs: NON_NEGATIVE_INTEGER.optional(),
     visible_output_tokens: NON_NEGATIVE_INTEGER.optional(),
     reasoning_tokens: NON_NEGATIVE_INTEGER.optional(),
     token_observed_agent_runs: NON_NEGATIVE_INTEGER.optional(),
@@ -82,6 +86,20 @@ export const SUPERVISOR_EXECUTION_USAGE_ZOD_SCHEMA = z
   })
   .strict()
   .superRefine((usage, ctx) => {
+    for (const [count, total] of [
+      [usage.cached_input_observed_agent_runs, usage.cached_input_tokens],
+      [usage.prepared_context_observed_agent_runs, usage.prepared_context_bytes],
+    ]) {
+      if (count !== undefined && (count > usage.agent_runs || (count > 0 && total === undefined))) {
+        ctx.addIssue({
+          code: "custom",
+          message: "Observed measurement runs require totals and cannot exceed agent runs.",
+        });
+      }
+    }
+    if ((usage.cached_input_tokens ?? 0) > usage.input_tokens) {
+      ctx.addIssue({ code: "custom", message: "Cached input cannot exceed input tokens." });
+    }
     if (
       usage.token_observed_agent_runs !== undefined &&
       usage.token_observed_agent_runs > usage.agent_runs
@@ -162,6 +180,18 @@ const SUPERVISOR_EPISODE_OPERATION_ZOD_SCHEMA = z
     recovery: SUPERVISOR_EPISODE_RECOVERY_ZOD_SCHEMA.optional(),
     replacement_of_operation_key: SHA256_DIGEST_SCHEMA.nullable().optional(),
     status: z.enum(SUPERVISOR_EPISODE_OPERATION_STATUS_VALUES),
+    usage: z
+      .object({
+        input_tokens: NON_NEGATIVE_INTEGER.optional(),
+        output_tokens: NON_NEGATIVE_INTEGER.optional(),
+        total_tokens: NON_NEGATIVE_INTEGER.optional(),
+        visible_output_tokens: NON_NEGATIVE_INTEGER.optional(),
+        reasoning_tokens: NON_NEGATIVE_INTEGER.optional(),
+        cached_input_tokens: NON_NEGATIVE_INTEGER.optional(),
+        prepared_context_bytes: NON_NEGATIVE_INTEGER.optional(),
+      })
+      .strict()
+      .optional(),
     result_digest: SHA256_DIGEST_SCHEMA.nullable(),
     postcondition_fingerprint_digest: SHA256_DIGEST_SCHEMA.nullable(),
     feedback_digest: SHA256_DIGEST_SCHEMA.nullable(),
@@ -773,6 +803,17 @@ export function completeSupervisorExecutionEpisode(opts: {
     input_tokens: journal.usage.input_tokens + Math.max(0, usageInput.input_tokens ?? 0),
     output_tokens: journal.usage.output_tokens + Math.max(0, usageInput.output_tokens ?? 0),
     total_tokens: journal.usage.total_tokens + Math.max(0, usageInput.total_tokens ?? 0),
+    cached_input_tokens:
+      (journal.usage.cached_input_tokens ?? 0) + Math.max(0, usageInput.cached_input_tokens ?? 0),
+    cached_input_observed_agent_runs:
+      (journal.usage.cached_input_observed_agent_runs ?? 0) +
+      (tokenUsageObserved && usageInput.cached_input_tokens !== undefined ? 1 : 0),
+    prepared_context_bytes:
+      (journal.usage.prepared_context_bytes ?? 0) +
+      Math.max(0, usageInput.prepared_context_bytes ?? 0),
+    prepared_context_observed_agent_runs:
+      (journal.usage.prepared_context_observed_agent_runs ?? 0) +
+      (isAgentOperation(last.kind) && usageInput.prepared_context_bytes !== undefined ? 1 : 0),
     visible_output_tokens:
       (journal.usage.visible_output_tokens ?? 0) +
       Math.max(0, usageInput.visible_output_tokens ?? 0),
@@ -792,6 +833,19 @@ export function completeSupervisorExecutionEpisode(opts: {
   };
   const operation = {
     ...last,
+    usage: Object.fromEntries(
+      [
+        "input_tokens",
+        "output_tokens",
+        "total_tokens",
+        "visible_output_tokens",
+        "reasoning_tokens",
+        "cached_input_tokens",
+        "prepared_context_bytes",
+      ]
+        .filter((key) => usageInput[key as keyof typeof usageInput] !== undefined)
+        .map((key) => [key, usageInput[key as keyof typeof usageInput]]),
+    ),
     status: opts.failed ? ("failed" as const) : ("completed" as const),
     result_digest: digestSupervisorEpisodeValue(opts.result),
     feedback_digest:

--- a/packages/core/src/tasks/kernel-semantic.ts
+++ b/packages/core/src/tasks/kernel-semantic.ts
@@ -58,6 +58,16 @@ export const kernelEpisodeBindingSchema = z.discriminatedUnion("phase", [
     contract_digest: digest,
     authority_digest: digest,
   }),
+  z.strictObject({
+    ...commonBinding,
+    phase: z.literal("inspection"),
+    work_item_id: safeId,
+    attempt: z.number().int().positive(),
+    claim_id: text,
+    contract_digest: digest,
+    authority_digest: digest,
+    result_digest: digest,
+  }),
 ]);
 export const kernelOutputClaimsSchema = z.array(z.strictObject({ id: safeId, kind: text, digest }));
 export type KernelEpisodeBinding = z.infer<typeof kernelEpisodeBindingSchema>;

--- a/packages/core/src/tasks/task-artifact-schema.task.ts
+++ b/packages/core/src/tasks/task-artifact-schema.task.ts
@@ -377,6 +377,8 @@ const TASK_TOKEN_USAGE_SCHEMA = z
   .object({
     schema_version: z.literal(1),
     state: z.enum(["observed", "partial", "unavailable"]),
+    cached_input_tokens: z.number().int().min(0).nullable().optional(),
+    cached_input_observed_agent_runs: z.number().int().min(0).optional(),
     input_tokens: z.number().int().min(0).nullable(),
     output_tokens: z.number().int().min(0).nullable(),
     reasoning_tokens: z.number().int().min(0).nullable(),
@@ -394,6 +396,18 @@ const TASK_TOKEN_USAGE_SCHEMA = z
   })
   .strict()
   .superRefine((usage, ctx) => {
+    if (
+      (usage.cached_input_observed_agent_runs ?? 0) > usage.observed_agent_runs ||
+      ((usage.cached_input_observed_agent_runs ?? 0) > 0 && usage.cached_input_tokens == null) ||
+      (usage.cached_input_tokens != null && (usage.cached_input_observed_agent_runs ?? 0) === 0) ||
+      (usage.cached_input_tokens != null &&
+        (usage.input_tokens == null || usage.cached_input_tokens > usage.input_tokens))
+    ) {
+      ctx.addIssue({
+        code: "custom",
+        message: "Cached input requires consistent supervisor-observed coverage and input totals.",
+      });
+    }
     if (usage.observed_agent_runs > usage.agent_runs) {
       ctx.addIssue({
         code: "custom",

--- a/packages/core/src/tasks/task-kernel/authority-delta.test.ts
+++ b/packages/core/src/tasks/task-kernel/authority-delta.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from "vitest";
+import { authorityDeltaApprovalEvidence } from "./authority-lineage.js";
+import { kernelDigest, reduceTaskCommand } from "./kernel.js";
+import type { TaskCommand } from "./model.js";
+import { authority, plan, aggregate, input } from "./kernel.test-fixtures.js";
+
+describe("canonical authority delta", () => {
+  it("applies an exact USER authority delta without changing the approved plan", () => {
+    const { digest: _fixtureDigest, ...parentContents } = authority;
+    const parent = { ...parentContents, digest: kernelDigest(parentContents) };
+    const nextFingerprint = kernelDigest("schema-sync");
+    const request = {
+      task_id: "task-1",
+      task_revision: 7,
+      plan_revision: plan.revision,
+      plan_digest: plan.digest,
+      parent_authority_digest: parent.digest,
+      repository_identity: parent.repository_identity,
+      previous_fingerprint: parent.repository_fingerprint,
+      repository_fingerprint: nextFingerprint,
+      repository_evidence_digest: kernelDigest("schema-observation"),
+      changed_paths: ["packages/core/src/tasks/task-kernel/kernel.ts", "schemas/generated.json"],
+      added_scope_roots: ["schemas/generated.json"],
+      added_repository_effects: ["schema"],
+    };
+    const requestDigest = kernelDigest(request);
+    const approvalEvidence = authorityDeltaApprovalEvidence({
+      task_id: "task-1",
+      request_digest: requestDigest,
+      actor_id: "USER",
+    });
+    const childContents = {
+      ...parent,
+      repository_fingerprint: nextFingerprint,
+      scope_roots: [...parent.scope_roots, "schemas/generated.json"].toSorted(),
+      repository_effects: [...parent.repository_effects, "schema"].toSorted(),
+      provenance: {
+        kind: "USER" as const,
+        actor_id: "USER",
+        evidence_digest: parent.provenance.evidence_digest,
+        parent_authority_digest: parent.digest,
+      },
+    };
+    const { digest: _parentDigest, ...digestContents } = childContents;
+    const record = {
+      authority: { ...digestContents, digest: kernelDigest(digestContents) },
+      approval_mode: "manual_operator" as const,
+      observation: {
+        kind: "authority_delta" as const,
+        evidence_digest: approvalEvidence,
+        previous_fingerprint: parent.repository_fingerprint,
+        changed_paths: request.changed_paths,
+        request_digest: requestDigest,
+        added_scope_roots: request.added_scope_roots,
+        added_repository_effects: request.added_repository_effects,
+        request_task_revision: request.task_revision,
+        repository_evidence_digest: request.repository_evidence_digest,
+      },
+    };
+    const state = aggregate({
+      authority_lineage: [
+        { authority: parent, approval_mode: "manual_operator", observation: null },
+      ],
+    });
+    const command: TaskCommand = {
+      kind: "approve_authority_delta",
+      task_id: state.id,
+      expected_task_revision: state.revision,
+      expected_state_fingerprint: nextFingerprint,
+      parent_authority_digest: parent.digest,
+      request_digest: requestDigest,
+      record,
+    };
+    const approved = reduceTaskCommand({
+      ...input(state, command),
+      actor: {
+        id: "USER",
+        kind: "USER",
+        transport: "manual",
+        capabilities: [],
+      },
+      authority: null,
+      repository_fingerprint: nextFingerprint,
+    });
+    expect(approved).toMatchObject({
+      kind: "accepted",
+      aggregate: {
+        revision: 8,
+        current_plan: plan,
+        authority_lineage: [{ authority: parent }, record],
+      },
+      events: [{ kind: "authority_continued" }],
+    });
+    expect(
+      reduceTaskCommand({
+        ...input(state, command),
+        actor: {
+          id: "agent",
+          kind: "AGENT",
+          transport: "managed",
+          capabilities: [],
+        },
+        authority: null,
+        repository_fingerprint: nextFingerprint,
+      }),
+    ).toMatchObject({ kind: "rejected", code: "AUTHORITY_SCOPE_EXCEEDED" });
+  });
+});

--- a/packages/core/src/tasks/task-kernel/authority-lineage.ts
+++ b/packages/core/src/tasks/task-kernel/authority-lineage.ts
@@ -4,12 +4,21 @@ import type {
   CanonicalAuthorityRecord,
   ExecutionAuthority,
   KernelInput,
+  Sha256Digest,
   TaskAggregate,
 } from "./model.js";
 
 export function authorityDigest(authority: Omit<ExecutionAuthority, "digest">) {
   const { digest: _digest, ...contents } = authority as ExecutionAuthority;
   return kernelDigest(contents);
+}
+
+export function authorityDeltaApprovalEvidence(input: {
+  task_id: string;
+  request_digest: Sha256Digest;
+  actor_id: string;
+}) {
+  return kernelDigest({ kind: "canonical_authority_delta_approval", ...input });
 }
 
 export function canonicalAuthorityIssues(aggregate: TaskAggregate): string[] {
@@ -26,9 +35,78 @@ export function canonicalAuthorityIssues(aggregate: TaskAggregate): string[] {
       (entry) =>
         entry?.revision === authority.plan_revision && entry.digest === authority.plan_digest,
     );
-    if (plan?.approval_evidence_digest !== authority.provenance.evidence_digest)
+    if (
+      record.observation?.kind !== "authority_delta" &&
+      plan?.approval_evidence_digest !== authority.provenance.evidence_digest
+    )
       issues.push("authority_plan");
-    if (record.approval_mode === null) {
+    if (record.observation?.kind === "authority_delta") {
+      const parent = records[index - 1]?.authority;
+      const observation = record.observation;
+      const immutable = parent
+        ? {
+            ...authority,
+            digest: parent.digest,
+            repository_fingerprint: parent.repository_fingerprint,
+            scope_roots: parent.scope_roots,
+            repository_effects: parent.repository_effects,
+            provenance: parent.provenance,
+          }
+        : null;
+      if (
+        !parent ||
+        record.approval_mode === null ||
+        record.approval_mode !== "manual_operator" ||
+        authority.provenance.kind !== "USER" ||
+        authority.provenance.parent_authority_digest !== parent.digest ||
+        authority.provenance.evidence_digest !== parent.provenance.evidence_digest ||
+        observation.evidence_digest !==
+          authorityDeltaApprovalEvidence({
+            task_id: aggregate.id,
+            request_digest: observation.request_digest!,
+            actor_id: authority.provenance.actor_id,
+          }) ||
+        observation.request_task_revision === undefined ||
+        observation.repository_evidence_digest === undefined ||
+        observation.added_scope_roots === undefined ||
+        observation.added_repository_effects === undefined ||
+        observation.added_scope_roots.length === 0 ||
+        JSON.stringify(observation.changed_paths) !==
+          JSON.stringify([...new Set(observation.changed_paths)].toSorted()) ||
+        JSON.stringify(observation.added_scope_roots) !==
+          JSON.stringify([...new Set(observation.added_scope_roots)].toSorted()) ||
+        JSON.stringify(observation.added_repository_effects) !==
+          JSON.stringify([...new Set(observation.added_repository_effects)].toSorted()) ||
+        observation.added_scope_roots.some((root) => !observation.changed_paths.includes(root)) ||
+        JSON.stringify(authority.scope_roots) !==
+          JSON.stringify(
+            [...new Set([...parent.scope_roots, ...observation.added_scope_roots])].toSorted(),
+          ) ||
+        JSON.stringify(authority.repository_effects) !==
+          JSON.stringify(
+            [
+              ...new Set([...parent.repository_effects, ...observation.added_repository_effects]),
+            ].toSorted(),
+          ) ||
+        !immutable ||
+        kernelDigest(immutable) !== kernelDigest(parent) ||
+        kernelDigest({
+          task_id: aggregate.id,
+          task_revision: observation.request_task_revision,
+          plan_revision: parent.plan_revision,
+          plan_digest: parent.plan_digest,
+          parent_authority_digest: parent.digest,
+          repository_identity: parent.repository_identity,
+          previous_fingerprint: parent.repository_fingerprint,
+          repository_fingerprint: authority.repository_fingerprint,
+          repository_evidence_digest: observation.repository_evidence_digest,
+          changed_paths: observation.changed_paths,
+          added_scope_roots: observation.added_scope_roots,
+          added_repository_effects: observation.added_repository_effects,
+        }) !== observation.request_digest
+      )
+        issues.push("authority_delta");
+    } else if (record.approval_mode === null) {
       const parent = records[index - 1]?.authority;
       if (!parent || !record.observation || continuationIssues(parent, record).length > 0)
         issues.push("authority_continuation");
@@ -81,6 +159,8 @@ export function continuationIssues(
       observation.changed_paths.length > 0
     )
       return ["plan_observation_binding"];
+  } else if (observation.kind === "authority_delta") {
+    return ["authority_delta_requires_user"];
   } else if (
     child.plan_revision !== parent.plan_revision ||
     child.plan_digest !== parent.plan_digest ||

--- a/packages/core/src/tasks/task-kernel/kernel.test.ts
+++ b/packages/core/src/tasks/task-kernel/kernel.test.ts
@@ -1,6 +1,7 @@
 import { createHash } from "node:crypto";
 
 import { describe, expect, it } from "vitest";
+import { authorityDeltaApprovalEvidence } from "./authority-lineage.js";
 
 import {
   EFFECT_OBSERVE_TRANSITION_TABLE,
@@ -29,6 +30,107 @@ import {
 } from "./kernel.test-fixtures.js";
 
 describe("canonical task kernel reducer", () => {
+  it("applies an exact USER authority delta without changing the approved plan", () => {
+    const { digest: _fixtureDigest, ...parentContents } = authority;
+    const parent = { ...parentContents, digest: kernelDigest(parentContents) };
+    const nextFingerprint = kernelDigest("schema-sync");
+    const request = {
+      task_id: "task-1",
+      task_revision: 7,
+      plan_revision: plan.revision,
+      plan_digest: plan.digest,
+      parent_authority_digest: parent.digest,
+      repository_identity: parent.repository_identity,
+      previous_fingerprint: parent.repository_fingerprint,
+      repository_fingerprint: nextFingerprint,
+      repository_evidence_digest: kernelDigest("schema-observation"),
+      changed_paths: ["packages/core/src/tasks/task-kernel/kernel.ts", "schemas/generated.json"],
+      added_scope_roots: ["schemas/generated.json"],
+      added_repository_effects: ["schema"],
+    };
+    const requestDigest = kernelDigest(request);
+    const approvalEvidence = authorityDeltaApprovalEvidence({
+      task_id: "task-1",
+      request_digest: requestDigest,
+      actor_id: "USER",
+    });
+    const childContents = {
+      ...parent,
+      repository_fingerprint: nextFingerprint,
+      scope_roots: [...parent.scope_roots, "schemas/generated.json"].toSorted(),
+      repository_effects: [...parent.repository_effects, "schema"].toSorted(),
+      provenance: {
+        kind: "USER" as const,
+        actor_id: "USER",
+        evidence_digest: parent.provenance.evidence_digest,
+        parent_authority_digest: parent.digest,
+      },
+    };
+    const { digest: _parentDigest, ...digestContents } = childContents;
+    const record = {
+      authority: { ...digestContents, digest: kernelDigest(digestContents) },
+      approval_mode: "manual_operator" as const,
+      observation: {
+        kind: "authority_delta" as const,
+        evidence_digest: approvalEvidence,
+        previous_fingerprint: parent.repository_fingerprint,
+        changed_paths: request.changed_paths,
+        request_digest: requestDigest,
+        added_scope_roots: request.added_scope_roots,
+        added_repository_effects: request.added_repository_effects,
+        request_task_revision: request.task_revision,
+        repository_evidence_digest: request.repository_evidence_digest,
+      },
+    };
+    const state = aggregate({
+      authority_lineage: [
+        { authority: parent, approval_mode: "manual_operator", observation: null },
+      ],
+    });
+    const command: TaskCommand = {
+      kind: "approve_authority_delta",
+      task_id: state.id,
+      expected_task_revision: state.revision,
+      expected_state_fingerprint: nextFingerprint,
+      parent_authority_digest: parent.digest,
+      request_digest: requestDigest,
+      record,
+    };
+    const approved = reduceTaskCommand({
+      ...input(state, command),
+      actor: {
+        id: "USER",
+        kind: "USER",
+        transport: "manual",
+        capabilities: [],
+      },
+      authority: null,
+      repository_fingerprint: nextFingerprint,
+    });
+    expect(approved).toMatchObject({
+      kind: "accepted",
+      aggregate: {
+        revision: 8,
+        current_plan: plan,
+        authority_lineage: [{ authority: parent }, record],
+      },
+      events: [{ kind: "authority_continued" }],
+    });
+    expect(
+      reduceTaskCommand({
+        ...input(state, command),
+        actor: {
+          id: "agent",
+          kind: "AGENT",
+          transport: "managed",
+          capabilities: [],
+        },
+        authority: null,
+        repository_fingerprint: nextFingerprint,
+      }),
+    ).toMatchObject({ kind: "rejected", code: "AUTHORITY_SCOPE_EXCEEDED" });
+  });
+
   it.each(["CLAIMED", "EXECUTING", "BLOCKED", "VALIDATING"] as const)(
     "does not abandon an optional %s claim at Task completion",
     (optionalState) => {

--- a/packages/core/src/tasks/task-kernel/kernel.test.ts
+++ b/packages/core/src/tasks/task-kernel/kernel.test.ts
@@ -1,7 +1,6 @@
 import { createHash } from "node:crypto";
 
 import { describe, expect, it } from "vitest";
-import { authorityDeltaApprovalEvidence } from "./authority-lineage.js";
 
 import {
   EFFECT_OBSERVE_TRANSITION_TABLE,
@@ -30,107 +29,6 @@ import {
 } from "./kernel.test-fixtures.js";
 
 describe("canonical task kernel reducer", () => {
-  it("applies an exact USER authority delta without changing the approved plan", () => {
-    const { digest: _fixtureDigest, ...parentContents } = authority;
-    const parent = { ...parentContents, digest: kernelDigest(parentContents) };
-    const nextFingerprint = kernelDigest("schema-sync");
-    const request = {
-      task_id: "task-1",
-      task_revision: 7,
-      plan_revision: plan.revision,
-      plan_digest: plan.digest,
-      parent_authority_digest: parent.digest,
-      repository_identity: parent.repository_identity,
-      previous_fingerprint: parent.repository_fingerprint,
-      repository_fingerprint: nextFingerprint,
-      repository_evidence_digest: kernelDigest("schema-observation"),
-      changed_paths: ["packages/core/src/tasks/task-kernel/kernel.ts", "schemas/generated.json"],
-      added_scope_roots: ["schemas/generated.json"],
-      added_repository_effects: ["schema"],
-    };
-    const requestDigest = kernelDigest(request);
-    const approvalEvidence = authorityDeltaApprovalEvidence({
-      task_id: "task-1",
-      request_digest: requestDigest,
-      actor_id: "USER",
-    });
-    const childContents = {
-      ...parent,
-      repository_fingerprint: nextFingerprint,
-      scope_roots: [...parent.scope_roots, "schemas/generated.json"].toSorted(),
-      repository_effects: [...parent.repository_effects, "schema"].toSorted(),
-      provenance: {
-        kind: "USER" as const,
-        actor_id: "USER",
-        evidence_digest: parent.provenance.evidence_digest,
-        parent_authority_digest: parent.digest,
-      },
-    };
-    const { digest: _parentDigest, ...digestContents } = childContents;
-    const record = {
-      authority: { ...digestContents, digest: kernelDigest(digestContents) },
-      approval_mode: "manual_operator" as const,
-      observation: {
-        kind: "authority_delta" as const,
-        evidence_digest: approvalEvidence,
-        previous_fingerprint: parent.repository_fingerprint,
-        changed_paths: request.changed_paths,
-        request_digest: requestDigest,
-        added_scope_roots: request.added_scope_roots,
-        added_repository_effects: request.added_repository_effects,
-        request_task_revision: request.task_revision,
-        repository_evidence_digest: request.repository_evidence_digest,
-      },
-    };
-    const state = aggregate({
-      authority_lineage: [
-        { authority: parent, approval_mode: "manual_operator", observation: null },
-      ],
-    });
-    const command: TaskCommand = {
-      kind: "approve_authority_delta",
-      task_id: state.id,
-      expected_task_revision: state.revision,
-      expected_state_fingerprint: nextFingerprint,
-      parent_authority_digest: parent.digest,
-      request_digest: requestDigest,
-      record,
-    };
-    const approved = reduceTaskCommand({
-      ...input(state, command),
-      actor: {
-        id: "USER",
-        kind: "USER",
-        transport: "manual",
-        capabilities: [],
-      },
-      authority: null,
-      repository_fingerprint: nextFingerprint,
-    });
-    expect(approved).toMatchObject({
-      kind: "accepted",
-      aggregate: {
-        revision: 8,
-        current_plan: plan,
-        authority_lineage: [{ authority: parent }, record],
-      },
-      events: [{ kind: "authority_continued" }],
-    });
-    expect(
-      reduceTaskCommand({
-        ...input(state, command),
-        actor: {
-          id: "agent",
-          kind: "AGENT",
-          transport: "managed",
-          capabilities: [],
-        },
-        authority: null,
-        repository_fingerprint: nextFingerprint,
-      }),
-    ).toMatchObject({ kind: "rejected", code: "AUTHORITY_SCOPE_EXCEEDED" });
-  });
-
   it.each(["CLAIMED", "EXECUTING", "BLOCKED", "VALIDATING"] as const)(
     "does not abandon an optional %s claim at Task completion",
     (optionalState) => {

--- a/packages/core/src/tasks/task-kernel/kernel.ts
+++ b/packages/core/src/tasks/task-kernel/kernel.ts
@@ -1,4 +1,9 @@
-import { authorityDigest, continuationAdmissionIssues } from "./authority-lineage.js";
+import {
+  authorityDeltaApprovalEvidence,
+  authorityDigest,
+  canonicalAuthorityIssues,
+  continuationAdmissionIssues,
+} from "./authority-lineage.js";
 import { kernelDigest } from "./digest.js";
 export { kernelDigest } from "./digest.js";
 
@@ -139,6 +144,7 @@ const EVENT_KIND: Readonly<Record<TaskCommand["kind"], DomainEvent["kind"]>> = {
   reject_plan: "plan_rejected",
   approve_plan: "plan_approved",
   continue_authority: "authority_continued",
+  approve_authority_delta: "authority_continued",
   materialize_work_items: "work_items_materialized",
   transition_work_item: "work_item_transitioned",
   accept_work_item_result: "work_item_result_accepted",
@@ -423,6 +429,83 @@ function preconditions(input: KernelInput): KernelResult | null {
     const issues = continuationAdmissionIssues(input, input.command.record);
     return issues.length > 0 ? rejected("AUTHORITY_SCOPE_EXCEEDED", issues) : null;
   }
+  if (input.command.kind === "approve_authority_delta") {
+    const command = input.command;
+    const parent = input.aggregate.authority_lineage?.at(-1)?.authority;
+    const record = command.record;
+    const observation = record.observation;
+    const child = record.authority;
+    const immutable = parent
+      ? {
+          ...child,
+          digest: parent.digest,
+          repository_fingerprint: parent.repository_fingerprint,
+          scope_roots: parent.scope_roots,
+          repository_effects: parent.repository_effects,
+          provenance: parent.provenance,
+        }
+      : null;
+    const issues =
+      !parent ||
+      input.actor.kind !== "USER" ||
+      input.actor.transport !== "manual" ||
+      input.authority !== null ||
+      command.parent_authority_digest !== parent.digest ||
+      record.approval_mode !== "manual_operator" ||
+      observation?.kind !== "authority_delta" ||
+      observation.request_digest !== command.request_digest ||
+      observation.request_task_revision !== input.aggregate.revision ||
+      observation.repository_evidence_digest === undefined ||
+      observation.previous_fingerprint !== parent.repository_fingerprint ||
+      child.repository_fingerprint !== input.repository_fingerprint ||
+      child.provenance.kind !== "USER" ||
+      child.provenance.actor_id !== input.actor.id ||
+      child.provenance.parent_authority_digest !== parent.digest ||
+      child.provenance.evidence_digest !== parent.provenance.evidence_digest ||
+      observation.evidence_digest !==
+        authorityDeltaApprovalEvidence({
+          task_id: input.aggregate.id,
+          request_digest: command.request_digest,
+          actor_id: input.actor.id,
+        }) ||
+      child.digest !== authorityDigest(child) ||
+      !immutable ||
+      kernelDigest(immutable) !== kernelDigest(parent) ||
+      JSON.stringify(child.scope_roots) !==
+        JSON.stringify(
+          [
+            ...new Set([...parent.scope_roots, ...(observation.added_scope_roots ?? [])]),
+          ].toSorted(),
+        ) ||
+      JSON.stringify(child.repository_effects) !==
+        JSON.stringify(
+          [
+            ...new Set([
+              ...parent.repository_effects,
+              ...(observation.added_repository_effects ?? []),
+            ]),
+          ].toSorted(),
+        ) ||
+      kernelDigest({
+        task_id: input.aggregate.id,
+        task_revision: input.aggregate.revision,
+        plan_revision: parent.plan_revision,
+        plan_digest: parent.plan_digest,
+        parent_authority_digest: parent.digest,
+        repository_identity: parent.repository_identity,
+        previous_fingerprint: parent.repository_fingerprint,
+        repository_fingerprint: input.repository_fingerprint,
+        repository_evidence_digest: observation.repository_evidence_digest,
+        changed_paths: observation.changed_paths,
+        added_scope_roots: observation.added_scope_roots ?? [],
+        added_repository_effects: observation.added_repository_effects ?? [],
+      }) !== command.request_digest ||
+      canonicalAuthorityIssues({
+        ...input.aggregate,
+        authority_lineage: [...(input.aggregate.authority_lineage ?? []), record],
+      }).length > 0;
+    return issues ? rejected("AUTHORITY_SCOPE_EXCEEDED", ["authority_delta_binding"]) : null;
+  }
   const workItemId = authorityWorkItem(input.command);
   if (workItemId !== null) {
     if (input.aggregate.state !== "ACTIVE") {
@@ -701,6 +784,14 @@ export function reduceTaskCommand(input: KernelInput): KernelResult {
       break;
     }
     case "continue_authority": {
+      next = {
+        ...aggregate,
+        revision: aggregate.revision + 1,
+        authority_lineage: [...(aggregate.authority_lineage ?? []), command.record],
+      };
+      break;
+    }
+    case "approve_authority_delta": {
       next = {
         ...aggregate,
         revision: aggregate.revision + 1,

--- a/packages/core/src/tasks/task-kernel/model.ts
+++ b/packages/core/src/tasks/task-kernel/model.ts
@@ -124,10 +124,15 @@ export type CanonicalApprovalMode =
   | "host_user_decision";
 
 export type AuthorityObservation = Readonly<{
-  kind: "plan_amendment" | "repository_implementation";
+  kind: "plan_amendment" | "repository_implementation" | "authority_delta";
   evidence_digest: Sha256Digest;
   previous_fingerprint: Sha256Digest;
   changed_paths: readonly string[];
+  request_digest?: Sha256Digest;
+  added_scope_roots?: readonly string[];
+  added_repository_effects?: readonly string[];
+  request_task_revision?: number;
+  repository_evidence_digest?: Sha256Digest;
 }>;
 
 /** Ordered authority lineage inside the same atomic aggregate as lifecycle state. */
@@ -276,6 +281,14 @@ export type TaskCommand =
       }
     >
   | CommandEnvelope<"continue_authority", { record: CanonicalAuthorityRecord }>
+  | CommandEnvelope<
+      "approve_authority_delta",
+      {
+        parent_authority_digest: Sha256Digest;
+        request_digest: Sha256Digest;
+        record: CanonicalAuthorityRecord;
+      }
+    >
   | CommandEnvelope<"materialize_work_items", { plan_revision: number; plan_digest: Sha256Digest }>
   | CommandEnvelope<
       "transition_work_item",

--- a/packages/core/src/tasks/task-store.ts
+++ b/packages/core/src/tasks/task-store.ts
@@ -155,6 +155,8 @@ export type TaskTokenUsageState = "observed" | "partial" | "unavailable";
 export type TaskTokenUsage = {
   schema_version: 1;
   state: TaskTokenUsageState;
+  cached_input_tokens?: number | null;
+  cached_input_observed_agent_runs?: number;
   input_tokens: number | null;
   output_tokens: number | null;
   reasoning_tokens: number | null;

--- a/packages/spec/schemas/agent-work-order-v2.schema.json
+++ b/packages/spec/schemas/agent-work-order-v2.schema.json
@@ -1038,6 +1038,76 @@
             "authority_digest"
           ],
           "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "properties": {
+            "task_id": {
+              "type": "string",
+              "minLength": 1
+            },
+            "repository_identity": {
+              "type": "string",
+              "pattern": "^sha256:[a-f0-9]{64}$"
+            },
+            "repository_fingerprint": {
+              "type": "string",
+              "pattern": "^sha256:[a-f0-9]{64}$"
+            },
+            "plan_revision": {
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 9007199254740991
+            },
+            "plan_digest": {
+              "type": "string",
+              "pattern": "^sha256:[a-f0-9]{64}$"
+            },
+            "phase": {
+              "type": "string",
+              "const": "inspection"
+            },
+            "work_item_id": {
+              "type": "string",
+              "minLength": 1
+            },
+            "attempt": {
+              "type": "integer",
+              "exclusiveMinimum": 0,
+              "maximum": 9007199254740991
+            },
+            "claim_id": {
+              "type": "string",
+              "minLength": 1
+            },
+            "contract_digest": {
+              "type": "string",
+              "pattern": "^sha256:[a-f0-9]{64}$"
+            },
+            "authority_digest": {
+              "type": "string",
+              "pattern": "^sha256:[a-f0-9]{64}$"
+            },
+            "result_digest": {
+              "type": "string",
+              "pattern": "^sha256:[a-f0-9]{64}$"
+            }
+          },
+          "required": [
+            "task_id",
+            "repository_identity",
+            "repository_fingerprint",
+            "plan_revision",
+            "plan_digest",
+            "phase",
+            "work_item_id",
+            "attempt",
+            "claim_id",
+            "contract_digest",
+            "authority_digest",
+            "result_digest"
+          ],
+          "additionalProperties": false
         }
       ]
     },

--- a/packages/spec/schemas/task-readme-frontmatter.schema.json
+++ b/packages/spec/schemas/task-readme-frontmatter.schema.json
@@ -715,6 +715,23 @@
           "type": "string",
           "enum": ["observed", "partial", "unavailable"]
         },
+        "cached_input_tokens": {
+          "anyOf": [
+            {
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 9007199254740991
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "cached_input_observed_agent_runs": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 9007199254740991
+        },
         "input_tokens": {
           "anyOf": [
             {

--- a/packages/spec/schemas/tasks-export.schema.json
+++ b/packages/spec/schemas/tasks-export.schema.json
@@ -491,6 +491,23 @@
                 "type": "string",
                 "enum": ["observed", "partial", "unavailable"]
               },
+              "cached_input_tokens": {
+                "anyOf": [
+                  {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 9007199254740991
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "cached_input_observed_agent_runs": {
+                "type": "integer",
+                "minimum": 0,
+                "maximum": 9007199254740991
+              },
               "input_tokens": {
                 "anyOf": [
                   {

--- a/schemas/agent-semantic-result.schema.json
+++ b/schemas/agent-semantic-result.schema.json
@@ -866,6 +866,76 @@
                 "authority_digest"
               ],
               "additionalProperties": false
+            },
+            {
+              "type": "object",
+              "properties": {
+                "task_id": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "repository_identity": {
+                  "type": "string",
+                  "pattern": "^sha256:[a-f0-9]{64}$"
+                },
+                "repository_fingerprint": {
+                  "type": "string",
+                  "pattern": "^sha256:[a-f0-9]{64}$"
+                },
+                "plan_revision": {
+                  "type": "integer",
+                  "minimum": 0,
+                  "maximum": 9007199254740991
+                },
+                "plan_digest": {
+                  "type": "string",
+                  "pattern": "^sha256:[a-f0-9]{64}$"
+                },
+                "phase": {
+                  "type": "string",
+                  "const": "inspection"
+                },
+                "work_item_id": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "attempt": {
+                  "type": "integer",
+                  "exclusiveMinimum": 0,
+                  "maximum": 9007199254740991
+                },
+                "claim_id": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "contract_digest": {
+                  "type": "string",
+                  "pattern": "^sha256:[a-f0-9]{64}$"
+                },
+                "authority_digest": {
+                  "type": "string",
+                  "pattern": "^sha256:[a-f0-9]{64}$"
+                },
+                "result_digest": {
+                  "type": "string",
+                  "pattern": "^sha256:[a-f0-9]{64}$"
+                }
+              },
+              "required": [
+                "task_id",
+                "repository_identity",
+                "repository_fingerprint",
+                "plan_revision",
+                "plan_digest",
+                "phase",
+                "work_item_id",
+                "attempt",
+                "claim_id",
+                "contract_digest",
+                "authority_digest",
+                "result_digest"
+              ],
+              "additionalProperties": false
             }
           ]
         },
@@ -2167,6 +2237,76 @@
                 "authority_digest"
               ],
               "additionalProperties": false
+            },
+            {
+              "type": "object",
+              "properties": {
+                "task_id": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "repository_identity": {
+                  "type": "string",
+                  "pattern": "^sha256:[a-f0-9]{64}$"
+                },
+                "repository_fingerprint": {
+                  "type": "string",
+                  "pattern": "^sha256:[a-f0-9]{64}$"
+                },
+                "plan_revision": {
+                  "type": "integer",
+                  "minimum": 0,
+                  "maximum": 9007199254740991
+                },
+                "plan_digest": {
+                  "type": "string",
+                  "pattern": "^sha256:[a-f0-9]{64}$"
+                },
+                "phase": {
+                  "type": "string",
+                  "const": "inspection"
+                },
+                "work_item_id": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "attempt": {
+                  "type": "integer",
+                  "exclusiveMinimum": 0,
+                  "maximum": 9007199254740991
+                },
+                "claim_id": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "contract_digest": {
+                  "type": "string",
+                  "pattern": "^sha256:[a-f0-9]{64}$"
+                },
+                "authority_digest": {
+                  "type": "string",
+                  "pattern": "^sha256:[a-f0-9]{64}$"
+                },
+                "result_digest": {
+                  "type": "string",
+                  "pattern": "^sha256:[a-f0-9]{64}$"
+                }
+              },
+              "required": [
+                "task_id",
+                "repository_identity",
+                "repository_fingerprint",
+                "plan_revision",
+                "plan_digest",
+                "phase",
+                "work_item_id",
+                "attempt",
+                "claim_id",
+                "contract_digest",
+                "authority_digest",
+                "result_digest"
+              ],
+              "additionalProperties": false
             }
           ]
         },
@@ -3466,6 +3606,76 @@
                 "claim_id",
                 "contract_digest",
                 "authority_digest"
+              ],
+              "additionalProperties": false
+            },
+            {
+              "type": "object",
+              "properties": {
+                "task_id": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "repository_identity": {
+                  "type": "string",
+                  "pattern": "^sha256:[a-f0-9]{64}$"
+                },
+                "repository_fingerprint": {
+                  "type": "string",
+                  "pattern": "^sha256:[a-f0-9]{64}$"
+                },
+                "plan_revision": {
+                  "type": "integer",
+                  "minimum": 0,
+                  "maximum": 9007199254740991
+                },
+                "plan_digest": {
+                  "type": "string",
+                  "pattern": "^sha256:[a-f0-9]{64}$"
+                },
+                "phase": {
+                  "type": "string",
+                  "const": "inspection"
+                },
+                "work_item_id": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "attempt": {
+                  "type": "integer",
+                  "exclusiveMinimum": 0,
+                  "maximum": 9007199254740991
+                },
+                "claim_id": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "contract_digest": {
+                  "type": "string",
+                  "pattern": "^sha256:[a-f0-9]{64}$"
+                },
+                "authority_digest": {
+                  "type": "string",
+                  "pattern": "^sha256:[a-f0-9]{64}$"
+                },
+                "result_digest": {
+                  "type": "string",
+                  "pattern": "^sha256:[a-f0-9]{64}$"
+                }
+              },
+              "required": [
+                "task_id",
+                "repository_identity",
+                "repository_fingerprint",
+                "plan_revision",
+                "plan_digest",
+                "phase",
+                "work_item_id",
+                "attempt",
+                "claim_id",
+                "contract_digest",
+                "authority_digest",
+                "result_digest"
               ],
               "additionalProperties": false
             }

--- a/schemas/agent-work-order-v2.schema.json
+++ b/schemas/agent-work-order-v2.schema.json
@@ -1038,6 +1038,76 @@
             "authority_digest"
           ],
           "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "properties": {
+            "task_id": {
+              "type": "string",
+              "minLength": 1
+            },
+            "repository_identity": {
+              "type": "string",
+              "pattern": "^sha256:[a-f0-9]{64}$"
+            },
+            "repository_fingerprint": {
+              "type": "string",
+              "pattern": "^sha256:[a-f0-9]{64}$"
+            },
+            "plan_revision": {
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 9007199254740991
+            },
+            "plan_digest": {
+              "type": "string",
+              "pattern": "^sha256:[a-f0-9]{64}$"
+            },
+            "phase": {
+              "type": "string",
+              "const": "inspection"
+            },
+            "work_item_id": {
+              "type": "string",
+              "minLength": 1
+            },
+            "attempt": {
+              "type": "integer",
+              "exclusiveMinimum": 0,
+              "maximum": 9007199254740991
+            },
+            "claim_id": {
+              "type": "string",
+              "minLength": 1
+            },
+            "contract_digest": {
+              "type": "string",
+              "pattern": "^sha256:[a-f0-9]{64}$"
+            },
+            "authority_digest": {
+              "type": "string",
+              "pattern": "^sha256:[a-f0-9]{64}$"
+            },
+            "result_digest": {
+              "type": "string",
+              "pattern": "^sha256:[a-f0-9]{64}$"
+            }
+          },
+          "required": [
+            "task_id",
+            "repository_identity",
+            "repository_fingerprint",
+            "plan_revision",
+            "plan_digest",
+            "phase",
+            "work_item_id",
+            "attempt",
+            "claim_id",
+            "contract_digest",
+            "authority_digest",
+            "result_digest"
+          ],
+          "additionalProperties": false
         }
       ]
     },

--- a/schemas/task-readme-frontmatter.schema.json
+++ b/schemas/task-readme-frontmatter.schema.json
@@ -715,6 +715,23 @@
           "type": "string",
           "enum": ["observed", "partial", "unavailable"]
         },
+        "cached_input_tokens": {
+          "anyOf": [
+            {
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 9007199254740991
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "cached_input_observed_agent_runs": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 9007199254740991
+        },
         "input_tokens": {
           "anyOf": [
             {

--- a/schemas/tasks-export.schema.json
+++ b/schemas/tasks-export.schema.json
@@ -491,6 +491,23 @@
                 "type": "string",
                 "enum": ["observed", "partial", "unavailable"]
               },
+              "cached_input_tokens": {
+                "anyOf": [
+                  {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 9007199254740991
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "cached_input_observed_agent_runs": {
+                "type": "integer",
+                "minimum": 0,
+                "maximum": 9007199254740991
+              },
               "input_tokens": {
                 "anyOf": [
                   {

--- a/scripts/baselines/agent-efficiency-VN1FN4-after.json
+++ b/scripts/baselines/agent-efficiency-VN1FN4-after.json
@@ -1,0 +1,6355 @@
+{
+  "commits": [
+    {
+      "service_only": true,
+      "sha": "9e0f99960120a41e4056c62403407b76759c2584",
+      "task_ids": [
+        "202609071219-QV0SX9"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "3c45166b31d0a9960f52aa11c3259afd472dd691",
+      "task_ids": [
+        "202609071219-QV0SX9"
+      ]
+    },
+    {
+      "service_only": false,
+      "sha": "9b9bc432eb60fc173548a717c8ec74cabd50c00a",
+      "task_ids": []
+    },
+    {
+      "service_only": false,
+      "sha": "07a55a939b2892abd9aa9c9fae7981d08e0b9c35",
+      "task_ids": []
+    },
+    {
+      "service_only": true,
+      "sha": "080bfea10e63472c9d895c7880d1f4a4dc720bc4",
+      "task_ids": [
+        "202609071219-QV0SX9"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "07e2ff7d228879b9a14a416c261c8f97f38ae287",
+      "task_ids": [
+        "202609071219-QV0SX9"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "082de2c2ca742fd4150dbf7439a2b1fb9f5f79ed",
+      "task_ids": [
+        "202609071219-QV0SX9"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "b36211390f5a1593bccfb1726991120573211292",
+      "task_ids": [
+        "202609071219-QV0SX9"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "c8ce954a6375a78add2fb33b23441ed7ce9b79d4",
+      "task_ids": [
+        "202609071219-QV0SX9"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "36ebe1d928d9f323ed134a1766acba485780b995",
+      "task_ids": [
+        "202609071219-QV0SX9"
+      ]
+    },
+    {
+      "service_only": false,
+      "sha": "b847aa915f64886905be06ccfb30e37544f35d25",
+      "task_ids": [
+        "202609071219-QV0SX9"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "b010b904ce131e171ea19346f91334b32d5de8a0",
+      "task_ids": [
+        "202609071219-QV0SX9"
+      ]
+    },
+    {
+      "service_only": false,
+      "sha": "4e57fd16b87422e1d88b96e7cce2aa85ac8d3c0e",
+      "task_ids": [
+        "202609071219-QV0SX9"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "0b3e88e60f2e34030fefc8b61cba391f236b2c55",
+      "task_ids": [
+        "202609071219-QV0SX9"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "7a9d567a1292a0a8d47bb41a8ba232301946f872",
+      "task_ids": [
+        "202609071219-QV0SX9"
+      ]
+    },
+    {
+      "service_only": false,
+      "sha": "cdaf72b1fa42660466fe8dd986ff87b2bd093f88",
+      "task_ids": [
+        "202609071219-QV0SX9"
+      ]
+    },
+    {
+      "service_only": false,
+      "sha": "cea8e6f8708be9f3f246a21459176543d5bbe7e0",
+      "task_ids": [
+        "202609071219-QV0SX9"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "2639130b3181867f53fa37121783c67c9ef1d064",
+      "task_ids": [
+        "202609071111-Y0Z0VQ"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "d065bf6221d1362a88c8b8054041316bc507ea42",
+      "task_ids": [
+        "202609071111-Y0Z0VQ"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "21f0360ecd16c1065a1088c8b8383bf27a88cf23",
+      "task_ids": [
+        "202609071111-Y0Z0VQ"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "faf628b0b1a989a7196fc768bdd13d47c03f08c8",
+      "task_ids": [
+        "202609071111-Y0Z0VQ"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "03a3f8cae62a7bff1990edd6e63cae1e94b3f860",
+      "task_ids": [
+        "202609071111-Y0Z0VQ"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "9a6fc0dc06200b626d95c9e0d1a060b80fe1e077",
+      "task_ids": [
+        "202609071111-Y0Z0VQ"
+      ]
+    },
+    {
+      "service_only": false,
+      "sha": "cde1de7f515f73fb4324b5064446d87b9e6ce598",
+      "task_ids": [
+        "202609071111-Y0Z0VQ"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "87b4cf46dcddead7252f413367d163adb06aca92",
+      "task_ids": [
+        "202609071111-Y0Z0VQ"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "68df2e923cd9a382998a9f892243d2421b64ec17",
+      "task_ids": [
+        "202609071111-Y0Z0VQ"
+      ]
+    },
+    {
+      "service_only": false,
+      "sha": "d0efb4b12add163221a45b68759fa85847fe0372",
+      "task_ids": [
+        "202609071111-Y0Z0VQ"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "f8a0e2fdaf2f0a9f7f328cc13679681707733b6f",
+      "task_ids": [
+        "202609071111-Y0Z0VQ"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "aa0ab4813d33e56363804d7225ab4052f180bb0c",
+      "task_ids": [
+        "202609071111-Y0Z0VQ"
+      ]
+    },
+    {
+      "service_only": false,
+      "sha": "1e4add62bb52962cd618a55bcef3553b37111ffd",
+      "task_ids": [
+        "202609071111-Y0Z0VQ"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "6142ca0b0f3562f631319bc03aea2db45d8643c9",
+      "task_ids": [
+        "202609071111-Y0Z0VQ"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "a080783870ced46d2f2c11f536bd5daba9b296fa",
+      "task_ids": [
+        "202609071111-Y0Z0VQ"
+      ]
+    },
+    {
+      "service_only": false,
+      "sha": "996e8a5174cfb8a880c8b7bc51be471440b8e325",
+      "task_ids": [
+        "202609071111-Y0Z0VQ"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "9b99271d55b0a1306942eead89a4b2974e3bdc1d",
+      "task_ids": [
+        "202609071111-Y0Z0VQ"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "db12f98164a34e35c88e9e89e87513ca2efab9d2",
+      "task_ids": [
+        "202609071111-Y0Z0VQ"
+      ]
+    },
+    {
+      "service_only": false,
+      "sha": "8456da808bbaf774a54ab0eca19d8ea76769f960",
+      "task_ids": [
+        "202609071111-Y0Z0VQ"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "70c146493dab30a859788ae20cfdeab3cf57f1fd",
+      "task_ids": [
+        "202609071219-QV0SX9"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "c70cf8be9f7315dcd7300e95556bcbf3cdc47cb3",
+      "task_ids": [
+        "202609071219-QV0SX9"
+      ]
+    },
+    {
+      "service_only": false,
+      "sha": "dad52228edd14a7ae9d798c0f5ae03fa5610e141",
+      "task_ids": [
+        "202609061750-Z0XXVD"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "b162edd7b2ee722b0c6f7cb063947975a001765c",
+      "task_ids": [
+        "202609070819-M065D1"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "55e59a4dd5df6ea3de516fe2523b40a8ffb52d21",
+      "task_ids": [
+        "202609070819-M065D1"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "a67fd07cc71439718b114325138b6a08b44b13e4",
+      "task_ids": [
+        "202609070819-M065D1"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "565b0f13273d1c282c141bb7e9be499303e583bd",
+      "task_ids": [
+        "202609070819-M065D1"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "ad68f7a96f1abd2126b9a2c3e61acf57f4384be8",
+      "task_ids": [
+        "202609070819-M065D1"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "57702f371e5a91cc780176f52984bec33a9890b6",
+      "task_ids": [
+        "202609070819-M065D1"
+      ]
+    },
+    {
+      "service_only": false,
+      "sha": "929b932be46d528c36e9083eccbf5fc86d3b7cdc",
+      "task_ids": [
+        "202609070819-M065D1"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "b99c7d87348d22b54cb2a36445fd94cddd732bf5",
+      "task_ids": [
+        "202609070351-6B37B9"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "d2353ae4c6cf5552443e9a60e63cbcfbb99e1e7b",
+      "task_ids": [
+        "202609070351-6B37B9"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "8d9ca51b4fb36ab8adfd85e9729b0adf8147c59c",
+      "task_ids": [
+        "202609070351-6B37B9"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "348a3600a37b39d61ebb4a4ac3f93c642de77198",
+      "task_ids": [
+        "202609070351-6B37B9"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "62a5710867e2fe3158f664a96e832151e91de8db",
+      "task_ids": [
+        "202609070351-6B37B9"
+      ]
+    },
+    {
+      "service_only": false,
+      "sha": "168fe0d0d1c98e97657094c4eb6ad7096848fac1",
+      "task_ids": [
+        "202609070351-6B37B9"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "8c1384303cc702fff2fb881c441cacc6c1c523c2",
+      "task_ids": [
+        "202609070351-6B37B9"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "2f8590f913eaa2cde9184811d7ad2820be33f453",
+      "task_ids": [
+        "202609070351-6B37B9"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "3f7059fbed9fd2fd3a3fbbaedf7af77c14a17233",
+      "task_ids": [
+        "202609070351-6B37B9"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "47dab7082e31791ca89c9fb1cafd0d6afad3dd57",
+      "task_ids": [
+        "202609070351-6B37B9"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "e1f7c52ef394a46eb5e490291ba409a22cccaf6f",
+      "task_ids": [
+        "202609070351-6B37B9"
+      ]
+    },
+    {
+      "service_only": false,
+      "sha": "c376de30e9ab1612f99c44f55890dd834d60c6e5",
+      "task_ids": []
+    },
+    {
+      "service_only": true,
+      "sha": "f8505e8e0edb6d3e420e22cef1620bae2bbdab1d",
+      "task_ids": [
+        "202609070351-6B37B9"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "43227b631a4f7593b60997908519bbb475e4860f",
+      "task_ids": [
+        "202609070351-6B37B9"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "33859c98d6e2dc4cc5a3528b73e7046ea2a96a98",
+      "task_ids": [
+        "202609070351-6B37B9"
+      ]
+    },
+    {
+      "service_only": false,
+      "sha": "68cf65a08ac1a380accf9821c9d3853069011248",
+      "task_ids": [
+        "202609070351-6B37B9"
+      ]
+    },
+    {
+      "service_only": false,
+      "sha": "304f02dc7966f75f74ea2aec083a337572350f0f",
+      "task_ids": [
+        "202609061750-Z0XXVD"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "68b7b240362fe005e4ea5c63ee214c37fc545212",
+      "task_ids": [
+        "202609070233-NG368H"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "b1783ceed8823238095113776d82647763ffbe1b",
+      "task_ids": [
+        "202609070233-NG368H"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "30d74ffe38dc78012602381b811ea4fcd1e4a855",
+      "task_ids": [
+        "202609070233-NG368H"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "185dc17c7eaa22c91fa82b9e481e98bfbb43fe1a",
+      "task_ids": [
+        "202609070233-NG368H"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "201859728a179ded09e43484cfbba117069d48a0",
+      "task_ids": [
+        "202609070233-NG368H"
+      ]
+    },
+    {
+      "service_only": false,
+      "sha": "93ed9b9899f35fb9e4c141f700c28eeb517808b7",
+      "task_ids": [
+        "202609070233-NG368H"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "8ebc48d745af6bbd72540f96c0f8c62748d168c6",
+      "task_ids": [
+        "202609070233-NG368H"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "4f04ff897849a85601dd7dcab7ca1eeceab1f1ee",
+      "task_ids": [
+        "202609070233-NG368H"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "2cab17c9542c83e8dfa4d3dd5bc186cc11e15394",
+      "task_ids": [
+        "202609070233-NG368H"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "b4d0e7acd0b9e47d751e135d47ef4eeaa358e66f",
+      "task_ids": [
+        "202609070233-NG368H"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "492136f731dc3b3c7583f37b22d83f4e6387320b",
+      "task_ids": [
+        "202609070233-NG368H"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "bf210e93cc9bab5d26e9cbc829b6007c70fe51eb",
+      "task_ids": [
+        "202609070233-NG368H"
+      ]
+    },
+    {
+      "service_only": false,
+      "sha": "8afecc9522106f828eda13bd768c00b0c523a6e8",
+      "task_ids": [
+        "202609070233-NG368H"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "81b3fe507426d82ea903d7a63fd6335b583d81b5",
+      "task_ids": [
+        "202609061750-Z0XXVD"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "eba01eac5a6b6c347f7850b4736ae620559b5115",
+      "task_ids": [
+        "202609061750-Z0XXVD"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "327a2b4b31957f9e989449a20b693dca2e444309",
+      "task_ids": [
+        "202609061750-Z0XXVD"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "f0131533865be689bef06bdf41cbe2730ecb0fc4",
+      "task_ids": [
+        "202609061750-Z0XXVD"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "ab635aca8893944fa51ef0ffb0b17afe8630f097",
+      "task_ids": [
+        "202609061750-Z0XXVD"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "59b81b8ee097844214dc09ca89d95caefd5a1fa5",
+      "task_ids": [
+        "202609061750-Z0XXVD"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "60f5e39b85594ff837ab6b719445d4615cd5f42a",
+      "task_ids": [
+        "202609061750-Z0XXVD"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "a2c83d96760c064af9677245abc2535b6b33f68d",
+      "task_ids": [
+        "202609061750-Z0XXVD"
+      ]
+    },
+    {
+      "service_only": false,
+      "sha": "69dff6a91be8ea2832e5065504e0b70d0fa9709f",
+      "task_ids": [
+        "202609061750-Z0XXVD"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "fd95bb6830d2df61a457e181f3ba2633523db65e",
+      "task_ids": [
+        "202609061750-Z0XXVD"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "b8b77e4e755036c2f5e8cdff829533ec1f9d5298",
+      "task_ids": [
+        "202609061750-Z0XXVD"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "6e300c95e95be8e3e538d9e6469ca309f9fbe87f",
+      "task_ids": [
+        "202609061750-Z0XXVD"
+      ]
+    },
+    {
+      "service_only": false,
+      "sha": "b9c18bde3de689c8a57f7abeafee6d69c77ca346",
+      "task_ids": [
+        "202609061750-Z0XXVD"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "e66cbb2a9345224810fd3f6b2489162de2d4b80c",
+      "task_ids": [
+        "202609061750-Z0XXVD"
+      ]
+    },
+    {
+      "service_only": false,
+      "sha": "8ba826b53de8ed163c203fc0d0ada8fb020ca642",
+      "task_ids": [
+        "202609061750-Z0XXVD"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "d6c9f8252eda2990c81abade61064f74ff5ab430",
+      "task_ids": [
+        "202609061750-Z0XXVD"
+      ]
+    },
+    {
+      "service_only": false,
+      "sha": "0530dc68ca31bc8a5b87ab091482bfd06081c873",
+      "task_ids": [
+        "202609061750-Z0XXVD"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "9404b8fc5e74dfa5f93d81a03c7e13b55a06cc13",
+      "task_ids": [
+        "202609061750-Z0XXVD"
+      ]
+    },
+    {
+      "service_only": false,
+      "sha": "86665790e1faee831ccd7dc4d21c111e3af953bf",
+      "task_ids": [
+        "202609061750-Z0XXVD"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "e3a8e6658b2966f0b8ee5d81d4b79a750d2e07ae",
+      "task_ids": [
+        "202609061750-Z0XXVD"
+      ]
+    },
+    {
+      "service_only": false,
+      "sha": "e070a79cd2466cb8b02d91a3731aac63b805cab2",
+      "task_ids": [
+        "202609061750-Z0XXVD"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "9f0dadafc8fb2ccb892503ffd54ac6bfeded1a85",
+      "task_ids": [
+        "202609061750-Z0XXVD"
+      ]
+    },
+    {
+      "service_only": false,
+      "sha": "1f6d5b06fccdc864d4a3721d7891c663d8442ff6",
+      "task_ids": [
+        "202609061750-Z0XXVD"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "196b416399ccb385636b01aacf7e2940d358db69",
+      "task_ids": [
+        "202609061750-Z0XXVD"
+      ]
+    },
+    {
+      "service_only": false,
+      "sha": "41415058404d73e8cd439c088d169637f0ef0d7f",
+      "task_ids": [
+        "202609061750-Z0XXVD"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "a6b00ad7e8d4bc1adadcbbc7083bc14e6882feed",
+      "task_ids": [
+        "202609061750-Z0XXVD"
+      ]
+    },
+    {
+      "service_only": false,
+      "sha": "ddf06df251b8acb3189390793d747741dd0f3e3c",
+      "task_ids": [
+        "202609061750-Z0XXVD"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "eaafbc7886d2b588b83e154815229c85e48ddc46",
+      "task_ids": [
+        "202609061750-Z0XXVD"
+      ]
+    },
+    {
+      "service_only": false,
+      "sha": "c1b560eb0ce149a3a5e5200b192b7128265a62e4",
+      "task_ids": [
+        "202609061750-Z0XXVD"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "2cf836db0fe3ad72ddc751b906f7ac1b436beb4d",
+      "task_ids": [
+        "202609061750-Z0XXVD"
+      ]
+    },
+    {
+      "service_only": false,
+      "sha": "19239f9e62e172de9e679b57e6cb786a2f6970f3",
+      "task_ids": [
+        "202609061750-Z0XXVD"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "da01e181e27bf3cd7bdede1c328e6b2bcdf689ff",
+      "task_ids": [
+        "202609061750-Z0XXVD"
+      ]
+    },
+    {
+      "service_only": false,
+      "sha": "a24cfb6c87e6e2945d587e1a3c7614ce71b8fb4b",
+      "task_ids": [
+        "202609061750-Z0XXVD"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "262da3130bc5628a7641c400c74368ae355000bf",
+      "task_ids": [
+        "202609061636-BW11J6"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "11b53e5f844d8d41b7fd5b5ec082ad7937c0721c",
+      "task_ids": [
+        "202609061636-BW11J6"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "a2564340a3ab3600f2c1278e39293a4499c155c7",
+      "task_ids": [
+        "202609061636-BW11J6"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "ca2bb87f77bbc3ae09edf571e483e98a44f4a9bf",
+      "task_ids": [
+        "202609061636-BW11J6"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "60244110592975d2f933a2384252083080fcf3d1",
+      "task_ids": [
+        "202609061636-BW11J6"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "ba8874a888de07be56ca1ec88c3954c7a0972bd9",
+      "task_ids": [
+        "202609061636-BW11J6"
+      ]
+    },
+    {
+      "service_only": false,
+      "sha": "a4aedd5a03255a560eebe6f6e62ae8328dd7a84b",
+      "task_ids": [
+        "202609061636-BW11J6"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "ec95c2e8030affdc7562c26c2f41dc098b9dc173",
+      "task_ids": [
+        "202609061636-BW11J6"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "19ce338e6fb63ee55c79de6d56a72c7a837fc8f7",
+      "task_ids": [
+        "202609061636-BW11J6"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "f3d1eb3130ab9c067a0503d63e3b043bb6885d3f",
+      "task_ids": [
+        "202609061636-BW11J6"
+      ]
+    },
+    {
+      "service_only": false,
+      "sha": "ad9e51536785a9d31279a2964e4c7f537badc7db",
+      "task_ids": [
+        "202609061636-BW11J6"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "b1e13dec007f8251957c77a887b9a887cc789a82",
+      "task_ids": [
+        "202609060720-NZXQ0E"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "ba67d24ab800fa59b097a563b65a47ddd2df3040",
+      "task_ids": [
+        "202609060720-NZXQ0E"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "467a21903b1ad3bc886702db47454d80834ba4cc",
+      "task_ids": [
+        "202609060720-NZXQ0E"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "e4955798705acb39b67decdd38d8d5555822cce6",
+      "task_ids": [
+        "202609060720-NZXQ0E"
+      ]
+    },
+    {
+      "service_only": false,
+      "sha": "48dda1e008438f65ba6e8a2253b723bde5994751",
+      "task_ids": [
+        "202609060720-NZXQ0E"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "430befb9567c4b34d393fd65aa84e2272ffa266e",
+      "task_ids": [
+        "202609060720-NZXQ0E"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "0183bdf929e4f1287f1a9eab47da83c48aff3fc7",
+      "task_ids": [
+        "202609060720-NZXQ0E"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "66ced0b68f08d835a762267662c2bf82d71ca16a",
+      "task_ids": [
+        "202609060720-NZXQ0E"
+      ]
+    },
+    {
+      "service_only": false,
+      "sha": "7d5e2ef3bac557d785b7ec613eaedbefc656e379",
+      "task_ids": [
+        "202609060720-NZXQ0E"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "ac565f6fb1e401686c6566f8fcf654799be258e6",
+      "task_ids": [
+        "202609060720-NZXQ0E"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "898d06351bcf8975bcec3d321e6a418899d7c6c6",
+      "task_ids": [
+        "202609060720-NZXQ0E"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "ec418b1b334b4efc934fa1a7506a149a7007441c",
+      "task_ids": [
+        "202609060720-NZXQ0E"
+      ]
+    },
+    {
+      "service_only": false,
+      "sha": "8f77e8033e63f503c06801cd8af358cc57f1aa2a",
+      "task_ids": [
+        "202609060720-NZXQ0E"
+      ]
+    },
+    {
+      "service_only": false,
+      "sha": "c74e8f1cddd60375b63cb30d0c3d62538b7fc702",
+      "task_ids": [
+        "202609060720-NZXQ0E"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "7a1731ccc2784fc5d4a1573fc8b8adbacf704689",
+      "task_ids": [
+        "202609060720-NZXQ0E"
+      ]
+    },
+    {
+      "service_only": false,
+      "sha": "736fba555b20672162360b9d5bc5d9205ffc3262",
+      "task_ids": [
+        "202609060720-NZXQ0E"
+      ]
+    },
+    {
+      "service_only": false,
+      "sha": "b33a39fb7c4ae579a74e6550f93ef557307ae645",
+      "task_ids": [
+        "202609060720-NZXQ0E"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "33d00156ba1063f607e4e823d4de714d6466390d",
+      "task_ids": [
+        "202609060720-NZXQ0E"
+      ]
+    },
+    {
+      "service_only": false,
+      "sha": "8ad0c158c5b4a6a9940b7bb62c321f84289f5e6d",
+      "task_ids": [
+        "202609060720-NZXQ0E"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "43f3ba86b40cfae0555ec7775d85d97b5d4c2377",
+      "task_ids": [
+        "202609060720-NZXQ0E"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "e7aae1f7418195dc506b00aef74c951d8831390a",
+      "task_ids": [
+        "202609042327-PH5N6S"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "fdf2dd5b358c2f17aa248a5e90bda436bcdef235",
+      "task_ids": [
+        "202609042327-PH5N6S"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "424c7e7e1659d29ce2963f1ea7981566949430b2",
+      "task_ids": [
+        "202609042327-PH5N6S"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "367024bb03d41c45982ef45ec4d87b058913a265",
+      "task_ids": [
+        "202609042327-PH5N6S"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "801dbd096b1f1b5a6735c3fb24220f38a5067e2f",
+      "task_ids": [
+        "202609042327-PH5N6S"
+      ]
+    },
+    {
+      "service_only": false,
+      "sha": "a25edd68b3639f22fe74be7476df9397c588b304",
+      "task_ids": [
+        "202609042327-PH5N6S"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "86505007bb7171bcfaafd4d0ee2ed1f1e8fab783",
+      "task_ids": [
+        "202609042327-PH5N6S"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "f15f2914fd02ed0372c4c65aced04639cb938f2f",
+      "task_ids": [
+        "202609042327-PH5N6S"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "9626c6364f0aab2a7f7efb3d05b4757a8207c156",
+      "task_ids": [
+        "202609042327-PH5N6S"
+      ]
+    },
+    {
+      "service_only": false,
+      "sha": "572353c8ad3dffbbf455bfcb82ce24d40574ae28",
+      "task_ids": [
+        "202609042327-PH5N6S"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "48d2e75856c3da7d3635946ad7d48f717afb5104",
+      "task_ids": [
+        "202609042327-PH5N6S"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "de6df111e267e997f5056fbfc7c0a2844e0576a0",
+      "task_ids": [
+        "202609042327-PH5N6S"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "ea8830b4bee74c656ed888384625f95046df2218",
+      "task_ids": [
+        "202609042327-PH5N6S"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "5d65025e875e3d533d5b1ad3196b566ee00d0efe",
+      "task_ids": [
+        "202609042327-PH5N6S"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "1c14163429fc67acdeb98b34a7fae404d68ddc38",
+      "task_ids": [
+        "202609042327-PH5N6S"
+      ]
+    },
+    {
+      "service_only": false,
+      "sha": "2e9f7df5ebad103bf6ade9d4cffb750da2dd0318",
+      "task_ids": [
+        "202609042327-PH5N6S"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "a8648b4c439676621ded1296f62b4eeb6720efe0",
+      "task_ids": [
+        "202609042327-PH5N6S"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "1438fcf8c4a38ea3456682c77fc4532dde2c7251",
+      "task_ids": [
+        "202609042327-PH5N6S"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "a5846b477ce0b3bde2fdf4f35a0bd973780bc886",
+      "task_ids": [
+        "202609042327-PH5N6S"
+      ]
+    },
+    {
+      "service_only": false,
+      "sha": "d8298cfe7b38b3b085a44810a4000ad323e67afd",
+      "task_ids": [
+        "202609042327-PH5N6S"
+      ]
+    },
+    {
+      "service_only": false,
+      "sha": "1981b974568071c65b8c0c3f971311de59758d83",
+      "task_ids": [
+        "202609042327-PH5N6S"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "cf909f3246f9227135813776df941f7740094e89",
+      "task_ids": [
+        "202609042327-PH5N6S"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "6bf388900d2c64a1849d2fb396268a67081d021d",
+      "task_ids": [
+        "202609042327-PH5N6S"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "b82739de719c160acb631be6d771c69ccaba1590",
+      "task_ids": [
+        "202609042327-PH5N6S"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "86e9343e668a2aa52883cab40c176b118ad33ffd",
+      "task_ids": [
+        "202609042327-PH5N6S"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "4b0c941f98ae31152ddef4aa925c439e57505225",
+      "task_ids": [
+        "202609042327-PH5N6S"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "e72029c56f3a62185c8af0c88e7cb944e717fa5e",
+      "task_ids": [
+        "202609042327-PH5N6S"
+      ]
+    },
+    {
+      "service_only": false,
+      "sha": "6764bc96f86b48a697e3fdc63ed7f96d6ee15cf1",
+      "task_ids": [
+        "202609042327-PH5N6S"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "556bd57198b1b3c70d3a242dc3e7f3e16f9edd01",
+      "task_ids": [
+        "202609041801-ZVX69C"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "e81a82df8905e1cd2b70e707edaeb54b540afa72",
+      "task_ids": [
+        "202609041801-ZVX69C"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "a4cbbf112295aba5da065449ecaa50394c2efed6",
+      "task_ids": [
+        "202609041801-ZVX69C"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "50d0834079f967679fd56ba98fa311eb7e457335",
+      "task_ids": [
+        "202609041801-ZVX69C"
+      ]
+    },
+    {
+      "service_only": false,
+      "sha": "8701b4ee14a0566d0c1fe97401604fa973847db4",
+      "task_ids": [
+        "202609041801-ZVX69C"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "e01b34f44379df3c04a5956e838aab85129dc8fa",
+      "task_ids": [
+        "202609041801-ZVX69C"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "1e3a1d54e7c1caaed49e899df8d16a28a32290c8",
+      "task_ids": [
+        "202609041801-ZVX69C"
+      ]
+    },
+    {
+      "service_only": false,
+      "sha": "2613ab498a2142b112afcd42351dbe6bb273a223",
+      "task_ids": []
+    },
+    {
+      "service_only": true,
+      "sha": "fbf8853c500b57ab28d42f6e140e6bbe03603f8e",
+      "task_ids": [
+        "202609041801-ZVX69C"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "2b0bcb6d5b595b8c0d9e70281d95a97f4cf1b917",
+      "task_ids": [
+        "202609041801-ZVX69C"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "8f7b0706b69c104806f4591567750ceb58697ce2",
+      "task_ids": [
+        "202609041801-ZVX69C"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "ad262173f6ee46b72668f12bc8b6ab40798338a3",
+      "task_ids": [
+        "202609041801-ZVX69C"
+      ]
+    },
+    {
+      "service_only": false,
+      "sha": "5e35370df7bd24be3cf0c5d59bd17bb1fd99f856",
+      "task_ids": [
+        "202609041801-ZVX69C"
+      ]
+    },
+    {
+      "service_only": false,
+      "sha": "b255ea521a19c0861a939284bc9fa8bdd5816325",
+      "task_ids": [
+        "202609041801-ZVX69C"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "ac91f8bfdd5718221a949f82c607936b77150cf1",
+      "task_ids": [
+        "202609041801-ZVX69C"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "baae32a2e3c5e0c45c1afa823009df3436d2fe67",
+      "task_ids": [
+        "202609041801-ZVX69C"
+      ]
+    },
+    {
+      "service_only": false,
+      "sha": "0bc37e5952e2713f665ee69687b4aab45f83fd54",
+      "task_ids": [
+        "202609041801-ZVX69C"
+      ]
+    },
+    {
+      "service_only": false,
+      "sha": "99fdb3c4cc9123982becb3edebb5bd030885fd0e",
+      "task_ids": [
+        "202609041801-ZVX69C"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "6c866e888b5d8af4bc6b10fc308462e56e3deb76",
+      "task_ids": [
+        "202609041801-ZVX69C"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "3fc391c151ab2f1879ea9eae5c2e8cb73469b787",
+      "task_ids": [
+        "202609041801-ZVX69C"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "218df006de80522a871e7d32b4e6b26de6fdb96a",
+      "task_ids": [
+        "202609041801-ZVX69C"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "4c90e955a1e7f6c577966ee4d7bf873a2e3936aa",
+      "task_ids": [
+        "202609041801-ZVX69C"
+      ]
+    },
+    {
+      "service_only": false,
+      "sha": "1050a0f4856603b998283a05f2caa4cc8ebcca96",
+      "task_ids": [
+        "202609041801-ZVX69C"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "11f06801e10fa00f954bd1d3ed22a5d138d0f46f",
+      "task_ids": [
+        "202609041801-ZVX69C"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "3cd9c9fa22be0b70c1f14d2f2100f5c0503aa3be",
+      "task_ids": [
+        "202609041801-ZVX69C"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "8f006bf84e1215d36d1e1182a190a89958cdaacb",
+      "task_ids": [
+        "202609041801-ZVX69C"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "42463c33c80a49eea4445f2aa6a382a6ab6588ac",
+      "task_ids": [
+        "202609041801-ZVX69C"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "4bed92f9eeac21183a2558bab17c9795a20ec6a7",
+      "task_ids": [
+        "202609041801-ZVX69C"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "09c20ba49b88479a3198f73d0989817e3a6f2895",
+      "task_ids": [
+        "202609041801-ZVX69C"
+      ]
+    },
+    {
+      "service_only": false,
+      "sha": "8b1594fdbddea370c02760dd835f4f98f9caf160",
+      "task_ids": [
+        "202609041801-ZVX69C"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "6e49077db61daed5204b514e7d6e071c190edda6",
+      "task_ids": [
+        "202609031717-PX8PZT"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "b97f2fe710146f34eeccb1bd57bd66f35390dafb",
+      "task_ids": [
+        "202609031717-PX8PZT"
+      ]
+    }
+  ],
+  "digest": "sha256:60c9be411166e867f42697229a64ec713260e34e0f8b45428b2490af6691ab5c",
+  "kind": "agent_efficiency_repository_snapshot",
+  "method": {
+    "artifact_selection": "All committed blobs under .agentplane/tasks; bytes are uncompressed Git blob sizes",
+    "commit_selection": "Last 200 non-merge commits reachable from source",
+    "duplicate_definition": "Identical Git blob object IDs across task artifact paths; no content migration",
+    "exclusions": [
+      "working tree changes",
+      "untracked artifacts",
+      "submodule contents",
+      "merge commits",
+      "private operational journals",
+      "paid provider capture"
+    ],
+    "limitations": [
+      "Usage is the committed supervisor projection, not a new provider capture",
+      "Prepared, delivered and model-read context are distinct and unavailable in historical projections",
+      "Historical WorkItem, role, episode and semantic-repeat attribution is unavailable",
+      "Service commit counts per task overlap for commits touching multiple tasks",
+      "Token totals sum observed fields only; coverage is reported separately"
+    ],
+    "service_commit_definition": "All changed paths are under .agentplane; classification does not imply a removable checkpoint",
+    "task_selection": "Newest 150 task IDs in committed tree, descending lexicographic path order"
+  },
+  "runtime": {
+    "arch": "arm64",
+    "cli_package_object": "0c8855f9089cef8b8d1f95092c0642e4f8f7b663",
+    "measurement_code_digest": "sha256:d761bbeb4bbdbef49347e90467e97ae9ca64d22b04c3911a0a8efe340511dbb4",
+    "node": "v24.18.0",
+    "platform": "darwin"
+  },
+  "schema_version": 1,
+  "source": {
+    "commit": "92efd467a7b045e7e784597168ac21bd41a975a1",
+    "tree": "2e735588bc3189925cb4651b84acfa21b4cb15f7",
+    "tree_listing_digest": "sha256:74a093dcd1616a759228879ec55b992e79443c2b4c78e702944cf361dc6f7b57"
+  },
+  "tasks": [
+    {
+      "artifact_bytes": 335333,
+      "artifact_count": 35,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 107386,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 129554,
+      "readme_object": "48b102ae68e1430f3312eb2c64621a0c6b07ee0b",
+      "readme_path": ".agentplane/tasks/202609071219-QV0SX9/README.md",
+      "roles": null,
+      "service_commits_in_window": 13,
+      "task_id": "202609071219-QV0SX9",
+      "usage": {
+        "agent_runs": 12,
+        "input_tokens": null,
+        "journal_digest": "sha256:1ebf7115b4879387c94098bdfd9a21e40b05fd466cd40df6ac1d579ecd318529",
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "provider_token_telemetry_unavailable",
+        "updated_at": "2026-09-07T15:04:52.952Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 300854,
+      "artifact_count": 20,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 85771,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 93917,
+      "readme_object": "07e7d77e548f3a7894e07d79409d647520dcd2c8",
+      "readme_path": ".agentplane/tasks/202609071111-Y0Z0VQ/README.md",
+      "roles": null,
+      "service_commits_in_window": 14,
+      "task_id": "202609071111-Y0Z0VQ",
+      "usage": {
+        "agent_runs": 7,
+        "input_tokens": null,
+        "journal_digest": "sha256:3df31ec7e71cd6bbec54168fbce181199c1194781cf9a2e989f8dc143f3c063c",
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "provider_token_telemetry_unavailable",
+        "updated_at": "2026-09-07T13:16:09.371Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 198529,
+      "artifact_count": 20,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 58586,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 66436,
+      "readme_object": "30898bef198a23d0759924c0149458b4de72173f",
+      "readme_path": ".agentplane/tasks/202609070819-M065D1/README.md",
+      "roles": null,
+      "service_commits_in_window": 6,
+      "task_id": "202609070819-M065D1",
+      "usage": {
+        "agent_runs": 3,
+        "input_tokens": null,
+        "journal_digest": "sha256:e0d676d0220d10db905bb16ebe81d8c89536c2b65845729edc891f7497899b8c",
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "provider_token_telemetry_unavailable",
+        "updated_at": "2026-09-07T08:44:29.010Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 290544,
+      "artifact_count": 31,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 73588,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 90844,
+      "readme_object": "13e54804bcd3cdd48aae70dffe9839ef22a9f96f",
+      "readme_path": ".agentplane/tasks/202609070351-6B37B9/README.md",
+      "roles": null,
+      "service_commits_in_window": 13,
+      "task_id": "202609070351-6B37B9",
+      "usage": {
+        "agent_runs": 6,
+        "input_tokens": null,
+        "journal_digest": "sha256:94a89bf3a7b8ef576b95127446c37b417639fb2adb7d3e75eede449ce722e147",
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "provider_token_telemetry_unavailable",
+        "updated_at": "2026-09-07T07:54:19.350Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 200396,
+      "artifact_count": 29,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 56356,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 68055,
+      "readme_object": "9f684d5768d98369096b25c18e606facddfe8ba8",
+      "readme_path": ".agentplane/tasks/202609070233-NG368H/README.md",
+      "roles": null,
+      "service_commits_in_window": 11,
+      "task_id": "202609070233-NG368H",
+      "usage": {
+        "agent_runs": 5,
+        "input_tokens": null,
+        "journal_digest": "sha256:569fda7b6ccba9e4907e8e4279326643f1c16d9b570218f27d97369a438ffcab",
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "provider_token_telemetry_unavailable",
+        "updated_at": "2026-09-07T03:21:32.873Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 1456882,
+      "artifact_count": 23,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 715516,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 733157,
+      "readme_object": "a849bb31efefef899019258ea8acf393734fbd30",
+      "readme_path": ".agentplane/tasks/202609061750-Z0XXVD/README.md",
+      "roles": null,
+      "service_commits_in_window": 21,
+      "task_id": "202609061750-Z0XXVD",
+      "usage": {
+        "agent_runs": 46,
+        "input_tokens": null,
+        "journal_digest": "sha256:9d56022cbb52a72c088d0b1f4fb9f448b96a69d5bd01382acbb38f90d243c317",
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "provider_token_telemetry_unavailable",
+        "updated_at": "2026-09-07T01:01:52.434Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 184113,
+      "artifact_count": 21,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 73011,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 84369,
+      "readme_object": "401b8fe47ce09363f60a74edd0337af57e9ec4d3",
+      "readme_path": ".agentplane/tasks/202609061636-BW11J6/README.md",
+      "roles": null,
+      "service_commits_in_window": 9,
+      "task_id": "202609061636-BW11J6",
+      "usage": {
+        "agent_runs": 6,
+        "input_tokens": null,
+        "journal_digest": "sha256:4e28104c22a036f3e88e82da4981575266058b59c7eea2155f562ec5f27954af",
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "provider_token_telemetry_unavailable",
+        "updated_at": "2026-09-06T17:11:06.855Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 727574,
+      "artifact_count": 40,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 270929,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 293991,
+      "readme_object": "bd1779e9295b3fb23740f1f5a074a7c5a2ec3ccf",
+      "readme_path": ".agentplane/tasks/202609060720-NZXQ0E/README.md",
+      "roles": null,
+      "service_commits_in_window": 13,
+      "task_id": "202609060720-NZXQ0E",
+      "usage": {
+        "agent_runs": 23,
+        "input_tokens": null,
+        "journal_digest": "sha256:5d591dce201889a75a133ddb0d5489d3b7aa1fac7b796e9db5f2c75594e52107",
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "provider_token_telemetry_unavailable",
+        "updated_at": "2026-09-06T15:20:16.025Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 724572,
+      "artifact_count": 38,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 190846,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 230583,
+      "readme_object": "9390ac20229fa384c2a716270f957bb3d5590667",
+      "readme_path": ".agentplane/tasks/202609042338-M5G987/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202609042338-M5G987",
+      "usage": {
+        "agent_runs": 16,
+        "input_tokens": null,
+        "journal_digest": "sha256:86fa312617296fc0f3cb42eb917c3099275b0564312c1dda6f904a8d40ea611d",
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "provider_token_telemetry_unavailable",
+        "updated_at": "2026-09-05T03:23:32.408Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 14865306,
+      "artifact_count": 61,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 233044,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 265039,
+      "readme_object": "17006c9c8705bc5c9e676ae45cc36ee2fccb4132",
+      "readme_path": ".agentplane/tasks/202609042327-PH5N6S/README.md",
+      "roles": null,
+      "service_commits_in_window": 22,
+      "task_id": "202609042327-PH5N6S",
+      "usage": {
+        "agent_runs": 17,
+        "input_tokens": null,
+        "journal_digest": "sha256:374e6d9c26f4150c8b0a3e2a3a512cad6fac813484f76b18c6543318f9b7e640",
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "provider_token_telemetry_unavailable",
+        "updated_at": "2026-09-06T16:19:31.818Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 178781,
+      "artifact_count": 20,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 67730,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 76035,
+      "readme_object": "61cf089c6c88e4d1ebcc752c5ae53fba0f01558a",
+      "readme_path": ".agentplane/tasks/202609042212-XR979S/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202609042212-XR979S",
+      "usage": {
+        "agent_runs": 5,
+        "input_tokens": null,
+        "journal_digest": "sha256:1c7111246c156a8e3693b566a7b11f31092f4aa85a26e77d77bb4b1517f88a59",
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "provider_token_telemetry_unavailable",
+        "updated_at": "2026-09-04T23:06:37.186Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 11350833,
+      "artifact_count": 122,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 546704,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 755610,
+      "readme_object": "6d32b78415c3f88231a1291e9bd3ad175564cc19",
+      "readme_path": ".agentplane/tasks/202609041801-ZVX69C/README.md",
+      "roles": null,
+      "service_commits_in_window": 22,
+      "task_id": "202609041801-ZVX69C",
+      "usage": {
+        "agent_runs": 45,
+        "input_tokens": null,
+        "journal_digest": "sha256:3e9beefc524d6313bc447c8d87dd04b15b07eb518d1bdf2a0e9867c31a884db2",
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "provider_token_telemetry_unavailable",
+        "updated_at": "2026-09-06T02:34:32.684Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 195954,
+      "artifact_count": 20,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 54536,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 64542,
+      "readme_object": "902e889165a437170fa307f6ad38285394ef8467",
+      "readme_path": ".agentplane/tasks/202609041447-YHERVV/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202609041447-YHERVV",
+      "usage": {
+        "agent_runs": 3,
+        "input_tokens": null,
+        "journal_digest": "sha256:7bd03cccd5c028f0e3b09cd7834ba47a176362b0b1f8d0502872ef5233164c41",
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "provider_token_telemetry_unavailable",
+        "updated_at": "2026-09-04T16:01:54.018Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 211851,
+      "artifact_count": 20,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 73443,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 85018,
+      "readme_object": "b0b7298b08c6965dc3448a2cf1fcaaee73b1a2bd",
+      "readme_path": ".agentplane/tasks/202609040943-X0G51D/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202609040943-X0G51D",
+      "usage": {
+        "agent_runs": 4,
+        "input_tokens": null,
+        "journal_digest": "sha256:a1ec56e03e5a3db998cc035fd48e7571b9c3739c3f83bc1add4959f669e6acc4",
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "provider_token_telemetry_unavailable",
+        "updated_at": "2026-09-04T10:55:03.882Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 1394271,
+      "artifact_count": 53,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 297849,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 355573,
+      "readme_object": "879762e55d83d59f45160e6c64c40ccf78cb67c9",
+      "readme_path": ".agentplane/tasks/202609032308-F31YXS/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202609032308-F31YXS",
+      "usage": {
+        "agent_runs": 35,
+        "input_tokens": 253622,
+        "journal_digest": "sha256:efa098f833c605e231fbad765ee0dc1a162a0e8f7eb4b2094ef32d867b198195",
+        "observed_agent_runs": 1,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "partial",
+        "total_tokens": 256772,
+        "unavailable_reason": "some_agent_runs_lack_provider_token_telemetry",
+        "updated_at": "2026-09-04T17:29:07.201Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 283990,
+      "artifact_count": 30,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 108640,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 127137,
+      "readme_object": "9c8db4639861c6749240b4ec16a9c6bcef60c51d",
+      "readme_path": ".agentplane/tasks/202609031902-8SH7ZM/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202609031902-8SH7ZM",
+      "usage": {
+        "agent_runs": 9,
+        "input_tokens": null,
+        "journal_digest": "sha256:e49b303a13bb08a26e25f43b9148d27a0c5e62021bc93c25f427680a6083583f",
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "provider_token_telemetry_unavailable",
+        "updated_at": "2026-09-03T20:41:34.018Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 4212631,
+      "artifact_count": 85,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 357653,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 424128,
+      "readme_object": "59df8eba6e092a4b3315a38b706c38f525c5376d",
+      "readme_path": ".agentplane/tasks/202609031717-PX8PZT/README.md",
+      "roles": null,
+      "service_commits_in_window": 2,
+      "task_id": "202609031717-PX8PZT",
+      "usage": {
+        "agent_runs": 34,
+        "input_tokens": null,
+        "journal_digest": "sha256:9de1a0c3092b04ee2dcab5c4472da3c18fd13f4a44e83e9e833c7df9d1e5f33d",
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "provider_token_telemetry_unavailable",
+        "updated_at": "2026-09-05T13:16:23.796Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 667176,
+      "artifact_count": 35,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 281619,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 316445,
+      "readme_object": "ea54a703f626d21fd6024a6c878bccb0baeda1cb",
+      "readme_path": ".agentplane/tasks/202609030849-925NNG/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202609030849-925NNG",
+      "usage": {
+        "agent_runs": 20,
+        "input_tokens": null,
+        "journal_digest": "sha256:d64d42523a8afdcdc6753557f046f4545cfa15c98634613ec4ea9d9868c64ba6",
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "provider_token_telemetry_unavailable",
+        "updated_at": "2026-09-03T14:22:45.670Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 1329223,
+      "artifact_count": 32,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 304951,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 322931,
+      "readme_object": "c452d97e35dcac1fc198d7d86421ef22ae0a9373",
+      "readme_path": ".agentplane/tasks/202609021331-5FPZAB/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202609021331-5FPZAB",
+      "usage": {
+        "agent_runs": 29,
+        "input_tokens": null,
+        "journal_digest": "sha256:5177cceb4fd6aa8798ff4080f682260ac782db9df25f2b20daa9041c7cb958b4",
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "provider_token_telemetry_unavailable",
+        "updated_at": "2026-09-03T16:49:00.615Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 320154,
+      "artifact_count": 41,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 54449,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 71314,
+      "readme_object": "a6f4248326c7fbae717964cfe4b3b16982316a2d",
+      "readme_path": ".agentplane/tasks/202608311713-A0F906/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608311713-A0F906",
+      "usage": {
+        "agent_runs": 9,
+        "input_tokens": null,
+        "journal_digest": "sha256:a82d5441e4f47bd9b88e9d42330c5f4b595740f306ef5bff0957d6e65d86fbc1",
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "provider_token_telemetry_unavailable",
+        "updated_at": "2026-08-31T20:41:07.196Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 494916,
+      "artifact_count": 42,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 109743,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 140927,
+      "readme_object": "82cf1f24fcea7623a773c9632f2b318403385470",
+      "readme_path": ".agentplane/tasks/202608301851-5W3XW6/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608301851-5W3XW6",
+      "usage": {
+        "agent_runs": 11,
+        "input_tokens": null,
+        "journal_digest": "sha256:3abc1a9514524a15e93ae1a4641af4b1c18029c015e7fc351cd1a69354467bcf",
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "provider_token_telemetry_unavailable",
+        "updated_at": "2026-08-30T21:16:04.108Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 209792,
+      "artifact_count": 30,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 45833,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 57621,
+      "readme_object": "21861c941840595f583374fb86fe76c56d2572f4",
+      "readme_path": ".agentplane/tasks/202608300559-3MDRBH/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608300559-3MDRBH",
+      "usage": {
+        "agent_runs": 6,
+        "input_tokens": null,
+        "journal_digest": "sha256:fdd4c5704ed3c2d591155fdb0f4c65e58c1b3ac7bdaa8dc204739d80a267fa59",
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "provider_token_telemetry_unavailable",
+        "updated_at": "2026-08-30T07:43:53.401Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 213675,
+      "artifact_count": 31,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 47100,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 60064,
+      "readme_object": "db472fbad0b905b0f3bf52c05ac3d5533f9a4f52",
+      "readme_path": ".agentplane/tasks/202608300119-ZHYXRS/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608300119-ZHYXRS",
+      "usage": {
+        "agent_runs": 8,
+        "input_tokens": null,
+        "journal_digest": "sha256:d1f250e4f614bd128cf4e4617f8768d04c7a905c47a976f05c03fed20ff0896f",
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "provider_token_telemetry_unavailable",
+        "updated_at": "2026-08-30T02:48:49.112Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 212906,
+      "artifact_count": 24,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 66522,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 81424,
+      "readme_object": "1075b1ef34f51061872110a15fe90c5fc5ddcc7b",
+      "readme_path": ".agentplane/tasks/202608292218-3N0FBK/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608292218-3N0FBK",
+      "usage": {
+        "agent_runs": 8,
+        "input_tokens": null,
+        "journal_digest": "sha256:3844627695bfd74e2bc0da44f2be58ec972b64a3d6af02dbec2b7c19c11ef45a",
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "provider_token_telemetry_unavailable",
+        "updated_at": "2026-08-29T23:38:37.475Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 1132108,
+      "artifact_count": 67,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 182854,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 246639,
+      "readme_object": "765fcde5752fcaa0913f9b92b920d2a27fb9f120",
+      "readme_path": ".agentplane/tasks/202608292032-1K47B8/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608292032-1K47B8",
+      "usage": {
+        "agent_runs": 26,
+        "input_tokens": null,
+        "journal_digest": "sha256:61db20777e166dcbd2c94367dd81b85697ff77d9136c98ce0a125e02b552d892",
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "provider_token_telemetry_unavailable",
+        "updated_at": "2026-08-30T03:20:06.529Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 133077,
+      "artifact_count": 20,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 40312,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 47963,
+      "readme_object": "4f424f3cf32f9492bd1b7c58018ca7bc8164a342",
+      "readme_path": ".agentplane/tasks/202608291505-F5AN0W/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608291505-F5AN0W",
+      "usage": {
+        "agent_runs": 3,
+        "input_tokens": null,
+        "journal_digest": "sha256:4ee2354ae7cecba29a857a501029a80ef26019a08e96481c2d2fd2baaa4d532c",
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "provider_token_telemetry_unavailable",
+        "updated_at": "2026-08-29T15:17:52.774Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 37792815,
+      "artifact_count": 66,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 696273,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 812944,
+      "readme_object": "ad4b2f976cc6ee5d9283be4c928c07aa911e26e1",
+      "readme_path": ".agentplane/tasks/202608291006-2A6BJC/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608291006-2A6BJC",
+      "usage": {
+        "agent_runs": 32,
+        "input_tokens": null,
+        "journal_digest": "sha256:3a4d6be99d1f2f8223e62c686eec544b25fdd647eee9e5ab21c5213abfb59d0c",
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "provider_token_telemetry_unavailable",
+        "updated_at": "2026-08-30T17:02:15.665Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 6322852,
+      "artifact_count": 79,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 1146037,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 1246542,
+      "readme_object": "f50bef650e0949b39ee02ce24866dae2874d4c14",
+      "readme_path": ".agentplane/tasks/202608291006-255K66/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608291006-255K66",
+      "usage": {
+        "agent_runs": 51,
+        "input_tokens": 378921,
+        "journal_digest": "sha256:c42029f7a79c6cf993ee1b971a08d66023df46eb3cbdf127b7e9c4ed2a83998b",
+        "observed_agent_runs": 1,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "partial",
+        "total_tokens": 383800,
+        "unavailable_reason": "some_agent_runs_lack_provider_token_telemetry",
+        "updated_at": "2026-09-02T13:03:09.273Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 2429477,
+      "artifact_count": 74,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 172133,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 221508,
+      "readme_object": "8966e3c252372274551a8e3fef2aaca2fad6a693",
+      "readme_path": ".agentplane/tasks/202608291005-K5TG4D/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608291005-K5TG4D",
+      "usage": {
+        "agent_runs": 18,
+        "input_tokens": null,
+        "journal_digest": "sha256:7cb63dac8eb93aa11606f9340deb46446e7d72e69cec176312e57b3444ee7aeb",
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "provider_token_telemetry_unavailable",
+        "updated_at": "2026-08-29T18:59:28.010Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 250092,
+      "artifact_count": 34,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 66609,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 83132,
+      "readme_object": "5c96676a5c579ecc9e9cc2fdae35e852caa92fba",
+      "readme_path": ".agentplane/tasks/202608290920-1PZGG8/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608290920-1PZGG8",
+      "usage": {
+        "agent_runs": 11,
+        "input_tokens": null,
+        "journal_digest": "sha256:ee3858dd95f6eca0f0bfc7f8c6249802bbe20c5d20d1cfce3595da7e5df45b43",
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "provider_token_telemetry_unavailable",
+        "updated_at": "2026-08-29T11:21:43.145Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 867735,
+      "artifact_count": 63,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 155422,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 194291,
+      "readme_object": "e90f63474840a6ea9e46e6da9c107d6986f2103e",
+      "readme_path": ".agentplane/tasks/202608290844-7JCQPF/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608290844-7JCQPF",
+      "usage": {
+        "agent_runs": 20,
+        "input_tokens": null,
+        "journal_digest": "sha256:f53569e941d84e69a595c3bc60e4bc4fb690b7a8145fac97df1b7c6d82241bde",
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "provider_token_telemetry_unavailable",
+        "updated_at": "2026-08-29T17:02:27.493Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 174482,
+      "artifact_count": 20,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 49422,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 60080,
+      "readme_object": "91d09c32291763a6c05354e0ff8ad66c4c64bd45",
+      "readme_path": ".agentplane/tasks/202608281151-WQ89A1/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608281151-WQ89A1",
+      "usage": {
+        "agent_runs": 3,
+        "input_tokens": null,
+        "journal_digest": "sha256:8035c8f0b458e8a032c7ed05e67f77a4c82a40d6ec54d8481f6e32e39becf586",
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "provider_token_telemetry_unavailable",
+        "updated_at": "2026-08-28T15:07:18.312Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 190859,
+      "artifact_count": 20,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 48143,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 58388,
+      "readme_object": "4b76ad30a085b619c43b56cf9fd871cc8cac5117",
+      "readme_path": ".agentplane/tasks/202608280614-PCBY2N/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608280614-PCBY2N",
+      "usage": {
+        "agent_runs": 3,
+        "input_tokens": null,
+        "journal_digest": "sha256:77b78e7becf42113506c88beae6b8f61a94b57a5d88e69f4b8c84b8a37a821d7",
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "provider_token_telemetry_unavailable",
+        "updated_at": "2026-08-28T11:30:30.152Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 1144203,
+      "artifact_count": 49,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 160849,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 191215,
+      "readme_object": "f0de59044ebc5fda0a337e16f73b9cd2db367384",
+      "readme_path": ".agentplane/tasks/202608280529-59VB06/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608280529-59VB06",
+      "usage": {
+        "agent_runs": 15,
+        "input_tokens": null,
+        "journal_digest": "sha256:6f969edb54bf02f93dd5f4311ceeb920b5690dbbeed129c4e51e4bb254f825fe",
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "provider_token_telemetry_unavailable",
+        "updated_at": "2026-08-28T18:53:55.196Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 416732,
+      "artifact_count": 40,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 73745,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 94134,
+      "readme_object": "dd9cab8492599421f09a94156831ed8e79f3fac8",
+      "readme_path": ".agentplane/tasks/202608280009-QMVHM2/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608280009-QMVHM2",
+      "usage": {
+        "agent_runs": 8,
+        "input_tokens": null,
+        "journal_digest": "sha256:96cf94f0249350e2c53de8107945ff138fd5986793589379b3eb5c4f54017432",
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "provider_token_telemetry_unavailable",
+        "updated_at": "2026-08-28T05:15:15.433Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 295323,
+      "artifact_count": 39,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 61419,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 78533,
+      "readme_object": "ffaf203753002e9a3892e1d7c6d949add8d4011c",
+      "readme_path": ".agentplane/tasks/202608272229-CFKR4P/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608272229-CFKR4P",
+      "usage": {
+        "agent_runs": 8,
+        "input_tokens": null,
+        "journal_digest": "sha256:7ab16ec17e1da9654da60cef68af47b2e77dc17a0892578524251fc796e2b176",
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "provider_token_telemetry_unavailable",
+        "updated_at": "2026-08-28T05:39:28.449Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 251953,
+      "artifact_count": 32,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 63083,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 82374,
+      "readme_object": "9c7dd7528efa2b17e9118726b4f24d642cc21b73",
+      "readme_path": ".agentplane/tasks/202608271659-AD3030/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608271659-AD3030",
+      "usage": {
+        "agent_runs": 9,
+        "input_tokens": null,
+        "journal_digest": "sha256:b8d0fa39dd7f4b40d44b47d85b8fdf5cef75236190ea6208aef25b4e4a047e6a",
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "provider_token_telemetry_unavailable",
+        "updated_at": "2026-08-27T23:33:45.947Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 169614,
+      "artifact_count": 20,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 45022,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 53773,
+      "readme_object": "e53c28f179f6f643bdc4553730eafdadbac9e9c2",
+      "readme_path": ".agentplane/tasks/202608271649-DVNTRR/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608271649-DVNTRR",
+      "usage": {
+        "agent_runs": 3,
+        "input_tokens": null,
+        "journal_digest": "sha256:4edd76474f8b59ac1ebd4e6ec8b9d2a3e8562a1579fff6d994a98967d24cebec",
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "provider_token_telemetry_unavailable",
+        "updated_at": "2026-08-27T17:09:25.567Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 188937,
+      "artifact_count": 21,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 56406,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 66341,
+      "readme_object": "6c04611f25773303728c8959cfc0cb19e0d7d89a",
+      "readme_path": ".agentplane/tasks/202608271544-1TDVPJ/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608271544-1TDVPJ",
+      "usage": {
+        "agent_runs": 5,
+        "input_tokens": null,
+        "journal_digest": "sha256:71f7f8c2a407745cd3fdaabead59b12e7a3e2580bd12f8cbe03428da32a6bfa0",
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "provider_token_telemetry_unavailable",
+        "updated_at": "2026-08-27T16:29:31.721Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 700365,
+      "artifact_count": 41,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 185442,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 208423,
+      "readme_object": "aeebb7c5b55d82c506061e8ed2149315df740101",
+      "readme_path": ".agentplane/tasks/202608271538-T21JCA/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608271538-T21JCA",
+      "usage": {
+        "agent_runs": 15,
+        "input_tokens": null,
+        "journal_digest": "sha256:580e23750edaa054bac4944baf4e0a8532f10ef031e66e60dd435b7b28d3683c",
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "provider_token_telemetry_unavailable",
+        "updated_at": "2026-08-27T19:45:26.431Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 206260,
+      "artifact_count": 20,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 50272,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 59717,
+      "readme_object": "fa9fc54ef18ffc39bb737f08ecb187cd4729d352",
+      "readme_path": ".agentplane/tasks/202608271520-175BQX/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608271520-175BQX",
+      "usage": {
+        "agent_runs": 3,
+        "input_tokens": null,
+        "journal_digest": "sha256:8326489c4df2fae4178e4d31870acafd831b9db4210b1ea1181f37567df3aff8",
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "provider_token_telemetry_unavailable",
+        "updated_at": "2026-08-27T16:37:02.017Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 162680,
+      "artifact_count": 20,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 43995,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 52484,
+      "readme_object": "35ac3b118629b3b2ea9961ffe0159556ea7712ac",
+      "readme_path": ".agentplane/tasks/202608271502-J6B4RW/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608271502-J6B4RW",
+      "usage": {
+        "agent_runs": 3,
+        "input_tokens": null,
+        "journal_digest": "sha256:13cdb8cf898d2c83789882ca945655c7279564d46fd140f508b6981e6f59047f",
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "provider_token_telemetry_unavailable",
+        "updated_at": "2026-08-27T15:47:46.664Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 177629,
+      "artifact_count": 21,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 44238,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 53670,
+      "readme_object": "7c221a23cdbe2242ce613e4eddd4e449b9fd4ee2",
+      "readme_path": ".agentplane/tasks/202608271450-TZHW4C/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608271450-TZHW4C",
+      "usage": {
+        "agent_runs": 4,
+        "input_tokens": null,
+        "journal_digest": "sha256:33058237068e9ae133af9c29bf1d8d54420ea06951925dcc82fbde3f828a03da",
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "provider_token_telemetry_unavailable",
+        "updated_at": "2026-08-27T16:48:47.224Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 162005,
+      "artifact_count": 21,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 44580,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 53667,
+      "readme_object": "464e8f26ece0389eae7d3910fdbb2fe559cff272",
+      "readme_path": ".agentplane/tasks/202608271441-DVEMAE/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608271441-DVEMAE",
+      "usage": {
+        "agent_runs": 4,
+        "input_tokens": null,
+        "journal_digest": "sha256:d2e9f65afdb146821e771e1da46af50c9d6aaf52c45ddf2b2563d0eac95df5bc",
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "provider_token_telemetry_unavailable",
+        "updated_at": "2026-08-27T16:16:59.917Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 202615,
+      "artifact_count": 20,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 65766,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 75328,
+      "readme_object": "5b4c7a0132cc3f3bdd286aab83537a23189ea802",
+      "readme_path": ".agentplane/tasks/202608271425-9EWJA1/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608271425-9EWJA1",
+      "usage": {
+        "agent_runs": 4,
+        "input_tokens": null,
+        "journal_digest": "sha256:41d8d4b0f0a9f3d895e8d4c6c212e967275d790fb6faf6535861f2b9135a432a",
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "provider_token_telemetry_unavailable",
+        "updated_at": "2026-08-27T14:53:45.543Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 177147,
+      "artifact_count": 22,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 48376,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 59492,
+      "readme_object": "dbe1cc90cde1c2da97a615f93bbba9741f6538ad",
+      "readme_path": ".agentplane/tasks/202608271358-G0N9P4/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608271358-G0N9P4",
+      "usage": {
+        "agent_runs": 5,
+        "input_tokens": null,
+        "journal_digest": "sha256:4dccf2d36623fbccb76c3d7f5b39076f849c7e75020d2127a588f854e57d0dd4",
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "provider_token_telemetry_unavailable",
+        "updated_at": "2026-08-27T14:47:16.004Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 201047,
+      "artifact_count": 21,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 70516,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 79640,
+      "readme_object": "6c42d42b25d3dd271eb41d0c79cbe0e0af5713af",
+      "readme_path": ".agentplane/tasks/202608271251-GHHA0Q/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608271251-GHHA0Q",
+      "usage": {
+        "agent_runs": 10,
+        "input_tokens": null,
+        "journal_digest": "sha256:58f7e89a395f4ceacf1e7bce2220179d6bc95d99c70c57145dee4666b14c89a1",
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "provider_token_telemetry_unavailable",
+        "updated_at": "2026-08-27T13:27:17.131Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 209489,
+      "artifact_count": 27,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 54906,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 74312,
+      "readme_object": "22a8d11d6b1bc3816a5535335041b0959c0ecca1",
+      "readme_path": ".agentplane/tasks/202608262034-QVVB66/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608262034-QVVB66",
+      "usage": {
+        "agent_runs": 11,
+        "input_tokens": null,
+        "journal_digest": "sha256:912d4a5921d3b1e167f0f843a774d278f69e08f8bd5d18256a195ae1c4b875ec",
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "provider_token_telemetry_unavailable",
+        "updated_at": "2026-08-26T23:26:37.373Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 714030,
+      "artifact_count": 60,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 137519,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 184498,
+      "readme_object": "86d156e38a961308e054eb3050816186058ab763",
+      "readme_path": ".agentplane/tasks/202608261249-BXQZ97/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608261249-BXQZ97",
+      "usage": {
+        "agent_runs": 24,
+        "input_tokens": null,
+        "journal_digest": "sha256:d03cc743b4dc72c9ce144204f1f13efec8616c80c8c721b6eb0edd25fab55164",
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "provider_token_telemetry_unavailable",
+        "updated_at": "2026-08-26T18:51:44.214Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 203840,
+      "artifact_count": 23,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 67772,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 82300,
+      "readme_object": "5b01df36e934fed38170e32e5ddd0d7bce29fac2",
+      "readme_path": ".agentplane/tasks/202608260947-C6WV4T/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608260947-C6WV4T",
+      "usage": {
+        "agent_runs": 10,
+        "input_tokens": null,
+        "journal_digest": "sha256:6f086f5a7d313f1c5a2efed04cf4376c79f4bc85b76efe03b59cb471248794ab",
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "provider_token_telemetry_unavailable",
+        "updated_at": "2026-08-26T10:56:47.786Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 8174016,
+      "artifact_count": 69,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 619551,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 656327,
+      "readme_object": "d2ee7a916910b79a0a54d7731c2108cf7bdf756b",
+      "readme_path": ".agentplane/tasks/202608251706-V287W1/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608251706-V287W1",
+      "usage": {
+        "agent_runs": 17,
+        "input_tokens": null,
+        "journal_digest": "sha256:3e77aec96705bedc6e6e028141e8b94e69f78eaec25b71de66b87f10cbe4ee19",
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "provider_token_telemetry_unavailable",
+        "updated_at": "2026-08-30T08:38:51.059Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 155138,
+      "artifact_count": 20,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 43074,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 50990,
+      "readme_object": "4dbe4941bbe77f02bb67d45c58dca1008688066a",
+      "readme_path": ".agentplane/tasks/202608250015-DZ61YB/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608250015-DZ61YB",
+      "usage": {
+        "agent_runs": 3,
+        "input_tokens": null,
+        "journal_digest": "sha256:92c2fbbe8c9ec2fa16b890c8baf842262b525db5acf94aa39f13f6690942352e",
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "provider_token_telemetry_unavailable",
+        "updated_at": "2026-08-25T01:06:09.566Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 313056,
+      "artifact_count": 36,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 65188,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 85949,
+      "readme_object": "812cf26bea2df1ce1c491a92f7fc0fb2b02ca942",
+      "readme_path": ".agentplane/tasks/202608242233-KTFFN7/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608242233-KTFFN7",
+      "usage": {
+        "agent_runs": 11,
+        "input_tokens": null,
+        "journal_digest": "sha256:cc5b9c84383874bcab421f6b9a160bb1a359d62fd4e7e6a7dd45b3335559de7c",
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "provider_token_telemetry_unavailable",
+        "updated_at": "2026-08-25T03:30:42.794Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 205047,
+      "artifact_count": 23,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 55657,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 67452,
+      "readme_object": "43be63fad5ac946b1762936a8059dd20d876b48d",
+      "readme_path": ".agentplane/tasks/202608230243-BCEYJ9/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608230243-BCEYJ9",
+      "usage": {
+        "agent_runs": 7,
+        "input_tokens": null,
+        "journal_digest": "sha256:6e5848ff48b5d2852b47bd81123bee66f5b42f41f60ebe567be59fb9c69f0793",
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "provider_token_telemetry_unavailable",
+        "updated_at": "2026-08-23T04:20:13.087Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 304930,
+      "artifact_count": 57,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 64971,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 80404,
+      "readme_object": "dc59ababdef8f7c785f07342981c2ee3dc9c06e6",
+      "readme_path": ".agentplane/tasks/202608230020-TEK7WE/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608230020-TEK7WE",
+      "usage": {
+        "agent_runs": 18,
+        "input_tokens": null,
+        "journal_digest": "sha256:544d7274c067f301893acf279ef48c87accd794e07662dfaf60b42094d6107c9",
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "provider_token_telemetry_unavailable",
+        "updated_at": "2026-08-23T05:06:19.996Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 127643,
+      "artifact_count": 13,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 49529,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 65495,
+      "readme_object": "d2c144f038c50ce032d8b96e12d461f21478fbfc",
+      "readme_path": ".agentplane/tasks/202608222129-K0TGS4/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608222129-K0TGS4",
+      "usage": {
+        "agent_runs": 0,
+        "input_tokens": null,
+        "journal_digest": null,
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "unavailable",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "supervisor_journal_missing",
+        "updated_at": "2026-08-23T06:55:16.559Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 888273,
+      "artifact_count": 23,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 115210,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 129893,
+      "readme_object": "6c1bc194d076f5ad3d4b6a77df4bc7850eaa19c7",
+      "readme_path": ".agentplane/tasks/202608222117-HQ5AA4/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608222117-HQ5AA4",
+      "usage": {
+        "agent_runs": 8,
+        "input_tokens": null,
+        "journal_digest": "sha256:83ff0775f9cb01685a777d1798a6bf52e88909136a6c18e41657b56fde0da6fb",
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "provider_token_telemetry_unavailable",
+        "updated_at": "2026-08-23T07:53:10.371Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 2196345,
+      "artifact_count": 47,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 139810,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 159122,
+      "readme_object": "b2d164cd68b6a2a13e79b44785cb399144c6fb0d",
+      "readme_path": ".agentplane/tasks/202608222055-1DKNTY/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608222055-1DKNTY",
+      "usage": {
+        "agent_runs": 10,
+        "input_tokens": null,
+        "journal_digest": "sha256:00c4290283d4e17b969d1bc888f2248e0b80f513860d5e26733b738242aa06cf",
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "provider_token_telemetry_unavailable",
+        "updated_at": "2026-08-23T08:54:28.157Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 221304,
+      "artifact_count": 41,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 42488,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 54393,
+      "readme_object": "8556d1402c3a62e213fce817d8ffde58cfd1ee7c",
+      "readme_path": ".agentplane/tasks/202608221939-911DRN/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608221939-911DRN",
+      "usage": {
+        "agent_runs": 5,
+        "input_tokens": null,
+        "journal_digest": "sha256:27b7c3cd72a00801f1dab2d2c29f51ab8a5bfd58f2fa43bd71d4595a7b51950f",
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "provider_token_telemetry_unavailable",
+        "updated_at": "2026-08-22T20:09:25.399Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 288332,
+      "artifact_count": 35,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 58530,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 77927,
+      "readme_object": "be69de1ae16dfdb2b1691223acf765e9dfaeb1c3",
+      "readme_path": ".agentplane/tasks/202608221545-ZCYV3B/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608221545-ZCYV3B",
+      "usage": {
+        "agent_runs": 11,
+        "input_tokens": null,
+        "journal_digest": "sha256:b31726556c46954a585f075555cee9f59d66414a8effd3d87f7227ce2e902f5a",
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "provider_token_telemetry_unavailable",
+        "updated_at": "2026-08-22T18:42:25.588Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 140466,
+      "artifact_count": 21,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 33829,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 42670,
+      "readme_object": "f6f3ceb6e478b2df033999e628caea6d720f6985",
+      "readme_path": ".agentplane/tasks/202608221511-ZD76VS/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608221511-ZD76VS",
+      "usage": {
+        "agent_runs": 3,
+        "input_tokens": null,
+        "journal_digest": "sha256:28242aaf23353da51dc7a6f0a54070c7b20bdde16f23940b6f391cb43e5ab9b8",
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "provider_token_telemetry_unavailable",
+        "updated_at": "2026-08-22T19:08:39.137Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 287663,
+      "artifact_count": 44,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 57414,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 80295,
+      "readme_object": "b6cf22ce735ab141c7b9e525a4de4be3e2455e0a",
+      "readme_path": ".agentplane/tasks/202608221335-6DSF3R/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608221335-6DSF3R",
+      "usage": {
+        "agent_runs": 11,
+        "input_tokens": null,
+        "journal_digest": "sha256:540610484ede76f2785e5cb41b5b1ac48d955107357f91969aa60f759cde80a7",
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "provider_token_telemetry_unavailable",
+        "updated_at": "2026-08-22T14:42:04.478Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 120337,
+      "artifact_count": 20,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 29922,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 34928,
+      "readme_object": "a54cb1a5fb14e2597c4e8d8b55e60855a537168f",
+      "readme_path": ".agentplane/tasks/202608221158-P5RSA8/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608221158-P5RSA8",
+      "usage": {
+        "agent_runs": 3,
+        "input_tokens": null,
+        "journal_digest": "sha256:5e459e1bef5981caa90cbe4cea520ad48f876e54438297331fd783ba4e0851e9",
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "provider_token_telemetry_unavailable",
+        "updated_at": "2026-08-22T12:06:26.132Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 122545,
+      "artifact_count": 20,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 31714,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 37328,
+      "readme_object": "a414ea5dfe588753a268a6dae8bc1ab2092335b7",
+      "readme_path": ".agentplane/tasks/202608221115-2H0QP2/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608221115-2H0QP2",
+      "usage": {
+        "agent_runs": 3,
+        "input_tokens": null,
+        "journal_digest": "sha256:7c0aada38fdbd7bd3be93720700e367f122e5ba22fe0480693fd28328660a7a2",
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "provider_token_telemetry_unavailable",
+        "updated_at": "2026-08-22T11:21:39.038Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 217052,
+      "artifact_count": 30,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 43981,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 58355,
+      "readme_object": "1f211c49e1014071bfec1850be46ea2d2ef7325b",
+      "readme_path": ".agentplane/tasks/202608221017-2HT3N7/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608221017-2HT3N7",
+      "usage": {
+        "agent_runs": 3,
+        "input_tokens": null,
+        "journal_digest": "sha256:f3e333f2e58c10d8953fb2a5aeb9fd084ded223580061927fe1f8778e11808e2",
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "provider_token_telemetry_unavailable",
+        "updated_at": "2026-08-22T11:00:04.544Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 505872,
+      "artifact_count": 55,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 101351,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 130840,
+      "readme_object": "920a89c4fbf2dbf023d566d1a0a1e98cc79483e5",
+      "readme_path": ".agentplane/tasks/202608220538-SVC324/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608220538-SVC324",
+      "usage": {
+        "agent_runs": 13,
+        "input_tokens": null,
+        "journal_digest": "sha256:f58a665570e5bf447f81c114a3a126de7727361f7ee741b4beb8bb5a84631c4e",
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "provider_token_telemetry_unavailable",
+        "updated_at": "2026-08-22T07:35:51.339Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 203946,
+      "artifact_count": 26,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 45535,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 75098,
+      "readme_object": "7157e9b9fa8bf8722799e896fd43d2d30a709909",
+      "readme_path": ".agentplane/tasks/202608212254-WR57ZD/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608212254-WR57ZD",
+      "usage": {
+        "agent_runs": 0,
+        "input_tokens": null,
+        "journal_digest": null,
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "unavailable",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "supervisor_journal_missing",
+        "updated_at": "2026-08-22T01:02:18.659Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 6386926,
+      "artifact_count": 154,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 161810,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 265178,
+      "readme_object": "a7daf894594cfe897714baddba2bd3297422e9bc",
+      "readme_path": ".agentplane/tasks/202608212244-6XZAYD/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608212244-6XZAYD",
+      "usage": {
+        "agent_runs": 38,
+        "input_tokens": null,
+        "journal_digest": "sha256:d5351cf3f7e2c390c53d69a27859984e5cfbd42863a76219522de4a646088720",
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "provider_token_telemetry_unavailable",
+        "updated_at": "2026-08-22T04:47:58.149Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 248725,
+      "artifact_count": 44,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 36038,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 52353,
+      "readme_object": "6d6397138fdc5edb127554984c66e5c6455e9833",
+      "readme_path": ".agentplane/tasks/202608211236-XEC2NE/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608211236-XEC2NE",
+      "usage": {
+        "agent_runs": 9,
+        "input_tokens": null,
+        "journal_digest": "sha256:d42a81a64557047ce6aa8183cb6560d24e43b1954e7b4b4ab6d3b4991f9a0bad",
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "provider_token_telemetry_unavailable",
+        "updated_at": "2026-08-21T21:37:38.539Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 6785172,
+      "artifact_count": 205,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 221078,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 333712,
+      "readme_object": "5e8f677b51d33435e60919253428e1f90df18b74",
+      "readme_path": ".agentplane/tasks/202608211020-FGAPJC/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608211020-FGAPJC",
+      "usage": {
+        "agent_runs": 60,
+        "input_tokens": null,
+        "journal_digest": "sha256:142f2183f77e6c69f744cc68de25bb554863b5c10e6a4f3bbd0604de2247d6ea",
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "provider_token_telemetry_unavailable",
+        "updated_at": "2026-08-21T19:33:27.415Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 288837,
+      "artifact_count": 50,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 39846,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 55709,
+      "readme_object": "bebdbec480e44f1d01bdec8730a5a5fd0a70c4b4",
+      "readme_path": ".agentplane/tasks/202608211010-X9X57M/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608211010-X9X57M",
+      "usage": {
+        "agent_runs": 11,
+        "input_tokens": null,
+        "journal_digest": "sha256:96b7f6a20630be6f37355fbcd53cf82b2926dc5b12ecd94af26f9eec80161e53",
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "provider_token_telemetry_unavailable",
+        "updated_at": "2026-08-21T12:21:38.456Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 106650,
+      "artifact_count": 20,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 16253,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 21807,
+      "readme_object": "46c23052619880fc2d11da02c2996f18d42a5d95",
+      "readme_path": ".agentplane/tasks/202608210853-0FYGE3/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608210853-0FYGE3",
+      "usage": {
+        "agent_runs": 3,
+        "input_tokens": null,
+        "journal_digest": "sha256:fa5a997bd8bffb700c8afefcecaff5ead33652c097aff552485bf67ce0e3ef63",
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "provider_token_telemetry_unavailable",
+        "updated_at": "2026-08-21T09:17:15.920Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 259416,
+      "artifact_count": 43,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 30225,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 44496,
+      "readme_object": "c11438e122ae3e29e0f023270adf4b123d021f97",
+      "readme_path": ".agentplane/tasks/202608202141-WC5RF1/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608202141-WC5RF1",
+      "usage": {
+        "agent_runs": 15,
+        "input_tokens": null,
+        "journal_digest": "sha256:6f5d505bb50917d70f67256f250ae51a791a3a53ac42993353809b59637d947e",
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "provider_token_telemetry_unavailable",
+        "updated_at": "2026-08-20T23:22:34.417Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 195278,
+      "artifact_count": 19,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 16285,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 21789,
+      "readme_object": "994c7b84a4eeeb3301bebe4a435539e92e300c37",
+      "readme_path": ".agentplane/tasks/202608202133-1C8P0N/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608202133-1C8P0N",
+      "usage": {
+        "agent_runs": 4,
+        "input_tokens": null,
+        "journal_digest": "sha256:eb490356f874554d49919e317f508fcc1a82ad140642d9d7dc7bd979f602c0d9",
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "provider_token_telemetry_unavailable",
+        "updated_at": "2026-08-20T22:15:57.621Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 345898,
+      "artifact_count": 42,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 73783,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 106115,
+      "readme_object": "ccf38ee7a168344eb3a53bcb48931350f4b76e92",
+      "readme_path": ".agentplane/tasks/202608202112-E6CDHP/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608202112-E6CDHP",
+      "usage": {
+        "agent_runs": 15,
+        "input_tokens": null,
+        "journal_digest": "sha256:838aafe1ecd3ef40bcb91848725baaac2a16e4949875625b8c0d7526b20dfb12",
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "provider_token_telemetry_unavailable",
+        "updated_at": "2026-08-21T22:15:02.975Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 1084228,
+      "artifact_count": 51,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 50484,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 71928,
+      "readme_object": "9554d862941aadef5faa90fe253e58ffafca397b",
+      "readme_path": ".agentplane/tasks/202608201524-TRM5DT/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608201524-TRM5DT",
+      "usage": {
+        "agent_runs": 11,
+        "input_tokens": null,
+        "journal_digest": "sha256:a51837e7fffd9c4a7e3945678eb097a11e15fe9cc90103d8a522831ca61c0dc9",
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "provider_token_telemetry_unavailable",
+        "updated_at": "2026-08-20T20:31:57.781Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 3666533,
+      "artifact_count": 93,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 194703,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 253713,
+      "readme_object": "46fa4f9f72f09980c6415f3154f701f7ed11bee1",
+      "readme_path": ".agentplane/tasks/202608200903-J459C2/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608200903-J459C2",
+      "usage": {
+        "agent_runs": 25,
+        "input_tokens": null,
+        "journal_digest": "sha256:a250d29f6daca6abbe1170dbf2f6beb74fcda1cc59b1c940e7f511c38b5727c5",
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "provider_token_telemetry_unavailable",
+        "updated_at": "2026-08-21T00:34:18.036Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 188376,
+      "artifact_count": 27,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 17907,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 25518,
+      "readme_object": "5458f4622ea7ab7f9ad401790befa36b0e2a55de",
+      "readme_path": ".agentplane/tasks/202608182243-NMAHN5/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608182243-NMAHN5",
+      "usage": {
+        "agent_runs": 2,
+        "input_tokens": null,
+        "journal_digest": "sha256:d0ea8b94c8015c823e8d40de8e63193464d63a41bbf0cba76919dabdf9ee95b0",
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "provider_token_telemetry_unavailable",
+        "updated_at": "2026-08-19T12:29:56.236Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 366150,
+      "artifact_count": 37,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 49077,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 77851,
+      "readme_object": "4bd210d87334953c1926a51a6838f7853e12e01d",
+      "readme_path": ".agentplane/tasks/202608181819-Z3GWTA/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608181819-Z3GWTA",
+      "usage": {
+        "agent_runs": 3,
+        "input_tokens": null,
+        "journal_digest": "sha256:d6dff919df7fa83ae189da687cd94bf7654cdeff45c466725c5b9f0a7a67091f",
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "provider_token_telemetry_unavailable",
+        "updated_at": "2026-08-18T20:43:44.308Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 3147228,
+      "artifact_count": 114,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 137763,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 207413,
+      "readme_object": "0f389aa4283af7639f292fc49cc65ebc05c54697",
+      "readme_path": ".agentplane/tasks/202608181750-CRZNFC/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608181750-CRZNFC",
+      "usage": {
+        "agent_runs": 35,
+        "input_tokens": null,
+        "journal_digest": "sha256:49509c6d7effdc8b34177b0c96b991ed34ba294fcb786c934af03d498e03c2a9",
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "provider_token_telemetry_unavailable",
+        "updated_at": "2026-08-19T04:31:36.772Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 786266,
+      "artifact_count": 49,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 50844,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 72020,
+      "readme_object": "92293122c2b8ce73488dddaa1137bc07cc85d672",
+      "readme_path": ".agentplane/tasks/202608181634-3EHFWF/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608181634-3EHFWF",
+      "usage": {
+        "agent_runs": 10,
+        "input_tokens": null,
+        "journal_digest": "sha256:5a48cb83a408c36f4d206d81a3f035c73a32fac14c61bfd951337e69f7cb6096",
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "provider_token_telemetry_unavailable",
+        "updated_at": "2026-08-18T17:39:35.708Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 758316,
+      "artifact_count": 48,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 40125,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 57602,
+      "readme_object": "4112d9da02985c1a013ab22bf21f3d440239db5e",
+      "readme_path": ".agentplane/tasks/202608181404-CR1F9W/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608181404-CR1F9W",
+      "usage": {
+        "agent_runs": 9,
+        "input_tokens": null,
+        "journal_digest": "sha256:b02ba3476bfad8355f330ec15a840592609aedaffac97c120eafa8dcca28c7f8",
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "provider_token_telemetry_unavailable",
+        "updated_at": "2026-08-18T15:42:35.725Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 1795089,
+      "artifact_count": 117,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 99877,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 167785,
+      "readme_object": "d4a97a1ffd8ed83f6dd3ba6f497d81b83c16d17b",
+      "readme_path": ".agentplane/tasks/202608171853-X3FD5M/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608171853-X3FD5M",
+      "usage": {
+        "agent_runs": 26,
+        "input_tokens": null,
+        "journal_digest": "sha256:6341c0b696b4bad9de4e1b43bf71090bb2cb5893fc04102054e294f0e6bd2366",
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "provider_token_telemetry_unavailable",
+        "updated_at": "2026-08-17T21:27:52.463Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 983493,
+      "artifact_count": 75,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 89398,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 148455,
+      "readme_object": "a820e2a307f03ae6efe0a24417b13d011ce6158e",
+      "readme_path": ".agentplane/tasks/202608171106-XFN696/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608171106-XFN696",
+      "usage": {
+        "agent_runs": 19,
+        "input_tokens": null,
+        "journal_digest": "sha256:922b75e5e58e96a6424c527e7b35568a8943a8fb5fce1eab4b4f499d0dd3b617",
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "provider_token_telemetry_unavailable",
+        "updated_at": "2026-08-17T18:03:12.936Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 698231,
+      "artifact_count": 81,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 65075,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 103222,
+      "readme_object": "7e007563df2212e74ca82c5d32c1869821e3d069",
+      "readme_path": ".agentplane/tasks/202608170928-8Y24PK/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608170928-8Y24PK",
+      "usage": {
+        "agent_runs": 16,
+        "input_tokens": null,
+        "journal_digest": "sha256:7d23b93cb9d0df73e88f30845d28d160e5183106a359379c03b068585dafe4f8",
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "provider_token_telemetry_unavailable",
+        "updated_at": "2026-08-17T23:14:12.743Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 340569,
+      "artifact_count": 77,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 35819,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 58651,
+      "readme_object": "8d9c7f320814f65898ab62d7a832810b19f5fb33",
+      "readme_path": ".agentplane/tasks/202608131733-KECD7J/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608131733-KECD7J",
+      "usage": {
+        "agent_runs": 5,
+        "input_tokens": 639700,
+        "journal_digest": "sha256:34363f3528d9bb5d2e30e2b64747a10551c9bd95801c4aa0937cd32f89f3402a",
+        "observed_agent_runs": 5,
+        "observed_by": "agentplane",
+        "output_tokens": 10844,
+        "reasoning_tokens": 2662,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "observed",
+        "total_tokens": 653206,
+        "unavailable_reason": null,
+        "updated_at": "2026-08-13T18:19:01.100Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 1189923,
+      "artifact_count": 65,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 57586,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 76731,
+      "readme_object": "5404dde653fbd9114f9dd9dbb6af7c136721f3b3",
+      "readme_path": ".agentplane/tasks/202608131730-BHEAQT/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608131730-BHEAQT",
+      "usage": {
+        "agent_runs": 3,
+        "input_tokens": 490474,
+        "journal_digest": "sha256:80f1a8b35a769ad8299141d552937a2375a08627ebc4e49a088e8957faa258f8",
+        "observed_agent_runs": 3,
+        "observed_by": "agentplane",
+        "output_tokens": 6459,
+        "reasoning_tokens": 1516,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "observed",
+        "total_tokens": 498449,
+        "unavailable_reason": null,
+        "updated_at": "2026-08-13T23:29:33.865Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 351845,
+      "artifact_count": 27,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 32765,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 49285,
+      "readme_object": "769a822e1318a1bc2170c3b52beb26e445490be3",
+      "readme_path": ".agentplane/tasks/202608122156-EZZZYH/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608122156-EZZZYH",
+      "usage": {
+        "agent_runs": 2,
+        "input_tokens": null,
+        "journal_digest": "sha256:4d0511c8b46d51691b0e9251e65cc32e0944a8efd1076840a4cd97249958b2a2",
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "provider_token_telemetry_unavailable",
+        "updated_at": "2026-08-13T17:11:23.534Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 258984,
+      "artifact_count": 30,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 31518,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 50223,
+      "readme_object": "43bccf832197ffa6c2828c0877c98cefbd5d81b8",
+      "readme_path": ".agentplane/tasks/202608120643-75ZFHW/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608120643-75ZFHW",
+      "usage": {
+        "agent_runs": 1,
+        "input_tokens": null,
+        "journal_digest": "sha256:6ce45672f0a42f80738af2416150b21af6e71d8ca4258ab6fbf39920af2ce841",
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "provider_token_telemetry_unavailable",
+        "updated_at": "2026-08-12T08:17:55.742Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 9314022,
+      "artifact_count": 169,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 99655,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 154881,
+      "readme_object": "bd0aee0534ecc0f5263c4a87f0ae67d60c1b4080",
+      "readme_path": ".agentplane/tasks/202608112259-T3ZDDM/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608112259-T3ZDDM",
+      "usage": {
+        "agent_runs": 11,
+        "input_tokens": 2103219,
+        "journal_digest": "sha256:03e6fa53f280c7e0e892ae6fd512478d296a02ef4e003494abd7ed49bdef51f7",
+        "observed_agent_runs": 10,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "partial",
+        "total_tokens": 2135814,
+        "unavailable_reason": "some_agent_runs_lack_provider_token_telemetry",
+        "updated_at": "2026-08-13T15:17:31.561Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 2314851,
+      "artifact_count": 99,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 38420,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 67569,
+      "readme_object": "87456dfe2438165756ab45f66c3079873eb72a64",
+      "readme_path": ".agentplane/tasks/202608112232-3NC7Y4/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608112232-3NC7Y4",
+      "usage": {
+        "agent_runs": 7,
+        "input_tokens": 1424631,
+        "journal_digest": "sha256:93cca0c3baf85202d0b79e5e560c922b6e0f4d110061e53eab303b043756d65d",
+        "observed_agent_runs": 7,
+        "observed_by": "agentplane",
+        "output_tokens": 17741,
+        "reasoning_tokens": 3755,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "observed",
+        "total_tokens": 1446127,
+        "unavailable_reason": null,
+        "updated_at": "2026-08-12T06:20:10.545Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 908433,
+      "artifact_count": 51,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 34052,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 58159,
+      "readme_object": "88320c5d9496a912963605c9bb29376d29644892",
+      "readme_path": ".agentplane/tasks/202608112213-NWJCBW/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608112213-NWJCBW",
+      "usage": {
+        "agent_runs": 0,
+        "input_tokens": null,
+        "journal_digest": null,
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "unavailable",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "supervisor_journal_missing",
+        "updated_at": "2026-08-12T00:17:22.153Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 378359,
+      "artifact_count": 49,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 21321,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 34411,
+      "readme_object": "03aa5cc450bda21874a2b787df91b6a30f4ba900",
+      "readme_path": ".agentplane/tasks/202608111922-W4ZM7J/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608111922-W4ZM7J",
+      "usage": {
+        "agent_runs": 1,
+        "input_tokens": null,
+        "journal_digest": "sha256:af2921d2c54ba16356be575bbdeb7b6d8a6bd05b0f05b4374affe3e3521c5483",
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "provider_token_telemetry_unavailable",
+        "updated_at": "2026-08-11T21:47:06.143Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 481623,
+      "artifact_count": 78,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 38296,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 66765,
+      "readme_object": "8f663b64a8ba30fabf08203f71047a92e9b82ed9",
+      "readme_path": ".agentplane/tasks/202608111036-QHR892/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608111036-QHR892",
+      "usage": {
+        "agent_runs": 5,
+        "input_tokens": 806967,
+        "journal_digest": "sha256:a47202ef0108833c2b0cd85a756602eea6e60c3a14fcbccee46bf4f11aff16e2",
+        "observed_agent_runs": 5,
+        "observed_by": "agentplane",
+        "output_tokens": 11436,
+        "reasoning_tokens": 3261,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "observed",
+        "total_tokens": 821664,
+        "unavailable_reason": null,
+        "updated_at": "2026-08-11T16:15:34.694Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 27120,
+      "artifact_count": 7,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 5518,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 8021,
+      "readme_object": "72e7dd76a29c759d7fac6a8a3154e45da7bfb389",
+      "readme_path": ".agentplane/tasks/202608111010-2M6168/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608111010-2M6168",
+      "usage": {
+        "agent_runs": 0,
+        "input_tokens": null,
+        "journal_digest": null,
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "unavailable",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "supervisor_journal_missing",
+        "updated_at": "2026-08-11T10:32:32.799Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 461013,
+      "artifact_count": 47,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 40003,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 68352,
+      "readme_object": "e82b0017fe714f53828d732867f3e5ce768b76be",
+      "readme_path": ".agentplane/tasks/202608110235-WCJJRD/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608110235-WCJJRD",
+      "usage": {
+        "agent_runs": 0,
+        "input_tokens": null,
+        "journal_digest": null,
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "unavailable",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "supervisor_journal_missing",
+        "updated_at": "2026-08-11T09:08:45.721Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 325276,
+      "artifact_count": 45,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 28933,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 48820,
+      "readme_object": "de905ddc6929128a73f70cfd626d3f58fa2f4f46",
+      "readme_path": ".agentplane/tasks/202608110110-3QTGFQ/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608110110-3QTGFQ",
+      "usage": {
+        "agent_runs": 1,
+        "input_tokens": null,
+        "journal_digest": "sha256:90eda43765582f18f2d4797a05eca613f69ac87dbfdd9a6f76ca52656db29c1d",
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "provider_token_telemetry_unavailable",
+        "updated_at": "2026-08-11T02:24:22.807Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 428375,
+      "artifact_count": 36,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 27442,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 45533,
+      "readme_object": "73efe2673e97b9208c186e485b0c9e2ab48d69d3",
+      "readme_path": ".agentplane/tasks/202608102243-1RG86M/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608102243-1RG86M",
+      "usage": {
+        "agent_runs": 0,
+        "input_tokens": null,
+        "journal_digest": null,
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "unavailable",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "supervisor_journal_missing",
+        "updated_at": "2026-08-11T00:55:58.628Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 32374,
+      "artifact_count": 7,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 9369,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 15804,
+      "readme_object": "95d3e7da915d224bdb313420e1bbb289f5f5ecb4",
+      "readme_path": ".agentplane/tasks/202608102115-7XGP97/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608102115-7XGP97",
+      "usage": {
+        "agent_runs": 0,
+        "input_tokens": null,
+        "journal_digest": null,
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "unavailable",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "supervisor_journal_missing",
+        "updated_at": "2026-08-11T20:30:35.360Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 57914,
+      "artifact_count": 12,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 21139,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 33299,
+      "readme_object": "8bc8c12d649794614d9ff0c329673119afabdcf2",
+      "readme_path": ".agentplane/tasks/202608102112-AY0H1F/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608102112-AY0H1F",
+      "usage": {
+        "agent_runs": 0,
+        "input_tokens": null,
+        "journal_digest": null,
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "unavailable",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "supervisor_journal_missing",
+        "updated_at": "2026-08-10T22:40:58.248Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 172247,
+      "artifact_count": 30,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 15596,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 23424,
+      "readme_object": "d34bde6f798c300368cf03763e1e2564dd2a1f64",
+      "readme_path": ".agentplane/tasks/202608101850-25R7W2/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608101850-25R7W2",
+      "usage": {
+        "agent_runs": 4,
+        "input_tokens": null,
+        "journal_digest": "sha256:03a6bdb4e5196933c6edaffd906e7bd946efe1cd7883dc197599eef17ded042f",
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "provider_token_telemetry_unavailable",
+        "updated_at": "2026-08-10T19:51:03.479Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 244568,
+      "artifact_count": 48,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 22017,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 34926,
+      "readme_object": "431da62aa44ac54c7398227d639df0641fdcd801",
+      "readme_path": ".agentplane/tasks/202608101506-4Y8ZY0/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608101506-4Y8ZY0",
+      "usage": {
+        "agent_runs": 8,
+        "input_tokens": null,
+        "journal_digest": "sha256:6dc3b13f1a782984d971dedde60f6f25a0cb8600fe9408b722c012bf6414de5b",
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "provider_token_telemetry_unavailable",
+        "updated_at": "2026-08-10T16:34:31.084Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 428904,
+      "artifact_count": 74,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 41227,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 69514,
+      "readme_object": "9c18c4fb66a52b8a1308dcd16ad887c70e97284d",
+      "readme_path": ".agentplane/tasks/202608101410-4GSCYN/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608101410-4GSCYN",
+      "usage": {
+        "agent_runs": 10,
+        "input_tokens": null,
+        "journal_digest": "sha256:b21e7f22b33c81ca8cb818ac571b1e5e2772be68b41776e9d8073c31cd4215dd",
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "provider_token_telemetry_unavailable",
+        "updated_at": "2026-08-10T18:06:34.082Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 377773,
+      "artifact_count": 13,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 11807,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 18834,
+      "readme_object": "95e36c322c542775c3f63286a66f960946d2727a",
+      "readme_path": ".agentplane/tasks/202608101357-58FSYQ/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608101357-58FSYQ",
+      "usage": {
+        "agent_runs": 0,
+        "input_tokens": null,
+        "journal_digest": null,
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "unavailable",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "supervisor_journal_missing",
+        "updated_at": "2026-08-10T21:47:55.696Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 165259,
+      "artifact_count": 38,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 21017,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 33992,
+      "readme_object": "43306c1e0838914c395c91813f486dfb8ae9c918",
+      "readme_path": ".agentplane/tasks/202608101223-ZCA7JG/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608101223-ZCA7JG",
+      "usage": {
+        "agent_runs": 0,
+        "input_tokens": null,
+        "journal_digest": null,
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "unavailable",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "supervisor_journal_missing",
+        "updated_at": "2026-08-10T13:02:53.365Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 125672,
+      "artifact_count": 30,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 24112,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 40151,
+      "readme_object": "b32ab1423614a14a12a9ecfb5e7e66fe722c01cd",
+      "readme_path": ".agentplane/tasks/202608101159-Y4H8N5/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608101159-Y4H8N5",
+      "usage": {
+        "agent_runs": 0,
+        "input_tokens": null,
+        "journal_digest": null,
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "unavailable",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "supervisor_journal_missing",
+        "updated_at": "2026-08-10T13:50:03.974Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 185935,
+      "artifact_count": 19,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 17677,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 27264,
+      "readme_object": "92b5c724f546e263838584313c0ce2266d015501",
+      "readme_path": ".agentplane/tasks/202608082119-P6SHBN/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608082119-P6SHBN",
+      "usage": {
+        "agent_runs": 0,
+        "input_tokens": null,
+        "journal_digest": null,
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "unavailable",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "supervisor_journal_missing",
+        "updated_at": "2026-08-08T22:35:08.762Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 650153,
+      "artifact_count": 103,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 47691,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 79988,
+      "readme_object": "02ec3ff955a8106c88faf0b1b98042bbe495e6fb",
+      "readme_path": ".agentplane/tasks/202608081216-YAN7DW/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608081216-YAN7DW",
+      "usage": {
+        "agent_runs": 19,
+        "input_tokens": 1396922,
+        "journal_digest": "sha256:7d9612127f1d813a883f008531b36733522cf22fa54c437c40b42691db16ab02",
+        "observed_agent_runs": 6,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "partial",
+        "total_tokens": 1416964,
+        "unavailable_reason": "some_agent_runs_lack_provider_token_telemetry",
+        "updated_at": "2026-08-08T15:28:59.590Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 200555,
+      "artifact_count": 32,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 17841,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 28144,
+      "readme_object": "3bb598a1706e729ef2e535bcf283d89979b242fc",
+      "readme_path": ".agentplane/tasks/202608080805-KPWPAV/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608080805-KPWPAV",
+      "usage": {
+        "agent_runs": 5,
+        "input_tokens": null,
+        "journal_digest": "sha256:d78024e0a294f93ba571a0c118622bef7af70aa65afe317282ae0bec101bdc52",
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "provider_token_telemetry_unavailable",
+        "updated_at": "2026-08-08T08:46:55.558Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 475895,
+      "artifact_count": 77,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 33600,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 54661,
+      "readme_object": "8970043bef0dfa9a6f3580dac9ab97ed08e0313e",
+      "readme_path": ".agentplane/tasks/202608080551-8BH6HY/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608080551-8BH6HY",
+      "usage": {
+        "agent_runs": 17,
+        "input_tokens": 706977,
+        "journal_digest": "sha256:1236223dc07895b49e0e74b4d897e468ee19a1239f09b4062fc844cf393db86a",
+        "observed_agent_runs": 4,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "partial",
+        "total_tokens": 717365,
+        "unavailable_reason": "some_agent_runs_lack_provider_token_telemetry",
+        "updated_at": "2026-08-08T07:50:44.670Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 75902,
+      "artifact_count": 19,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 12899,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 20563,
+      "readme_object": "d77802ec74a05b0de321bfcd43ef1e0af3d4d634",
+      "readme_path": ".agentplane/tasks/202608080431-541KC2/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608080431-541KC2",
+      "usage": {
+        "agent_runs": 1,
+        "input_tokens": 79043,
+        "journal_digest": "sha256:a233a090ab6935a0912b2f6efe7ad5041feabdee3d4d09114e40c897b8cc6a70",
+        "observed_agent_runs": 1,
+        "observed_by": "agentplane",
+        "output_tokens": 1554,
+        "reasoning_tokens": 197,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "observed",
+        "total_tokens": 80794,
+        "unavailable_reason": null,
+        "updated_at": "2026-08-08T04:48:55.677Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 207865,
+      "artifact_count": 49,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 28868,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 50051,
+      "readme_object": "ebe276972d506e48ccfd2c877afb5e7692b78ba5",
+      "readme_path": ".agentplane/tasks/202608080403-N0VXJ0/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608080403-N0VXJ0",
+      "usage": {
+        "agent_runs": 5,
+        "input_tokens": 399652,
+        "journal_digest": "sha256:fa729f74c80917cfd327bc5cb3419db4ec868aa36b97de5b6f150f5326bb6b5c",
+        "observed_agent_runs": 4,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "partial",
+        "total_tokens": 406925,
+        "unavailable_reason": "some_agent_runs_lack_provider_token_telemetry",
+        "updated_at": "2026-08-08T05:02:19.640Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 199645,
+      "artifact_count": 42,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 24444,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 41258,
+      "readme_object": "d14ed2402d650ea0d84d8904e00dcfb7c5746fd5",
+      "readme_path": ".agentplane/tasks/202608080355-G5FXDA/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608080355-G5FXDA",
+      "usage": {
+        "agent_runs": 4,
+        "input_tokens": 322930,
+        "journal_digest": "sha256:1a5747708942ec97bb6fdde6a751af451488a335fb119c9cdec664e1950e5653",
+        "observed_agent_runs": 3,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "partial",
+        "total_tokens": 329045,
+        "unavailable_reason": "some_agent_runs_lack_provider_token_telemetry",
+        "updated_at": "2026-08-08T05:34:53.467Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 139762,
+      "artifact_count": 39,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 17505,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 26998,
+      "readme_object": "40aba1afaa6a2275dc955ed788ce8ec33c4cec51",
+      "readme_path": ".agentplane/tasks/202608070235-JPPAMT/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608070235-JPPAMT",
+      "usage": {
+        "agent_runs": 3,
+        "input_tokens": 304222,
+        "journal_digest": "sha256:e19f5f864b620f8fc15dedcc8c2b55d16957e111c9967dcb1ffa72578858be62",
+        "observed_agent_runs": 3,
+        "observed_by": "agentplane",
+        "output_tokens": 4885,
+        "reasoning_tokens": 947,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "observed",
+        "total_tokens": 310054,
+        "unavailable_reason": null,
+        "updated_at": "2026-08-07T02:49:08.114Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 250818,
+      "artifact_count": 59,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 23494,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 39598,
+      "readme_object": "6de701dafbdde2ea20ab565c1359748318d1b09e",
+      "readme_path": ".agentplane/tasks/202608070209-J3DEJ1/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608070209-J3DEJ1",
+      "usage": {
+        "agent_runs": 5,
+        "input_tokens": 925359,
+        "journal_digest": "sha256:af2d0eccd5435027e4ac2b85e8f97a88b73c31078133c1e2a4fbffec56c8ecdd",
+        "observed_agent_runs": 5,
+        "observed_by": "agentplane",
+        "output_tokens": 10339,
+        "reasoning_tokens": 2405,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "observed",
+        "total_tokens": 938103,
+        "unavailable_reason": null,
+        "updated_at": "2026-08-08T03:26:04.314Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 421821,
+      "artifact_count": 43,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 23354,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 38291,
+      "readme_object": "31053bda32dc1a02c718b9d56e8bf7ad08d43fe6",
+      "readme_path": ".agentplane/tasks/202608062023-V3WHE9/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608062023-V3WHE9",
+      "usage": {
+        "agent_runs": 3,
+        "input_tokens": 650741,
+        "journal_digest": "sha256:e80609f90fa8087e6195eedd2feffde8f96b2c38677175d784bcf6c370248ede",
+        "observed_agent_runs": 3,
+        "observed_by": "agentplane",
+        "output_tokens": 7002,
+        "reasoning_tokens": 1631,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "observed",
+        "total_tokens": 659374,
+        "unavailable_reason": null,
+        "updated_at": "2026-08-08T01:56:12.385Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 1548099,
+      "artifact_count": 86,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 45118,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 78285,
+      "readme_object": "7567385d134494ad61ee4f86588a1ecd5d940126",
+      "readme_path": ".agentplane/tasks/202608062021-Z0X584/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608062021-Z0X584",
+      "usage": {
+        "agent_runs": 7,
+        "input_tokens": 1308554,
+        "journal_digest": "sha256:9c903fdc1fdb6b6b868591098316983ad91965d775bf31e9790ae7401ba9f331",
+        "observed_agent_runs": 7,
+        "observed_by": "agentplane",
+        "output_tokens": 15059,
+        "reasoning_tokens": 3199,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "observed",
+        "total_tokens": 1326812,
+        "unavailable_reason": null,
+        "updated_at": "2026-08-07T04:11:18.794Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 1334082,
+      "artifact_count": 157,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 56192,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 99608,
+      "readme_object": "dc6ca5059d9894742842ab09edfc63185411db43",
+      "readme_path": ".agentplane/tasks/202608062021-V2EESE/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608062021-V2EESE",
+      "usage": {
+        "agent_runs": 16,
+        "input_tokens": 2432588,
+        "journal_digest": "sha256:5bd80b9e2b0b39567ef7c2b005375b0346a9498d11ae144bbd2216234a184e8e",
+        "observed_agent_runs": 12,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "partial",
+        "total_tokens": 2469058,
+        "unavailable_reason": "some_agent_runs_lack_provider_token_telemetry",
+        "updated_at": "2026-08-07T22:12:07.578Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 875669,
+      "artifact_count": 97,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 51542,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 90695,
+      "readme_object": "a646968daab28509c78115b23b579bd8906a2ef5",
+      "readme_path": ".agentplane/tasks/202608062021-MCY8ZC/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608062021-MCY8ZC",
+      "usage": {
+        "agent_runs": 8,
+        "input_tokens": 2139084,
+        "journal_digest": "sha256:b9641c27eacd5c189c74908e22db0334266eb08cb837727e4a1dfe5975e68ff2",
+        "observed_agent_runs": 8,
+        "observed_by": "agentplane",
+        "output_tokens": 21305,
+        "reasoning_tokens": 5279,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "observed",
+        "total_tokens": 2165668,
+        "unavailable_reason": null,
+        "updated_at": "2026-08-07T23:59:48.692Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 187949,
+      "artifact_count": 34,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 27781,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 45936,
+      "readme_object": "076ff06603ca3ef753397eb1279d0bad267c6bdf",
+      "readme_path": ".agentplane/tasks/202608062021-HTRP5J/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608062021-HTRP5J",
+      "usage": {
+        "agent_runs": 2,
+        "input_tokens": 344979,
+        "journal_digest": "sha256:bf906bbf2a05fe15e280679e88afb75da668322f2195a69318df0e1cbe157bb2",
+        "observed_agent_runs": 2,
+        "observed_by": "agentplane",
+        "output_tokens": 4062,
+        "reasoning_tokens": 948,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "observed",
+        "total_tokens": 349989,
+        "unavailable_reason": null,
+        "updated_at": "2026-08-08T00:47:37.214Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 177336,
+      "artifact_count": 42,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 25249,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 41630,
+      "readme_object": "2810c81035bc3f27107ff8fdf925224660358298",
+      "readme_path": ".agentplane/tasks/202608061925-KANFC0/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608061925-KANFC0",
+      "usage": {
+        "agent_runs": 3,
+        "input_tokens": 249760,
+        "journal_digest": "sha256:1706725a4dad5788e39b4b24d91ed316d0a912c3bcb50304ae0aa9151ddb9ec0",
+        "observed_agent_runs": 3,
+        "observed_by": "agentplane",
+        "output_tokens": 4630,
+        "reasoning_tokens": 918,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "observed",
+        "total_tokens": 255308,
+        "unavailable_reason": null,
+        "updated_at": "2026-08-07T03:01:13.392Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 314832,
+      "artifact_count": 49,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 18420,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 29606,
+      "readme_object": "326dc5368797db8bb4782eb4d04cdc64f8623363",
+      "readme_path": ".agentplane/tasks/202608061850-BZT3D9/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608061850-BZT3D9",
+      "usage": {
+        "agent_runs": 5,
+        "input_tokens": 446755,
+        "journal_digest": "sha256:3d316f5315a02663da97b9cd2ffa3b363b18fdce1595d5d31d33fe49fa6692e6",
+        "observed_agent_runs": 4,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "partial",
+        "total_tokens": 454322,
+        "unavailable_reason": "some_agent_runs_lack_provider_token_telemetry",
+        "updated_at": "2026-08-06T23:41:10.152Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 911950,
+      "artifact_count": 43,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 20002,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 31628,
+      "readme_object": "7702048bf4fb94e491470b852d6793f8d6b653a0",
+      "readme_path": ".agentplane/tasks/202608061742-G2ZA4T/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608061742-G2ZA4T",
+      "usage": {
+        "agent_runs": 3,
+        "input_tokens": 389542,
+        "journal_digest": "sha256:6bc1a4dc2d8ce1399bc4b3998c053fb95e25b735deaa9a9ec4340a7f0865fe35",
+        "observed_agent_runs": 2,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "partial",
+        "total_tokens": 395884,
+        "unavailable_reason": "some_agent_runs_lack_provider_token_telemetry",
+        "updated_at": "2026-08-07T02:01:16.433Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 284237,
+      "artifact_count": 39,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 22897,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 38377,
+      "readme_object": "2dcb84dc73c53fa672ab1812a8f99b658877d871",
+      "readme_path": ".agentplane/tasks/202608061646-WCARQG/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608061646-WCARQG",
+      "usage": {
+        "agent_runs": 0,
+        "input_tokens": null,
+        "journal_digest": null,
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "unavailable",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "supervisor_journal_missing",
+        "updated_at": "2026-08-06T17:16:44.392Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 535587,
+      "artifact_count": 67,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 90241,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 150470,
+      "readme_object": "e9e7fe03b9f8dbcbec8d99b7e748c9c5310e1d80",
+      "readme_path": ".agentplane/tasks/202608061646-BYY8A1/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608061646-BYY8A1",
+      "usage": {
+        "agent_runs": 0,
+        "input_tokens": null,
+        "journal_digest": null,
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "unavailable",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "supervisor_journal_missing",
+        "updated_at": "2026-08-08T21:18:02.612Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 1437091,
+      "artifact_count": 173,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 76101,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 133099,
+      "readme_object": "d7fdc6598525a6e05891e64a263de68baee0dff9",
+      "readme_path": ".agentplane/tasks/202608061646-30TKV4/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608061646-30TKV4",
+      "usage": {
+        "agent_runs": 16,
+        "input_tokens": 3071303,
+        "journal_digest": "sha256:d666e3c3c8ddc62d92de0c27839b519ad9e07f53fe8833a7256b59bfbfb8fed4",
+        "observed_agent_runs": 14,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "partial",
+        "total_tokens": 3112038,
+        "unavailable_reason": "some_agent_runs_lack_provider_token_telemetry",
+        "updated_at": "2026-08-07T01:41:11.948Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 166228,
+      "artifact_count": 18,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 14933,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 23694,
+      "readme_object": "dd63575503f28826f770bb5ed8f3b44268685e9f",
+      "readme_path": ".agentplane/tasks/202608061244-J3EC6A/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608061244-J3EC6A",
+      "usage": {
+        "agent_runs": 0,
+        "input_tokens": null,
+        "journal_digest": null,
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "unavailable",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "supervisor_journal_missing",
+        "updated_at": "2026-08-06T13:17:34.604Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 910612,
+      "artifact_count": 60,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 40766,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 70902,
+      "readme_object": "5c3a617b9c9f16e688f8c36c910084419c7c13d9",
+      "readme_path": ".agentplane/tasks/202608052127-XWDY4R/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608052127-XWDY4R",
+      "usage": {
+        "agent_runs": 2,
+        "input_tokens": null,
+        "journal_digest": "sha256:e741a0246ea10957965db0ba00782575bb9d51a9edd6a9a9cde921bc29bf9b84",
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "provider_token_telemetry_unavailable",
+        "updated_at": "2026-08-06T12:33:08.974Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 2138984,
+      "artifact_count": 122,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 57294,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 100787,
+      "readme_object": "17ce9c1b87b3bda2f71205ae6d796f71e590cd5d",
+      "readme_path": ".agentplane/tasks/202608041322-M26FS0/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608041322-M26FS0",
+      "usage": {
+        "agent_runs": 6,
+        "input_tokens": 956291,
+        "journal_digest": "sha256:53ae3c9292126416b0b4c24babe9dcf70493d65a626564a804e5bb229e2f8604",
+        "observed_agent_runs": 6,
+        "observed_by": "agentplane",
+        "output_tokens": 12440,
+        "reasoning_tokens": 2434,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "observed",
+        "total_tokens": 971165,
+        "unavailable_reason": null,
+        "updated_at": "2026-08-05T20:56:17.055Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 454900,
+      "artifact_count": 47,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 24369,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 41472,
+      "readme_object": "05cfaf1988bd4e603e6a93592fe8a9c455a6390b",
+      "readme_path": ".agentplane/tasks/202608041057-WZRXEX/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608041057-WZRXEX",
+      "usage": {
+        "agent_runs": 0,
+        "input_tokens": null,
+        "journal_digest": null,
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "unavailable",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "supervisor_journal_missing",
+        "updated_at": "2026-08-04T12:49:00.184Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 100600,
+      "artifact_count": 21,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 19034,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 30532,
+      "readme_object": "4e743fddf11c995e1f0844cefcb647fcd2429b07",
+      "readme_path": ".agentplane/tasks/202608040748-7Z0401/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608040748-7Z0401",
+      "usage": {
+        "agent_runs": 0,
+        "input_tokens": null,
+        "journal_digest": null,
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "unavailable",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "supervisor_journal_missing",
+        "updated_at": "2026-08-04T08:00:43.433Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 97603,
+      "artifact_count": 19,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 13380,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 21205,
+      "readme_object": "5878530857d8623119a7c376c792127312288128",
+      "readme_path": ".agentplane/tasks/202608040215-0Z0C92/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608040215-0Z0C92",
+      "usage": {
+        "agent_runs": 0,
+        "input_tokens": null,
+        "journal_digest": null,
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "unavailable",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "supervisor_journal_missing",
+        "updated_at": "2026-08-04T02:28:38.820Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 80596,
+      "artifact_count": 17,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 11164,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 16385,
+      "readme_object": "1d520701d33760ae3ce2b6611bf60616e78c2969",
+      "readme_path": ".agentplane/tasks/202608040106-CC1TAP/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608040106-CC1TAP",
+      "usage": {
+        "agent_runs": 0,
+        "input_tokens": null,
+        "journal_digest": null,
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "unavailable",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "supervisor_journal_missing",
+        "updated_at": "2026-08-04T01:11:17.800Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 392800,
+      "artifact_count": 47,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 30333,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 49692,
+      "readme_object": "5d63f4c060cb07101984c997262cd32f021e0cef",
+      "readme_path": ".agentplane/tasks/202608040031-4XD57R/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608040031-4XD57R",
+      "usage": {
+        "agent_runs": 0,
+        "input_tokens": null,
+        "journal_digest": "sha256:02d6502e608a3c5bd4e29d8e1f1745b8f8499ec912a55fb418466611dc9c7fd0",
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "no_supervised_agent_runs",
+        "updated_at": "2026-08-04T01:28:35.267Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 145895,
+      "artifact_count": 35,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 18498,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 29724,
+      "readme_object": "473d776ca66e0f9326ff08c4a950813c915aba59",
+      "readme_path": ".agentplane/tasks/202608032336-A9H6WR/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608032336-A9H6WR",
+      "usage": {
+        "agent_runs": 0,
+        "input_tokens": null,
+        "journal_digest": null,
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "unavailable",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "supervisor_journal_missing",
+        "updated_at": "2026-08-03T23:54:40.874Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 147539,
+      "artifact_count": 21,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 14607,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 23976,
+      "readme_object": "2eface6c5411643602a549aa81f8a420efc61a8d",
+      "readme_path": ".agentplane/tasks/202608032250-WDRW1E/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608032250-WDRW1E",
+      "usage": {
+        "agent_runs": 0,
+        "input_tokens": null,
+        "journal_digest": null,
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "unavailable",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "supervisor_journal_missing",
+        "updated_at": "2026-08-03T23:01:11.683Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 131662,
+      "artifact_count": 31,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 22480,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 37002,
+      "readme_object": "85e08c52abac99021501315d969c0e70a5820922",
+      "readme_path": ".agentplane/tasks/202608032207-V8HMV8/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608032207-V8HMV8",
+      "usage": {
+        "agent_runs": 0,
+        "input_tokens": null,
+        "journal_digest": null,
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "unavailable",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "supervisor_journal_missing",
+        "updated_at": "2026-08-03T22:22:01.090Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 90731,
+      "artifact_count": 18,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 13841,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 21331,
+      "readme_object": "2c8c258d775c396797e24dd76cf24f601f0472f9",
+      "readme_path": ".agentplane/tasks/202608032116-V9DBA5/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608032116-V9DBA5",
+      "usage": {
+        "agent_runs": 0,
+        "input_tokens": null,
+        "journal_digest": null,
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "unavailable",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "supervisor_journal_missing",
+        "updated_at": "2026-08-03T21:46:10.871Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 171667,
+      "artifact_count": 21,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 11625,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 17065,
+      "readme_object": "3de70e2b4c765a700937ed4ea26a253c87241ed2",
+      "readme_path": ".agentplane/tasks/202608032116-QFBVB5/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608032116-QFBVB5",
+      "usage": {
+        "agent_runs": 0,
+        "input_tokens": null,
+        "journal_digest": null,
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "unavailable",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "supervisor_journal_missing",
+        "updated_at": "2026-08-03T21:26:21.704Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 112752,
+      "artifact_count": 26,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 15917,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 25200,
+      "readme_object": "22b68622e669a243e9eb0e36356a25b2579762df",
+      "readme_path": ".agentplane/tasks/202608032042-DAMQDM/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608032042-DAMQDM",
+      "usage": {
+        "agent_runs": 0,
+        "input_tokens": null,
+        "journal_digest": null,
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "unavailable",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "supervisor_journal_missing",
+        "updated_at": "2026-08-03T20:57:18.103Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 179409,
+      "artifact_count": 30,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 15549,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 25165,
+      "readme_object": "6ba0ef0cad579dc0f9ec6f32dadfdecc4fa76555",
+      "readme_path": ".agentplane/tasks/202608031426-0BY4B4/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608031426-0BY4B4",
+      "usage": {
+        "agent_runs": 2,
+        "input_tokens": 459781,
+        "journal_digest": "sha256:e520e8a0da6f7bfd59e6f571d0cdef2c89ecbd54daa33bacd0c6a86c28d3ab44",
+        "observed_agent_runs": 2,
+        "observed_by": "agentplane",
+        "output_tokens": 4285,
+        "reasoning_tokens": 939,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "observed",
+        "total_tokens": 465005,
+        "unavailable_reason": null,
+        "updated_at": "2026-08-03T14:55:34.914Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 131711,
+      "artifact_count": 18,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 18666,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 30505,
+      "readme_object": "42fb766c57c408d79f159d5bc9cc36fc4e9729d1",
+      "readme_path": ".agentplane/tasks/202608031321-5GK3DD/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608031321-5GK3DD",
+      "usage": {
+        "agent_runs": 0,
+        "input_tokens": null,
+        "journal_digest": null,
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "unavailable",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "supervisor_journal_missing",
+        "updated_at": "2026-08-03T14:10:09.820Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 107030,
+      "artifact_count": 24,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 10286,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 15682,
+      "readme_object": "1d7f93a90616705304de9a0ee4a59fa0d0e4ba4b",
+      "readme_path": ".agentplane/tasks/202608031303-B5Q5NM/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608031303-B5Q5NM",
+      "usage": {
+        "agent_runs": 0,
+        "input_tokens": null,
+        "journal_digest": null,
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "unavailable",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "supervisor_journal_missing",
+        "updated_at": "2026-08-03T13:12:49.933Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 180433,
+      "artifact_count": 17,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 14749,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 23149,
+      "readme_object": "607273901a9c640d01fed1fca5ba08744fdc36d7",
+      "readme_path": ".agentplane/tasks/202608022324-Y26ENH/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608022324-Y26ENH",
+      "usage": null,
+      "usage_source": "not_recorded",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 885103,
+      "artifact_count": 66,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 27677,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 46980,
+      "readme_object": "429cdd7887e52183c48e16d991bfa759689a45f9",
+      "readme_path": ".agentplane/tasks/202608022324-9VCYWG/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608022324-9VCYWG",
+      "usage": null,
+      "usage_source": "not_recorded",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 125911,
+      "artifact_count": 26,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 15218,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 24584,
+      "readme_object": "2fb98b59ee7a92712091f451f0c0d0467fa27f51",
+      "readme_path": ".agentplane/tasks/202608022236-AWTDJ9/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608022236-AWTDJ9",
+      "usage": null,
+      "usage_source": "not_recorded",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 268024,
+      "artifact_count": 44,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 18045,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 29857,
+      "readme_object": "eb6655281d61de441e4b0f19115674623cb4e2b0",
+      "readme_path": ".agentplane/tasks/202608022128-39YSZ1/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608022128-39YSZ1",
+      "usage": null,
+      "usage_source": "not_recorded",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 711180,
+      "artifact_count": 84,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 37429,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 65032,
+      "readme_object": "6e88f0049e98f1449b9c03e72b3abb1961c912c3",
+      "readme_path": ".agentplane/tasks/202608021535-CNQKXP/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608021535-CNQKXP",
+      "usage": {
+        "agent_runs": 7,
+        "input_tokens": 1307728,
+        "journal_digest": "sha256:0ec99c20f41c5c63af56637ab566b94b4e536029f9853b83ec813d5d09920527",
+        "observed_agent_runs": 7,
+        "observed_by": "agentplane",
+        "output_tokens": 15843,
+        "reasoning_tokens": 3307,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "observed",
+        "total_tokens": 1326878,
+        "unavailable_reason": null,
+        "updated_at": "2026-08-03T20:24:43.867Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 844064,
+      "artifact_count": 78,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 51132,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 88928,
+      "readme_object": "078931502bd1d630da4c52f54fa8fb8905ff4718",
+      "readme_path": ".agentplane/tasks/202608021535-9EWFAB/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608021535-9EWFAB",
+      "usage": {
+        "agent_runs": 5,
+        "input_tokens": 1198550,
+        "journal_digest": "sha256:23943ac709581889b7ab87fada067c62d133886b88ff3f2511939a92710574e3",
+        "observed_agent_runs": 5,
+        "observed_by": "agentplane",
+        "output_tokens": 11596,
+        "reasoning_tokens": 2687,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "observed",
+        "total_tokens": 1212833,
+        "unavailable_reason": null,
+        "updated_at": "2026-08-03T18:12:49.189Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 706509,
+      "artifact_count": 53,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 20780,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 32650,
+      "readme_object": "da77df9ebc1c50e9887308ca79a5d9822102bafc",
+      "readme_path": ".agentplane/tasks/202608021534-YN84E1/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608021534-YN84E1",
+      "usage": null,
+      "usage_source": "not_recorded",
+      "work_items": null
+    }
+  ],
+  "totals": {
+    "agent_runs": {
+      "tasks_observed": 145,
+      "value": 1314
+    },
+    "artifact_bytes": 311912258,
+    "artifact_count": 23405,
+    "cached_input_tokens": {
+      "tasks_observed": 0,
+      "value": null
+    },
+    "duplicate_bytes": 23267340,
+    "duplicate_paths": 2329,
+    "input_tokens": {
+      "tasks_observed": 27,
+      "value": 25188295
+    },
+    "observed_agent_runs": {
+      "tasks_observed": 145,
+      "value": 133
+    },
+    "output_tokens": {
+      "tasks_observed": 16,
+      "value": 159480
+    },
+    "reasoning_tokens": {
+      "tasks_observed": 16,
+      "value": 36085
+    },
+    "sampled_commits": 200,
+    "sampled_tasks": 150,
+    "service_commits": 146,
+    "tasks_with_usage": 145,
+    "usage_states": {
+      "not_recorded": 5,
+      "observed": 16,
+      "partial": 11,
+      "unavailable": 118
+    }
+  }
+}

--- a/scripts/baselines/agent-efficiency-VN1FN4-after.json
+++ b/scripts/baselines/agent-efficiency-VN1FN4-after.json
@@ -3,16 +3,12 @@
     {
       "service_only": true,
       "sha": "9e0f99960120a41e4056c62403407b76759c2584",
-      "task_ids": [
-        "202609071219-QV0SX9"
-      ]
+      "task_ids": ["202609071219-QV0SX9"]
     },
     {
       "service_only": true,
       "sha": "3c45166b31d0a9960f52aa11c3259afd472dd691",
-      "task_ids": [
-        "202609071219-QV0SX9"
-      ]
+      "task_ids": ["202609071219-QV0SX9"]
     },
     {
       "service_only": false,
@@ -27,373 +23,267 @@
     {
       "service_only": true,
       "sha": "080bfea10e63472c9d895c7880d1f4a4dc720bc4",
-      "task_ids": [
-        "202609071219-QV0SX9"
-      ]
+      "task_ids": ["202609071219-QV0SX9"]
     },
     {
       "service_only": true,
       "sha": "07e2ff7d228879b9a14a416c261c8f97f38ae287",
-      "task_ids": [
-        "202609071219-QV0SX9"
-      ]
+      "task_ids": ["202609071219-QV0SX9"]
     },
     {
       "service_only": true,
       "sha": "082de2c2ca742fd4150dbf7439a2b1fb9f5f79ed",
-      "task_ids": [
-        "202609071219-QV0SX9"
-      ]
+      "task_ids": ["202609071219-QV0SX9"]
     },
     {
       "service_only": true,
       "sha": "b36211390f5a1593bccfb1726991120573211292",
-      "task_ids": [
-        "202609071219-QV0SX9"
-      ]
+      "task_ids": ["202609071219-QV0SX9"]
     },
     {
       "service_only": true,
       "sha": "c8ce954a6375a78add2fb33b23441ed7ce9b79d4",
-      "task_ids": [
-        "202609071219-QV0SX9"
-      ]
+      "task_ids": ["202609071219-QV0SX9"]
     },
     {
       "service_only": true,
       "sha": "36ebe1d928d9f323ed134a1766acba485780b995",
-      "task_ids": [
-        "202609071219-QV0SX9"
-      ]
+      "task_ids": ["202609071219-QV0SX9"]
     },
     {
       "service_only": false,
       "sha": "b847aa915f64886905be06ccfb30e37544f35d25",
-      "task_ids": [
-        "202609071219-QV0SX9"
-      ]
+      "task_ids": ["202609071219-QV0SX9"]
     },
     {
       "service_only": true,
       "sha": "b010b904ce131e171ea19346f91334b32d5de8a0",
-      "task_ids": [
-        "202609071219-QV0SX9"
-      ]
+      "task_ids": ["202609071219-QV0SX9"]
     },
     {
       "service_only": false,
       "sha": "4e57fd16b87422e1d88b96e7cce2aa85ac8d3c0e",
-      "task_ids": [
-        "202609071219-QV0SX9"
-      ]
+      "task_ids": ["202609071219-QV0SX9"]
     },
     {
       "service_only": true,
       "sha": "0b3e88e60f2e34030fefc8b61cba391f236b2c55",
-      "task_ids": [
-        "202609071219-QV0SX9"
-      ]
+      "task_ids": ["202609071219-QV0SX9"]
     },
     {
       "service_only": true,
       "sha": "7a9d567a1292a0a8d47bb41a8ba232301946f872",
-      "task_ids": [
-        "202609071219-QV0SX9"
-      ]
+      "task_ids": ["202609071219-QV0SX9"]
     },
     {
       "service_only": false,
       "sha": "cdaf72b1fa42660466fe8dd986ff87b2bd093f88",
-      "task_ids": [
-        "202609071219-QV0SX9"
-      ]
+      "task_ids": ["202609071219-QV0SX9"]
     },
     {
       "service_only": false,
       "sha": "cea8e6f8708be9f3f246a21459176543d5bbe7e0",
-      "task_ids": [
-        "202609071219-QV0SX9"
-      ]
+      "task_ids": ["202609071219-QV0SX9"]
     },
     {
       "service_only": true,
       "sha": "2639130b3181867f53fa37121783c67c9ef1d064",
-      "task_ids": [
-        "202609071111-Y0Z0VQ"
-      ]
+      "task_ids": ["202609071111-Y0Z0VQ"]
     },
     {
       "service_only": true,
       "sha": "d065bf6221d1362a88c8b8054041316bc507ea42",
-      "task_ids": [
-        "202609071111-Y0Z0VQ"
-      ]
+      "task_ids": ["202609071111-Y0Z0VQ"]
     },
     {
       "service_only": true,
       "sha": "21f0360ecd16c1065a1088c8b8383bf27a88cf23",
-      "task_ids": [
-        "202609071111-Y0Z0VQ"
-      ]
+      "task_ids": ["202609071111-Y0Z0VQ"]
     },
     {
       "service_only": true,
       "sha": "faf628b0b1a989a7196fc768bdd13d47c03f08c8",
-      "task_ids": [
-        "202609071111-Y0Z0VQ"
-      ]
+      "task_ids": ["202609071111-Y0Z0VQ"]
     },
     {
       "service_only": true,
       "sha": "03a3f8cae62a7bff1990edd6e63cae1e94b3f860",
-      "task_ids": [
-        "202609071111-Y0Z0VQ"
-      ]
+      "task_ids": ["202609071111-Y0Z0VQ"]
     },
     {
       "service_only": true,
       "sha": "9a6fc0dc06200b626d95c9e0d1a060b80fe1e077",
-      "task_ids": [
-        "202609071111-Y0Z0VQ"
-      ]
+      "task_ids": ["202609071111-Y0Z0VQ"]
     },
     {
       "service_only": false,
       "sha": "cde1de7f515f73fb4324b5064446d87b9e6ce598",
-      "task_ids": [
-        "202609071111-Y0Z0VQ"
-      ]
+      "task_ids": ["202609071111-Y0Z0VQ"]
     },
     {
       "service_only": true,
       "sha": "87b4cf46dcddead7252f413367d163adb06aca92",
-      "task_ids": [
-        "202609071111-Y0Z0VQ"
-      ]
+      "task_ids": ["202609071111-Y0Z0VQ"]
     },
     {
       "service_only": true,
       "sha": "68df2e923cd9a382998a9f892243d2421b64ec17",
-      "task_ids": [
-        "202609071111-Y0Z0VQ"
-      ]
+      "task_ids": ["202609071111-Y0Z0VQ"]
     },
     {
       "service_only": false,
       "sha": "d0efb4b12add163221a45b68759fa85847fe0372",
-      "task_ids": [
-        "202609071111-Y0Z0VQ"
-      ]
+      "task_ids": ["202609071111-Y0Z0VQ"]
     },
     {
       "service_only": true,
       "sha": "f8a0e2fdaf2f0a9f7f328cc13679681707733b6f",
-      "task_ids": [
-        "202609071111-Y0Z0VQ"
-      ]
+      "task_ids": ["202609071111-Y0Z0VQ"]
     },
     {
       "service_only": true,
       "sha": "aa0ab4813d33e56363804d7225ab4052f180bb0c",
-      "task_ids": [
-        "202609071111-Y0Z0VQ"
-      ]
+      "task_ids": ["202609071111-Y0Z0VQ"]
     },
     {
       "service_only": false,
       "sha": "1e4add62bb52962cd618a55bcef3553b37111ffd",
-      "task_ids": [
-        "202609071111-Y0Z0VQ"
-      ]
+      "task_ids": ["202609071111-Y0Z0VQ"]
     },
     {
       "service_only": true,
       "sha": "6142ca0b0f3562f631319bc03aea2db45d8643c9",
-      "task_ids": [
-        "202609071111-Y0Z0VQ"
-      ]
+      "task_ids": ["202609071111-Y0Z0VQ"]
     },
     {
       "service_only": true,
       "sha": "a080783870ced46d2f2c11f536bd5daba9b296fa",
-      "task_ids": [
-        "202609071111-Y0Z0VQ"
-      ]
+      "task_ids": ["202609071111-Y0Z0VQ"]
     },
     {
       "service_only": false,
       "sha": "996e8a5174cfb8a880c8b7bc51be471440b8e325",
-      "task_ids": [
-        "202609071111-Y0Z0VQ"
-      ]
+      "task_ids": ["202609071111-Y0Z0VQ"]
     },
     {
       "service_only": true,
       "sha": "9b99271d55b0a1306942eead89a4b2974e3bdc1d",
-      "task_ids": [
-        "202609071111-Y0Z0VQ"
-      ]
+      "task_ids": ["202609071111-Y0Z0VQ"]
     },
     {
       "service_only": true,
       "sha": "db12f98164a34e35c88e9e89e87513ca2efab9d2",
-      "task_ids": [
-        "202609071111-Y0Z0VQ"
-      ]
+      "task_ids": ["202609071111-Y0Z0VQ"]
     },
     {
       "service_only": false,
       "sha": "8456da808bbaf774a54ab0eca19d8ea76769f960",
-      "task_ids": [
-        "202609071111-Y0Z0VQ"
-      ]
+      "task_ids": ["202609071111-Y0Z0VQ"]
     },
     {
       "service_only": true,
       "sha": "70c146493dab30a859788ae20cfdeab3cf57f1fd",
-      "task_ids": [
-        "202609071219-QV0SX9"
-      ]
+      "task_ids": ["202609071219-QV0SX9"]
     },
     {
       "service_only": true,
       "sha": "c70cf8be9f7315dcd7300e95556bcbf3cdc47cb3",
-      "task_ids": [
-        "202609071219-QV0SX9"
-      ]
+      "task_ids": ["202609071219-QV0SX9"]
     },
     {
       "service_only": false,
       "sha": "dad52228edd14a7ae9d798c0f5ae03fa5610e141",
-      "task_ids": [
-        "202609061750-Z0XXVD"
-      ]
+      "task_ids": ["202609061750-Z0XXVD"]
     },
     {
       "service_only": true,
       "sha": "b162edd7b2ee722b0c6f7cb063947975a001765c",
-      "task_ids": [
-        "202609070819-M065D1"
-      ]
+      "task_ids": ["202609070819-M065D1"]
     },
     {
       "service_only": true,
       "sha": "55e59a4dd5df6ea3de516fe2523b40a8ffb52d21",
-      "task_ids": [
-        "202609070819-M065D1"
-      ]
+      "task_ids": ["202609070819-M065D1"]
     },
     {
       "service_only": true,
       "sha": "a67fd07cc71439718b114325138b6a08b44b13e4",
-      "task_ids": [
-        "202609070819-M065D1"
-      ]
+      "task_ids": ["202609070819-M065D1"]
     },
     {
       "service_only": true,
       "sha": "565b0f13273d1c282c141bb7e9be499303e583bd",
-      "task_ids": [
-        "202609070819-M065D1"
-      ]
+      "task_ids": ["202609070819-M065D1"]
     },
     {
       "service_only": true,
       "sha": "ad68f7a96f1abd2126b9a2c3e61acf57f4384be8",
-      "task_ids": [
-        "202609070819-M065D1"
-      ]
+      "task_ids": ["202609070819-M065D1"]
     },
     {
       "service_only": true,
       "sha": "57702f371e5a91cc780176f52984bec33a9890b6",
-      "task_ids": [
-        "202609070819-M065D1"
-      ]
+      "task_ids": ["202609070819-M065D1"]
     },
     {
       "service_only": false,
       "sha": "929b932be46d528c36e9083eccbf5fc86d3b7cdc",
-      "task_ids": [
-        "202609070819-M065D1"
-      ]
+      "task_ids": ["202609070819-M065D1"]
     },
     {
       "service_only": true,
       "sha": "b99c7d87348d22b54cb2a36445fd94cddd732bf5",
-      "task_ids": [
-        "202609070351-6B37B9"
-      ]
+      "task_ids": ["202609070351-6B37B9"]
     },
     {
       "service_only": true,
       "sha": "d2353ae4c6cf5552443e9a60e63cbcfbb99e1e7b",
-      "task_ids": [
-        "202609070351-6B37B9"
-      ]
+      "task_ids": ["202609070351-6B37B9"]
     },
     {
       "service_only": true,
       "sha": "8d9ca51b4fb36ab8adfd85e9729b0adf8147c59c",
-      "task_ids": [
-        "202609070351-6B37B9"
-      ]
+      "task_ids": ["202609070351-6B37B9"]
     },
     {
       "service_only": true,
       "sha": "348a3600a37b39d61ebb4a4ac3f93c642de77198",
-      "task_ids": [
-        "202609070351-6B37B9"
-      ]
+      "task_ids": ["202609070351-6B37B9"]
     },
     {
       "service_only": true,
       "sha": "62a5710867e2fe3158f664a96e832151e91de8db",
-      "task_ids": [
-        "202609070351-6B37B9"
-      ]
+      "task_ids": ["202609070351-6B37B9"]
     },
     {
       "service_only": false,
       "sha": "168fe0d0d1c98e97657094c4eb6ad7096848fac1",
-      "task_ids": [
-        "202609070351-6B37B9"
-      ]
+      "task_ids": ["202609070351-6B37B9"]
     },
     {
       "service_only": true,
       "sha": "8c1384303cc702fff2fb881c441cacc6c1c523c2",
-      "task_ids": [
-        "202609070351-6B37B9"
-      ]
+      "task_ids": ["202609070351-6B37B9"]
     },
     {
       "service_only": true,
       "sha": "2f8590f913eaa2cde9184811d7ad2820be33f453",
-      "task_ids": [
-        "202609070351-6B37B9"
-      ]
+      "task_ids": ["202609070351-6B37B9"]
     },
     {
       "service_only": true,
       "sha": "3f7059fbed9fd2fd3a3fbbaedf7af77c14a17233",
-      "task_ids": [
-        "202609070351-6B37B9"
-      ]
+      "task_ids": ["202609070351-6B37B9"]
     },
     {
       "service_only": true,
       "sha": "47dab7082e31791ca89c9fb1cafd0d6afad3dd57",
-      "task_ids": [
-        "202609070351-6B37B9"
-      ]
+      "task_ids": ["202609070351-6B37B9"]
     },
     {
       "service_only": true,
       "sha": "e1f7c52ef394a46eb5e490291ba409a22cccaf6f",
-      "task_ids": [
-        "202609070351-6B37B9"
-      ]
+      "task_ids": ["202609070351-6B37B9"]
     },
     {
       "service_only": false,
@@ -403,821 +293,587 @@
     {
       "service_only": true,
       "sha": "f8505e8e0edb6d3e420e22cef1620bae2bbdab1d",
-      "task_ids": [
-        "202609070351-6B37B9"
-      ]
+      "task_ids": ["202609070351-6B37B9"]
     },
     {
       "service_only": true,
       "sha": "43227b631a4f7593b60997908519bbb475e4860f",
-      "task_ids": [
-        "202609070351-6B37B9"
-      ]
+      "task_ids": ["202609070351-6B37B9"]
     },
     {
       "service_only": true,
       "sha": "33859c98d6e2dc4cc5a3528b73e7046ea2a96a98",
-      "task_ids": [
-        "202609070351-6B37B9"
-      ]
+      "task_ids": ["202609070351-6B37B9"]
     },
     {
       "service_only": false,
       "sha": "68cf65a08ac1a380accf9821c9d3853069011248",
-      "task_ids": [
-        "202609070351-6B37B9"
-      ]
+      "task_ids": ["202609070351-6B37B9"]
     },
     {
       "service_only": false,
       "sha": "304f02dc7966f75f74ea2aec083a337572350f0f",
-      "task_ids": [
-        "202609061750-Z0XXVD"
-      ]
+      "task_ids": ["202609061750-Z0XXVD"]
     },
     {
       "service_only": true,
       "sha": "68b7b240362fe005e4ea5c63ee214c37fc545212",
-      "task_ids": [
-        "202609070233-NG368H"
-      ]
+      "task_ids": ["202609070233-NG368H"]
     },
     {
       "service_only": true,
       "sha": "b1783ceed8823238095113776d82647763ffbe1b",
-      "task_ids": [
-        "202609070233-NG368H"
-      ]
+      "task_ids": ["202609070233-NG368H"]
     },
     {
       "service_only": true,
       "sha": "30d74ffe38dc78012602381b811ea4fcd1e4a855",
-      "task_ids": [
-        "202609070233-NG368H"
-      ]
+      "task_ids": ["202609070233-NG368H"]
     },
     {
       "service_only": true,
       "sha": "185dc17c7eaa22c91fa82b9e481e98bfbb43fe1a",
-      "task_ids": [
-        "202609070233-NG368H"
-      ]
+      "task_ids": ["202609070233-NG368H"]
     },
     {
       "service_only": true,
       "sha": "201859728a179ded09e43484cfbba117069d48a0",
-      "task_ids": [
-        "202609070233-NG368H"
-      ]
+      "task_ids": ["202609070233-NG368H"]
     },
     {
       "service_only": false,
       "sha": "93ed9b9899f35fb9e4c141f700c28eeb517808b7",
-      "task_ids": [
-        "202609070233-NG368H"
-      ]
+      "task_ids": ["202609070233-NG368H"]
     },
     {
       "service_only": true,
       "sha": "8ebc48d745af6bbd72540f96c0f8c62748d168c6",
-      "task_ids": [
-        "202609070233-NG368H"
-      ]
+      "task_ids": ["202609070233-NG368H"]
     },
     {
       "service_only": true,
       "sha": "4f04ff897849a85601dd7dcab7ca1eeceab1f1ee",
-      "task_ids": [
-        "202609070233-NG368H"
-      ]
+      "task_ids": ["202609070233-NG368H"]
     },
     {
       "service_only": true,
       "sha": "2cab17c9542c83e8dfa4d3dd5bc186cc11e15394",
-      "task_ids": [
-        "202609070233-NG368H"
-      ]
+      "task_ids": ["202609070233-NG368H"]
     },
     {
       "service_only": true,
       "sha": "b4d0e7acd0b9e47d751e135d47ef4eeaa358e66f",
-      "task_ids": [
-        "202609070233-NG368H"
-      ]
+      "task_ids": ["202609070233-NG368H"]
     },
     {
       "service_only": true,
       "sha": "492136f731dc3b3c7583f37b22d83f4e6387320b",
-      "task_ids": [
-        "202609070233-NG368H"
-      ]
+      "task_ids": ["202609070233-NG368H"]
     },
     {
       "service_only": true,
       "sha": "bf210e93cc9bab5d26e9cbc829b6007c70fe51eb",
-      "task_ids": [
-        "202609070233-NG368H"
-      ]
+      "task_ids": ["202609070233-NG368H"]
     },
     {
       "service_only": false,
       "sha": "8afecc9522106f828eda13bd768c00b0c523a6e8",
-      "task_ids": [
-        "202609070233-NG368H"
-      ]
+      "task_ids": ["202609070233-NG368H"]
     },
     {
       "service_only": true,
       "sha": "81b3fe507426d82ea903d7a63fd6335b583d81b5",
-      "task_ids": [
-        "202609061750-Z0XXVD"
-      ]
+      "task_ids": ["202609061750-Z0XXVD"]
     },
     {
       "service_only": true,
       "sha": "eba01eac5a6b6c347f7850b4736ae620559b5115",
-      "task_ids": [
-        "202609061750-Z0XXVD"
-      ]
+      "task_ids": ["202609061750-Z0XXVD"]
     },
     {
       "service_only": true,
       "sha": "327a2b4b31957f9e989449a20b693dca2e444309",
-      "task_ids": [
-        "202609061750-Z0XXVD"
-      ]
+      "task_ids": ["202609061750-Z0XXVD"]
     },
     {
       "service_only": true,
       "sha": "f0131533865be689bef06bdf41cbe2730ecb0fc4",
-      "task_ids": [
-        "202609061750-Z0XXVD"
-      ]
+      "task_ids": ["202609061750-Z0XXVD"]
     },
     {
       "service_only": true,
       "sha": "ab635aca8893944fa51ef0ffb0b17afe8630f097",
-      "task_ids": [
-        "202609061750-Z0XXVD"
-      ]
+      "task_ids": ["202609061750-Z0XXVD"]
     },
     {
       "service_only": true,
       "sha": "59b81b8ee097844214dc09ca89d95caefd5a1fa5",
-      "task_ids": [
-        "202609061750-Z0XXVD"
-      ]
+      "task_ids": ["202609061750-Z0XXVD"]
     },
     {
       "service_only": true,
       "sha": "60f5e39b85594ff837ab6b719445d4615cd5f42a",
-      "task_ids": [
-        "202609061750-Z0XXVD"
-      ]
+      "task_ids": ["202609061750-Z0XXVD"]
     },
     {
       "service_only": true,
       "sha": "a2c83d96760c064af9677245abc2535b6b33f68d",
-      "task_ids": [
-        "202609061750-Z0XXVD"
-      ]
+      "task_ids": ["202609061750-Z0XXVD"]
     },
     {
       "service_only": false,
       "sha": "69dff6a91be8ea2832e5065504e0b70d0fa9709f",
-      "task_ids": [
-        "202609061750-Z0XXVD"
-      ]
+      "task_ids": ["202609061750-Z0XXVD"]
     },
     {
       "service_only": true,
       "sha": "fd95bb6830d2df61a457e181f3ba2633523db65e",
-      "task_ids": [
-        "202609061750-Z0XXVD"
-      ]
+      "task_ids": ["202609061750-Z0XXVD"]
     },
     {
       "service_only": true,
       "sha": "b8b77e4e755036c2f5e8cdff829533ec1f9d5298",
-      "task_ids": [
-        "202609061750-Z0XXVD"
-      ]
+      "task_ids": ["202609061750-Z0XXVD"]
     },
     {
       "service_only": true,
       "sha": "6e300c95e95be8e3e538d9e6469ca309f9fbe87f",
-      "task_ids": [
-        "202609061750-Z0XXVD"
-      ]
+      "task_ids": ["202609061750-Z0XXVD"]
     },
     {
       "service_only": false,
       "sha": "b9c18bde3de689c8a57f7abeafee6d69c77ca346",
-      "task_ids": [
-        "202609061750-Z0XXVD"
-      ]
+      "task_ids": ["202609061750-Z0XXVD"]
     },
     {
       "service_only": true,
       "sha": "e66cbb2a9345224810fd3f6b2489162de2d4b80c",
-      "task_ids": [
-        "202609061750-Z0XXVD"
-      ]
+      "task_ids": ["202609061750-Z0XXVD"]
     },
     {
       "service_only": false,
       "sha": "8ba826b53de8ed163c203fc0d0ada8fb020ca642",
-      "task_ids": [
-        "202609061750-Z0XXVD"
-      ]
+      "task_ids": ["202609061750-Z0XXVD"]
     },
     {
       "service_only": true,
       "sha": "d6c9f8252eda2990c81abade61064f74ff5ab430",
-      "task_ids": [
-        "202609061750-Z0XXVD"
-      ]
+      "task_ids": ["202609061750-Z0XXVD"]
     },
     {
       "service_only": false,
       "sha": "0530dc68ca31bc8a5b87ab091482bfd06081c873",
-      "task_ids": [
-        "202609061750-Z0XXVD"
-      ]
+      "task_ids": ["202609061750-Z0XXVD"]
     },
     {
       "service_only": true,
       "sha": "9404b8fc5e74dfa5f93d81a03c7e13b55a06cc13",
-      "task_ids": [
-        "202609061750-Z0XXVD"
-      ]
+      "task_ids": ["202609061750-Z0XXVD"]
     },
     {
       "service_only": false,
       "sha": "86665790e1faee831ccd7dc4d21c111e3af953bf",
-      "task_ids": [
-        "202609061750-Z0XXVD"
-      ]
+      "task_ids": ["202609061750-Z0XXVD"]
     },
     {
       "service_only": true,
       "sha": "e3a8e6658b2966f0b8ee5d81d4b79a750d2e07ae",
-      "task_ids": [
-        "202609061750-Z0XXVD"
-      ]
+      "task_ids": ["202609061750-Z0XXVD"]
     },
     {
       "service_only": false,
       "sha": "e070a79cd2466cb8b02d91a3731aac63b805cab2",
-      "task_ids": [
-        "202609061750-Z0XXVD"
-      ]
+      "task_ids": ["202609061750-Z0XXVD"]
     },
     {
       "service_only": true,
       "sha": "9f0dadafc8fb2ccb892503ffd54ac6bfeded1a85",
-      "task_ids": [
-        "202609061750-Z0XXVD"
-      ]
+      "task_ids": ["202609061750-Z0XXVD"]
     },
     {
       "service_only": false,
       "sha": "1f6d5b06fccdc864d4a3721d7891c663d8442ff6",
-      "task_ids": [
-        "202609061750-Z0XXVD"
-      ]
+      "task_ids": ["202609061750-Z0XXVD"]
     },
     {
       "service_only": true,
       "sha": "196b416399ccb385636b01aacf7e2940d358db69",
-      "task_ids": [
-        "202609061750-Z0XXVD"
-      ]
+      "task_ids": ["202609061750-Z0XXVD"]
     },
     {
       "service_only": false,
       "sha": "41415058404d73e8cd439c088d169637f0ef0d7f",
-      "task_ids": [
-        "202609061750-Z0XXVD"
-      ]
+      "task_ids": ["202609061750-Z0XXVD"]
     },
     {
       "service_only": true,
       "sha": "a6b00ad7e8d4bc1adadcbbc7083bc14e6882feed",
-      "task_ids": [
-        "202609061750-Z0XXVD"
-      ]
+      "task_ids": ["202609061750-Z0XXVD"]
     },
     {
       "service_only": false,
       "sha": "ddf06df251b8acb3189390793d747741dd0f3e3c",
-      "task_ids": [
-        "202609061750-Z0XXVD"
-      ]
+      "task_ids": ["202609061750-Z0XXVD"]
     },
     {
       "service_only": true,
       "sha": "eaafbc7886d2b588b83e154815229c85e48ddc46",
-      "task_ids": [
-        "202609061750-Z0XXVD"
-      ]
+      "task_ids": ["202609061750-Z0XXVD"]
     },
     {
       "service_only": false,
       "sha": "c1b560eb0ce149a3a5e5200b192b7128265a62e4",
-      "task_ids": [
-        "202609061750-Z0XXVD"
-      ]
+      "task_ids": ["202609061750-Z0XXVD"]
     },
     {
       "service_only": true,
       "sha": "2cf836db0fe3ad72ddc751b906f7ac1b436beb4d",
-      "task_ids": [
-        "202609061750-Z0XXVD"
-      ]
+      "task_ids": ["202609061750-Z0XXVD"]
     },
     {
       "service_only": false,
       "sha": "19239f9e62e172de9e679b57e6cb786a2f6970f3",
-      "task_ids": [
-        "202609061750-Z0XXVD"
-      ]
+      "task_ids": ["202609061750-Z0XXVD"]
     },
     {
       "service_only": true,
       "sha": "da01e181e27bf3cd7bdede1c328e6b2bcdf689ff",
-      "task_ids": [
-        "202609061750-Z0XXVD"
-      ]
+      "task_ids": ["202609061750-Z0XXVD"]
     },
     {
       "service_only": false,
       "sha": "a24cfb6c87e6e2945d587e1a3c7614ce71b8fb4b",
-      "task_ids": [
-        "202609061750-Z0XXVD"
-      ]
+      "task_ids": ["202609061750-Z0XXVD"]
     },
     {
       "service_only": true,
       "sha": "262da3130bc5628a7641c400c74368ae355000bf",
-      "task_ids": [
-        "202609061636-BW11J6"
-      ]
+      "task_ids": ["202609061636-BW11J6"]
     },
     {
       "service_only": true,
       "sha": "11b53e5f844d8d41b7fd5b5ec082ad7937c0721c",
-      "task_ids": [
-        "202609061636-BW11J6"
-      ]
+      "task_ids": ["202609061636-BW11J6"]
     },
     {
       "service_only": true,
       "sha": "a2564340a3ab3600f2c1278e39293a4499c155c7",
-      "task_ids": [
-        "202609061636-BW11J6"
-      ]
+      "task_ids": ["202609061636-BW11J6"]
     },
     {
       "service_only": true,
       "sha": "ca2bb87f77bbc3ae09edf571e483e98a44f4a9bf",
-      "task_ids": [
-        "202609061636-BW11J6"
-      ]
+      "task_ids": ["202609061636-BW11J6"]
     },
     {
       "service_only": true,
       "sha": "60244110592975d2f933a2384252083080fcf3d1",
-      "task_ids": [
-        "202609061636-BW11J6"
-      ]
+      "task_ids": ["202609061636-BW11J6"]
     },
     {
       "service_only": true,
       "sha": "ba8874a888de07be56ca1ec88c3954c7a0972bd9",
-      "task_ids": [
-        "202609061636-BW11J6"
-      ]
+      "task_ids": ["202609061636-BW11J6"]
     },
     {
       "service_only": false,
       "sha": "a4aedd5a03255a560eebe6f6e62ae8328dd7a84b",
-      "task_ids": [
-        "202609061636-BW11J6"
-      ]
+      "task_ids": ["202609061636-BW11J6"]
     },
     {
       "service_only": true,
       "sha": "ec95c2e8030affdc7562c26c2f41dc098b9dc173",
-      "task_ids": [
-        "202609061636-BW11J6"
-      ]
+      "task_ids": ["202609061636-BW11J6"]
     },
     {
       "service_only": true,
       "sha": "19ce338e6fb63ee55c79de6d56a72c7a837fc8f7",
-      "task_ids": [
-        "202609061636-BW11J6"
-      ]
+      "task_ids": ["202609061636-BW11J6"]
     },
     {
       "service_only": true,
       "sha": "f3d1eb3130ab9c067a0503d63e3b043bb6885d3f",
-      "task_ids": [
-        "202609061636-BW11J6"
-      ]
+      "task_ids": ["202609061636-BW11J6"]
     },
     {
       "service_only": false,
       "sha": "ad9e51536785a9d31279a2964e4c7f537badc7db",
-      "task_ids": [
-        "202609061636-BW11J6"
-      ]
+      "task_ids": ["202609061636-BW11J6"]
     },
     {
       "service_only": true,
       "sha": "b1e13dec007f8251957c77a887b9a887cc789a82",
-      "task_ids": [
-        "202609060720-NZXQ0E"
-      ]
+      "task_ids": ["202609060720-NZXQ0E"]
     },
     {
       "service_only": true,
       "sha": "ba67d24ab800fa59b097a563b65a47ddd2df3040",
-      "task_ids": [
-        "202609060720-NZXQ0E"
-      ]
+      "task_ids": ["202609060720-NZXQ0E"]
     },
     {
       "service_only": true,
       "sha": "467a21903b1ad3bc886702db47454d80834ba4cc",
-      "task_ids": [
-        "202609060720-NZXQ0E"
-      ]
+      "task_ids": ["202609060720-NZXQ0E"]
     },
     {
       "service_only": true,
       "sha": "e4955798705acb39b67decdd38d8d5555822cce6",
-      "task_ids": [
-        "202609060720-NZXQ0E"
-      ]
+      "task_ids": ["202609060720-NZXQ0E"]
     },
     {
       "service_only": false,
       "sha": "48dda1e008438f65ba6e8a2253b723bde5994751",
-      "task_ids": [
-        "202609060720-NZXQ0E"
-      ]
+      "task_ids": ["202609060720-NZXQ0E"]
     },
     {
       "service_only": true,
       "sha": "430befb9567c4b34d393fd65aa84e2272ffa266e",
-      "task_ids": [
-        "202609060720-NZXQ0E"
-      ]
+      "task_ids": ["202609060720-NZXQ0E"]
     },
     {
       "service_only": true,
       "sha": "0183bdf929e4f1287f1a9eab47da83c48aff3fc7",
-      "task_ids": [
-        "202609060720-NZXQ0E"
-      ]
+      "task_ids": ["202609060720-NZXQ0E"]
     },
     {
       "service_only": true,
       "sha": "66ced0b68f08d835a762267662c2bf82d71ca16a",
-      "task_ids": [
-        "202609060720-NZXQ0E"
-      ]
+      "task_ids": ["202609060720-NZXQ0E"]
     },
     {
       "service_only": false,
       "sha": "7d5e2ef3bac557d785b7ec613eaedbefc656e379",
-      "task_ids": [
-        "202609060720-NZXQ0E"
-      ]
+      "task_ids": ["202609060720-NZXQ0E"]
     },
     {
       "service_only": true,
       "sha": "ac565f6fb1e401686c6566f8fcf654799be258e6",
-      "task_ids": [
-        "202609060720-NZXQ0E"
-      ]
+      "task_ids": ["202609060720-NZXQ0E"]
     },
     {
       "service_only": true,
       "sha": "898d06351bcf8975bcec3d321e6a418899d7c6c6",
-      "task_ids": [
-        "202609060720-NZXQ0E"
-      ]
+      "task_ids": ["202609060720-NZXQ0E"]
     },
     {
       "service_only": true,
       "sha": "ec418b1b334b4efc934fa1a7506a149a7007441c",
-      "task_ids": [
-        "202609060720-NZXQ0E"
-      ]
+      "task_ids": ["202609060720-NZXQ0E"]
     },
     {
       "service_only": false,
       "sha": "8f77e8033e63f503c06801cd8af358cc57f1aa2a",
-      "task_ids": [
-        "202609060720-NZXQ0E"
-      ]
+      "task_ids": ["202609060720-NZXQ0E"]
     },
     {
       "service_only": false,
       "sha": "c74e8f1cddd60375b63cb30d0c3d62538b7fc702",
-      "task_ids": [
-        "202609060720-NZXQ0E"
-      ]
+      "task_ids": ["202609060720-NZXQ0E"]
     },
     {
       "service_only": true,
       "sha": "7a1731ccc2784fc5d4a1573fc8b8adbacf704689",
-      "task_ids": [
-        "202609060720-NZXQ0E"
-      ]
+      "task_ids": ["202609060720-NZXQ0E"]
     },
     {
       "service_only": false,
       "sha": "736fba555b20672162360b9d5bc5d9205ffc3262",
-      "task_ids": [
-        "202609060720-NZXQ0E"
-      ]
+      "task_ids": ["202609060720-NZXQ0E"]
     },
     {
       "service_only": false,
       "sha": "b33a39fb7c4ae579a74e6550f93ef557307ae645",
-      "task_ids": [
-        "202609060720-NZXQ0E"
-      ]
+      "task_ids": ["202609060720-NZXQ0E"]
     },
     {
       "service_only": true,
       "sha": "33d00156ba1063f607e4e823d4de714d6466390d",
-      "task_ids": [
-        "202609060720-NZXQ0E"
-      ]
+      "task_ids": ["202609060720-NZXQ0E"]
     },
     {
       "service_only": false,
       "sha": "8ad0c158c5b4a6a9940b7bb62c321f84289f5e6d",
-      "task_ids": [
-        "202609060720-NZXQ0E"
-      ]
+      "task_ids": ["202609060720-NZXQ0E"]
     },
     {
       "service_only": true,
       "sha": "43f3ba86b40cfae0555ec7775d85d97b5d4c2377",
-      "task_ids": [
-        "202609060720-NZXQ0E"
-      ]
+      "task_ids": ["202609060720-NZXQ0E"]
     },
     {
       "service_only": true,
       "sha": "e7aae1f7418195dc506b00aef74c951d8831390a",
-      "task_ids": [
-        "202609042327-PH5N6S"
-      ]
+      "task_ids": ["202609042327-PH5N6S"]
     },
     {
       "service_only": true,
       "sha": "fdf2dd5b358c2f17aa248a5e90bda436bcdef235",
-      "task_ids": [
-        "202609042327-PH5N6S"
-      ]
+      "task_ids": ["202609042327-PH5N6S"]
     },
     {
       "service_only": true,
       "sha": "424c7e7e1659d29ce2963f1ea7981566949430b2",
-      "task_ids": [
-        "202609042327-PH5N6S"
-      ]
+      "task_ids": ["202609042327-PH5N6S"]
     },
     {
       "service_only": true,
       "sha": "367024bb03d41c45982ef45ec4d87b058913a265",
-      "task_ids": [
-        "202609042327-PH5N6S"
-      ]
+      "task_ids": ["202609042327-PH5N6S"]
     },
     {
       "service_only": true,
       "sha": "801dbd096b1f1b5a6735c3fb24220f38a5067e2f",
-      "task_ids": [
-        "202609042327-PH5N6S"
-      ]
+      "task_ids": ["202609042327-PH5N6S"]
     },
     {
       "service_only": false,
       "sha": "a25edd68b3639f22fe74be7476df9397c588b304",
-      "task_ids": [
-        "202609042327-PH5N6S"
-      ]
+      "task_ids": ["202609042327-PH5N6S"]
     },
     {
       "service_only": true,
       "sha": "86505007bb7171bcfaafd4d0ee2ed1f1e8fab783",
-      "task_ids": [
-        "202609042327-PH5N6S"
-      ]
+      "task_ids": ["202609042327-PH5N6S"]
     },
     {
       "service_only": true,
       "sha": "f15f2914fd02ed0372c4c65aced04639cb938f2f",
-      "task_ids": [
-        "202609042327-PH5N6S"
-      ]
+      "task_ids": ["202609042327-PH5N6S"]
     },
     {
       "service_only": true,
       "sha": "9626c6364f0aab2a7f7efb3d05b4757a8207c156",
-      "task_ids": [
-        "202609042327-PH5N6S"
-      ]
+      "task_ids": ["202609042327-PH5N6S"]
     },
     {
       "service_only": false,
       "sha": "572353c8ad3dffbbf455bfcb82ce24d40574ae28",
-      "task_ids": [
-        "202609042327-PH5N6S"
-      ]
+      "task_ids": ["202609042327-PH5N6S"]
     },
     {
       "service_only": true,
       "sha": "48d2e75856c3da7d3635946ad7d48f717afb5104",
-      "task_ids": [
-        "202609042327-PH5N6S"
-      ]
+      "task_ids": ["202609042327-PH5N6S"]
     },
     {
       "service_only": true,
       "sha": "de6df111e267e997f5056fbfc7c0a2844e0576a0",
-      "task_ids": [
-        "202609042327-PH5N6S"
-      ]
+      "task_ids": ["202609042327-PH5N6S"]
     },
     {
       "service_only": true,
       "sha": "ea8830b4bee74c656ed888384625f95046df2218",
-      "task_ids": [
-        "202609042327-PH5N6S"
-      ]
+      "task_ids": ["202609042327-PH5N6S"]
     },
     {
       "service_only": true,
       "sha": "5d65025e875e3d533d5b1ad3196b566ee00d0efe",
-      "task_ids": [
-        "202609042327-PH5N6S"
-      ]
+      "task_ids": ["202609042327-PH5N6S"]
     },
     {
       "service_only": true,
       "sha": "1c14163429fc67acdeb98b34a7fae404d68ddc38",
-      "task_ids": [
-        "202609042327-PH5N6S"
-      ]
+      "task_ids": ["202609042327-PH5N6S"]
     },
     {
       "service_only": false,
       "sha": "2e9f7df5ebad103bf6ade9d4cffb750da2dd0318",
-      "task_ids": [
-        "202609042327-PH5N6S"
-      ]
+      "task_ids": ["202609042327-PH5N6S"]
     },
     {
       "service_only": true,
       "sha": "a8648b4c439676621ded1296f62b4eeb6720efe0",
-      "task_ids": [
-        "202609042327-PH5N6S"
-      ]
+      "task_ids": ["202609042327-PH5N6S"]
     },
     {
       "service_only": true,
       "sha": "1438fcf8c4a38ea3456682c77fc4532dde2c7251",
-      "task_ids": [
-        "202609042327-PH5N6S"
-      ]
+      "task_ids": ["202609042327-PH5N6S"]
     },
     {
       "service_only": true,
       "sha": "a5846b477ce0b3bde2fdf4f35a0bd973780bc886",
-      "task_ids": [
-        "202609042327-PH5N6S"
-      ]
+      "task_ids": ["202609042327-PH5N6S"]
     },
     {
       "service_only": false,
       "sha": "d8298cfe7b38b3b085a44810a4000ad323e67afd",
-      "task_ids": [
-        "202609042327-PH5N6S"
-      ]
+      "task_ids": ["202609042327-PH5N6S"]
     },
     {
       "service_only": false,
       "sha": "1981b974568071c65b8c0c3f971311de59758d83",
-      "task_ids": [
-        "202609042327-PH5N6S"
-      ]
+      "task_ids": ["202609042327-PH5N6S"]
     },
     {
       "service_only": true,
       "sha": "cf909f3246f9227135813776df941f7740094e89",
-      "task_ids": [
-        "202609042327-PH5N6S"
-      ]
+      "task_ids": ["202609042327-PH5N6S"]
     },
     {
       "service_only": true,
       "sha": "6bf388900d2c64a1849d2fb396268a67081d021d",
-      "task_ids": [
-        "202609042327-PH5N6S"
-      ]
+      "task_ids": ["202609042327-PH5N6S"]
     },
     {
       "service_only": true,
       "sha": "b82739de719c160acb631be6d771c69ccaba1590",
-      "task_ids": [
-        "202609042327-PH5N6S"
-      ]
+      "task_ids": ["202609042327-PH5N6S"]
     },
     {
       "service_only": true,
       "sha": "86e9343e668a2aa52883cab40c176b118ad33ffd",
-      "task_ids": [
-        "202609042327-PH5N6S"
-      ]
+      "task_ids": ["202609042327-PH5N6S"]
     },
     {
       "service_only": true,
       "sha": "4b0c941f98ae31152ddef4aa925c439e57505225",
-      "task_ids": [
-        "202609042327-PH5N6S"
-      ]
+      "task_ids": ["202609042327-PH5N6S"]
     },
     {
       "service_only": true,
       "sha": "e72029c56f3a62185c8af0c88e7cb944e717fa5e",
-      "task_ids": [
-        "202609042327-PH5N6S"
-      ]
+      "task_ids": ["202609042327-PH5N6S"]
     },
     {
       "service_only": false,
       "sha": "6764bc96f86b48a697e3fdc63ed7f96d6ee15cf1",
-      "task_ids": [
-        "202609042327-PH5N6S"
-      ]
+      "task_ids": ["202609042327-PH5N6S"]
     },
     {
       "service_only": true,
       "sha": "556bd57198b1b3c70d3a242dc3e7f3e16f9edd01",
-      "task_ids": [
-        "202609041801-ZVX69C"
-      ]
+      "task_ids": ["202609041801-ZVX69C"]
     },
     {
       "service_only": true,
       "sha": "e81a82df8905e1cd2b70e707edaeb54b540afa72",
-      "task_ids": [
-        "202609041801-ZVX69C"
-      ]
+      "task_ids": ["202609041801-ZVX69C"]
     },
     {
       "service_only": true,
       "sha": "a4cbbf112295aba5da065449ecaa50394c2efed6",
-      "task_ids": [
-        "202609041801-ZVX69C"
-      ]
+      "task_ids": ["202609041801-ZVX69C"]
     },
     {
       "service_only": true,
       "sha": "50d0834079f967679fd56ba98fa311eb7e457335",
-      "task_ids": [
-        "202609041801-ZVX69C"
-      ]
+      "task_ids": ["202609041801-ZVX69C"]
     },
     {
       "service_only": false,
       "sha": "8701b4ee14a0566d0c1fe97401604fa973847db4",
-      "task_ids": [
-        "202609041801-ZVX69C"
-      ]
+      "task_ids": ["202609041801-ZVX69C"]
     },
     {
       "service_only": true,
       "sha": "e01b34f44379df3c04a5956e838aab85129dc8fa",
-      "task_ids": [
-        "202609041801-ZVX69C"
-      ]
+      "task_ids": ["202609041801-ZVX69C"]
     },
     {
       "service_only": true,
       "sha": "1e3a1d54e7c1caaed49e899df8d16a28a32290c8",
-      "task_ids": [
-        "202609041801-ZVX69C"
-      ]
+      "task_ids": ["202609041801-ZVX69C"]
     },
     {
       "service_only": false,
@@ -1227,170 +883,122 @@
     {
       "service_only": true,
       "sha": "fbf8853c500b57ab28d42f6e140e6bbe03603f8e",
-      "task_ids": [
-        "202609041801-ZVX69C"
-      ]
+      "task_ids": ["202609041801-ZVX69C"]
     },
     {
       "service_only": true,
       "sha": "2b0bcb6d5b595b8c0d9e70281d95a97f4cf1b917",
-      "task_ids": [
-        "202609041801-ZVX69C"
-      ]
+      "task_ids": ["202609041801-ZVX69C"]
     },
     {
       "service_only": true,
       "sha": "8f7b0706b69c104806f4591567750ceb58697ce2",
-      "task_ids": [
-        "202609041801-ZVX69C"
-      ]
+      "task_ids": ["202609041801-ZVX69C"]
     },
     {
       "service_only": true,
       "sha": "ad262173f6ee46b72668f12bc8b6ab40798338a3",
-      "task_ids": [
-        "202609041801-ZVX69C"
-      ]
+      "task_ids": ["202609041801-ZVX69C"]
     },
     {
       "service_only": false,
       "sha": "5e35370df7bd24be3cf0c5d59bd17bb1fd99f856",
-      "task_ids": [
-        "202609041801-ZVX69C"
-      ]
+      "task_ids": ["202609041801-ZVX69C"]
     },
     {
       "service_only": false,
       "sha": "b255ea521a19c0861a939284bc9fa8bdd5816325",
-      "task_ids": [
-        "202609041801-ZVX69C"
-      ]
+      "task_ids": ["202609041801-ZVX69C"]
     },
     {
       "service_only": true,
       "sha": "ac91f8bfdd5718221a949f82c607936b77150cf1",
-      "task_ids": [
-        "202609041801-ZVX69C"
-      ]
+      "task_ids": ["202609041801-ZVX69C"]
     },
     {
       "service_only": true,
       "sha": "baae32a2e3c5e0c45c1afa823009df3436d2fe67",
-      "task_ids": [
-        "202609041801-ZVX69C"
-      ]
+      "task_ids": ["202609041801-ZVX69C"]
     },
     {
       "service_only": false,
       "sha": "0bc37e5952e2713f665ee69687b4aab45f83fd54",
-      "task_ids": [
-        "202609041801-ZVX69C"
-      ]
+      "task_ids": ["202609041801-ZVX69C"]
     },
     {
       "service_only": false,
       "sha": "99fdb3c4cc9123982becb3edebb5bd030885fd0e",
-      "task_ids": [
-        "202609041801-ZVX69C"
-      ]
+      "task_ids": ["202609041801-ZVX69C"]
     },
     {
       "service_only": true,
       "sha": "6c866e888b5d8af4bc6b10fc308462e56e3deb76",
-      "task_ids": [
-        "202609041801-ZVX69C"
-      ]
+      "task_ids": ["202609041801-ZVX69C"]
     },
     {
       "service_only": true,
       "sha": "3fc391c151ab2f1879ea9eae5c2e8cb73469b787",
-      "task_ids": [
-        "202609041801-ZVX69C"
-      ]
+      "task_ids": ["202609041801-ZVX69C"]
     },
     {
       "service_only": true,
       "sha": "218df006de80522a871e7d32b4e6b26de6fdb96a",
-      "task_ids": [
-        "202609041801-ZVX69C"
-      ]
+      "task_ids": ["202609041801-ZVX69C"]
     },
     {
       "service_only": true,
       "sha": "4c90e955a1e7f6c577966ee4d7bf873a2e3936aa",
-      "task_ids": [
-        "202609041801-ZVX69C"
-      ]
+      "task_ids": ["202609041801-ZVX69C"]
     },
     {
       "service_only": false,
       "sha": "1050a0f4856603b998283a05f2caa4cc8ebcca96",
-      "task_ids": [
-        "202609041801-ZVX69C"
-      ]
+      "task_ids": ["202609041801-ZVX69C"]
     },
     {
       "service_only": true,
       "sha": "11f06801e10fa00f954bd1d3ed22a5d138d0f46f",
-      "task_ids": [
-        "202609041801-ZVX69C"
-      ]
+      "task_ids": ["202609041801-ZVX69C"]
     },
     {
       "service_only": true,
       "sha": "3cd9c9fa22be0b70c1f14d2f2100f5c0503aa3be",
-      "task_ids": [
-        "202609041801-ZVX69C"
-      ]
+      "task_ids": ["202609041801-ZVX69C"]
     },
     {
       "service_only": true,
       "sha": "8f006bf84e1215d36d1e1182a190a89958cdaacb",
-      "task_ids": [
-        "202609041801-ZVX69C"
-      ]
+      "task_ids": ["202609041801-ZVX69C"]
     },
     {
       "service_only": true,
       "sha": "42463c33c80a49eea4445f2aa6a382a6ab6588ac",
-      "task_ids": [
-        "202609041801-ZVX69C"
-      ]
+      "task_ids": ["202609041801-ZVX69C"]
     },
     {
       "service_only": true,
       "sha": "4bed92f9eeac21183a2558bab17c9795a20ec6a7",
-      "task_ids": [
-        "202609041801-ZVX69C"
-      ]
+      "task_ids": ["202609041801-ZVX69C"]
     },
     {
       "service_only": true,
       "sha": "09c20ba49b88479a3198f73d0989817e3a6f2895",
-      "task_ids": [
-        "202609041801-ZVX69C"
-      ]
+      "task_ids": ["202609041801-ZVX69C"]
     },
     {
       "service_only": false,
       "sha": "8b1594fdbddea370c02760dd835f4f98f9caf160",
-      "task_ids": [
-        "202609041801-ZVX69C"
-      ]
+      "task_ids": ["202609041801-ZVX69C"]
     },
     {
       "service_only": true,
       "sha": "6e49077db61daed5204b514e7d6e071c190edda6",
-      "task_ids": [
-        "202609031717-PX8PZT"
-      ]
+      "task_ids": ["202609031717-PX8PZT"]
     },
     {
       "service_only": true,
       "sha": "b97f2fe710146f34eeccb1bd57bd66f35390dafb",
-      "task_ids": [
-        "202609031717-PX8PZT"
-      ]
+      "task_ids": ["202609031717-PX8PZT"]
     }
   ],
   "digest": "sha256:60c9be411166e867f42697229a64ec713260e34e0f8b45428b2490af6691ab5c",

--- a/scripts/baselines/agent-efficiency-VN1FN4-before.json
+++ b/scripts/baselines/agent-efficiency-VN1FN4-before.json
@@ -1,0 +1,6355 @@
+{
+  "commits": [
+    {
+      "service_only": true,
+      "sha": "9e0f99960120a41e4056c62403407b76759c2584",
+      "task_ids": [
+        "202609071219-QV0SX9"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "3c45166b31d0a9960f52aa11c3259afd472dd691",
+      "task_ids": [
+        "202609071219-QV0SX9"
+      ]
+    },
+    {
+      "service_only": false,
+      "sha": "9b9bc432eb60fc173548a717c8ec74cabd50c00a",
+      "task_ids": []
+    },
+    {
+      "service_only": false,
+      "sha": "07a55a939b2892abd9aa9c9fae7981d08e0b9c35",
+      "task_ids": []
+    },
+    {
+      "service_only": true,
+      "sha": "080bfea10e63472c9d895c7880d1f4a4dc720bc4",
+      "task_ids": [
+        "202609071219-QV0SX9"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "07e2ff7d228879b9a14a416c261c8f97f38ae287",
+      "task_ids": [
+        "202609071219-QV0SX9"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "082de2c2ca742fd4150dbf7439a2b1fb9f5f79ed",
+      "task_ids": [
+        "202609071219-QV0SX9"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "b36211390f5a1593bccfb1726991120573211292",
+      "task_ids": [
+        "202609071219-QV0SX9"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "c8ce954a6375a78add2fb33b23441ed7ce9b79d4",
+      "task_ids": [
+        "202609071219-QV0SX9"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "36ebe1d928d9f323ed134a1766acba485780b995",
+      "task_ids": [
+        "202609071219-QV0SX9"
+      ]
+    },
+    {
+      "service_only": false,
+      "sha": "b847aa915f64886905be06ccfb30e37544f35d25",
+      "task_ids": [
+        "202609071219-QV0SX9"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "b010b904ce131e171ea19346f91334b32d5de8a0",
+      "task_ids": [
+        "202609071219-QV0SX9"
+      ]
+    },
+    {
+      "service_only": false,
+      "sha": "4e57fd16b87422e1d88b96e7cce2aa85ac8d3c0e",
+      "task_ids": [
+        "202609071219-QV0SX9"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "0b3e88e60f2e34030fefc8b61cba391f236b2c55",
+      "task_ids": [
+        "202609071219-QV0SX9"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "7a9d567a1292a0a8d47bb41a8ba232301946f872",
+      "task_ids": [
+        "202609071219-QV0SX9"
+      ]
+    },
+    {
+      "service_only": false,
+      "sha": "cdaf72b1fa42660466fe8dd986ff87b2bd093f88",
+      "task_ids": [
+        "202609071219-QV0SX9"
+      ]
+    },
+    {
+      "service_only": false,
+      "sha": "cea8e6f8708be9f3f246a21459176543d5bbe7e0",
+      "task_ids": [
+        "202609071219-QV0SX9"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "2639130b3181867f53fa37121783c67c9ef1d064",
+      "task_ids": [
+        "202609071111-Y0Z0VQ"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "d065bf6221d1362a88c8b8054041316bc507ea42",
+      "task_ids": [
+        "202609071111-Y0Z0VQ"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "21f0360ecd16c1065a1088c8b8383bf27a88cf23",
+      "task_ids": [
+        "202609071111-Y0Z0VQ"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "faf628b0b1a989a7196fc768bdd13d47c03f08c8",
+      "task_ids": [
+        "202609071111-Y0Z0VQ"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "03a3f8cae62a7bff1990edd6e63cae1e94b3f860",
+      "task_ids": [
+        "202609071111-Y0Z0VQ"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "9a6fc0dc06200b626d95c9e0d1a060b80fe1e077",
+      "task_ids": [
+        "202609071111-Y0Z0VQ"
+      ]
+    },
+    {
+      "service_only": false,
+      "sha": "cde1de7f515f73fb4324b5064446d87b9e6ce598",
+      "task_ids": [
+        "202609071111-Y0Z0VQ"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "87b4cf46dcddead7252f413367d163adb06aca92",
+      "task_ids": [
+        "202609071111-Y0Z0VQ"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "68df2e923cd9a382998a9f892243d2421b64ec17",
+      "task_ids": [
+        "202609071111-Y0Z0VQ"
+      ]
+    },
+    {
+      "service_only": false,
+      "sha": "d0efb4b12add163221a45b68759fa85847fe0372",
+      "task_ids": [
+        "202609071111-Y0Z0VQ"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "f8a0e2fdaf2f0a9f7f328cc13679681707733b6f",
+      "task_ids": [
+        "202609071111-Y0Z0VQ"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "aa0ab4813d33e56363804d7225ab4052f180bb0c",
+      "task_ids": [
+        "202609071111-Y0Z0VQ"
+      ]
+    },
+    {
+      "service_only": false,
+      "sha": "1e4add62bb52962cd618a55bcef3553b37111ffd",
+      "task_ids": [
+        "202609071111-Y0Z0VQ"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "6142ca0b0f3562f631319bc03aea2db45d8643c9",
+      "task_ids": [
+        "202609071111-Y0Z0VQ"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "a080783870ced46d2f2c11f536bd5daba9b296fa",
+      "task_ids": [
+        "202609071111-Y0Z0VQ"
+      ]
+    },
+    {
+      "service_only": false,
+      "sha": "996e8a5174cfb8a880c8b7bc51be471440b8e325",
+      "task_ids": [
+        "202609071111-Y0Z0VQ"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "9b99271d55b0a1306942eead89a4b2974e3bdc1d",
+      "task_ids": [
+        "202609071111-Y0Z0VQ"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "db12f98164a34e35c88e9e89e87513ca2efab9d2",
+      "task_ids": [
+        "202609071111-Y0Z0VQ"
+      ]
+    },
+    {
+      "service_only": false,
+      "sha": "8456da808bbaf774a54ab0eca19d8ea76769f960",
+      "task_ids": [
+        "202609071111-Y0Z0VQ"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "70c146493dab30a859788ae20cfdeab3cf57f1fd",
+      "task_ids": [
+        "202609071219-QV0SX9"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "c70cf8be9f7315dcd7300e95556bcbf3cdc47cb3",
+      "task_ids": [
+        "202609071219-QV0SX9"
+      ]
+    },
+    {
+      "service_only": false,
+      "sha": "dad52228edd14a7ae9d798c0f5ae03fa5610e141",
+      "task_ids": [
+        "202609061750-Z0XXVD"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "b162edd7b2ee722b0c6f7cb063947975a001765c",
+      "task_ids": [
+        "202609070819-M065D1"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "55e59a4dd5df6ea3de516fe2523b40a8ffb52d21",
+      "task_ids": [
+        "202609070819-M065D1"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "a67fd07cc71439718b114325138b6a08b44b13e4",
+      "task_ids": [
+        "202609070819-M065D1"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "565b0f13273d1c282c141bb7e9be499303e583bd",
+      "task_ids": [
+        "202609070819-M065D1"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "ad68f7a96f1abd2126b9a2c3e61acf57f4384be8",
+      "task_ids": [
+        "202609070819-M065D1"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "57702f371e5a91cc780176f52984bec33a9890b6",
+      "task_ids": [
+        "202609070819-M065D1"
+      ]
+    },
+    {
+      "service_only": false,
+      "sha": "929b932be46d528c36e9083eccbf5fc86d3b7cdc",
+      "task_ids": [
+        "202609070819-M065D1"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "b99c7d87348d22b54cb2a36445fd94cddd732bf5",
+      "task_ids": [
+        "202609070351-6B37B9"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "d2353ae4c6cf5552443e9a60e63cbcfbb99e1e7b",
+      "task_ids": [
+        "202609070351-6B37B9"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "8d9ca51b4fb36ab8adfd85e9729b0adf8147c59c",
+      "task_ids": [
+        "202609070351-6B37B9"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "348a3600a37b39d61ebb4a4ac3f93c642de77198",
+      "task_ids": [
+        "202609070351-6B37B9"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "62a5710867e2fe3158f664a96e832151e91de8db",
+      "task_ids": [
+        "202609070351-6B37B9"
+      ]
+    },
+    {
+      "service_only": false,
+      "sha": "168fe0d0d1c98e97657094c4eb6ad7096848fac1",
+      "task_ids": [
+        "202609070351-6B37B9"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "8c1384303cc702fff2fb881c441cacc6c1c523c2",
+      "task_ids": [
+        "202609070351-6B37B9"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "2f8590f913eaa2cde9184811d7ad2820be33f453",
+      "task_ids": [
+        "202609070351-6B37B9"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "3f7059fbed9fd2fd3a3fbbaedf7af77c14a17233",
+      "task_ids": [
+        "202609070351-6B37B9"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "47dab7082e31791ca89c9fb1cafd0d6afad3dd57",
+      "task_ids": [
+        "202609070351-6B37B9"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "e1f7c52ef394a46eb5e490291ba409a22cccaf6f",
+      "task_ids": [
+        "202609070351-6B37B9"
+      ]
+    },
+    {
+      "service_only": false,
+      "sha": "c376de30e9ab1612f99c44f55890dd834d60c6e5",
+      "task_ids": []
+    },
+    {
+      "service_only": true,
+      "sha": "f8505e8e0edb6d3e420e22cef1620bae2bbdab1d",
+      "task_ids": [
+        "202609070351-6B37B9"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "43227b631a4f7593b60997908519bbb475e4860f",
+      "task_ids": [
+        "202609070351-6B37B9"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "33859c98d6e2dc4cc5a3528b73e7046ea2a96a98",
+      "task_ids": [
+        "202609070351-6B37B9"
+      ]
+    },
+    {
+      "service_only": false,
+      "sha": "68cf65a08ac1a380accf9821c9d3853069011248",
+      "task_ids": [
+        "202609070351-6B37B9"
+      ]
+    },
+    {
+      "service_only": false,
+      "sha": "304f02dc7966f75f74ea2aec083a337572350f0f",
+      "task_ids": [
+        "202609061750-Z0XXVD"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "68b7b240362fe005e4ea5c63ee214c37fc545212",
+      "task_ids": [
+        "202609070233-NG368H"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "b1783ceed8823238095113776d82647763ffbe1b",
+      "task_ids": [
+        "202609070233-NG368H"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "30d74ffe38dc78012602381b811ea4fcd1e4a855",
+      "task_ids": [
+        "202609070233-NG368H"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "185dc17c7eaa22c91fa82b9e481e98bfbb43fe1a",
+      "task_ids": [
+        "202609070233-NG368H"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "201859728a179ded09e43484cfbba117069d48a0",
+      "task_ids": [
+        "202609070233-NG368H"
+      ]
+    },
+    {
+      "service_only": false,
+      "sha": "93ed9b9899f35fb9e4c141f700c28eeb517808b7",
+      "task_ids": [
+        "202609070233-NG368H"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "8ebc48d745af6bbd72540f96c0f8c62748d168c6",
+      "task_ids": [
+        "202609070233-NG368H"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "4f04ff897849a85601dd7dcab7ca1eeceab1f1ee",
+      "task_ids": [
+        "202609070233-NG368H"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "2cab17c9542c83e8dfa4d3dd5bc186cc11e15394",
+      "task_ids": [
+        "202609070233-NG368H"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "b4d0e7acd0b9e47d751e135d47ef4eeaa358e66f",
+      "task_ids": [
+        "202609070233-NG368H"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "492136f731dc3b3c7583f37b22d83f4e6387320b",
+      "task_ids": [
+        "202609070233-NG368H"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "bf210e93cc9bab5d26e9cbc829b6007c70fe51eb",
+      "task_ids": [
+        "202609070233-NG368H"
+      ]
+    },
+    {
+      "service_only": false,
+      "sha": "8afecc9522106f828eda13bd768c00b0c523a6e8",
+      "task_ids": [
+        "202609070233-NG368H"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "81b3fe507426d82ea903d7a63fd6335b583d81b5",
+      "task_ids": [
+        "202609061750-Z0XXVD"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "eba01eac5a6b6c347f7850b4736ae620559b5115",
+      "task_ids": [
+        "202609061750-Z0XXVD"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "327a2b4b31957f9e989449a20b693dca2e444309",
+      "task_ids": [
+        "202609061750-Z0XXVD"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "f0131533865be689bef06bdf41cbe2730ecb0fc4",
+      "task_ids": [
+        "202609061750-Z0XXVD"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "ab635aca8893944fa51ef0ffb0b17afe8630f097",
+      "task_ids": [
+        "202609061750-Z0XXVD"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "59b81b8ee097844214dc09ca89d95caefd5a1fa5",
+      "task_ids": [
+        "202609061750-Z0XXVD"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "60f5e39b85594ff837ab6b719445d4615cd5f42a",
+      "task_ids": [
+        "202609061750-Z0XXVD"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "a2c83d96760c064af9677245abc2535b6b33f68d",
+      "task_ids": [
+        "202609061750-Z0XXVD"
+      ]
+    },
+    {
+      "service_only": false,
+      "sha": "69dff6a91be8ea2832e5065504e0b70d0fa9709f",
+      "task_ids": [
+        "202609061750-Z0XXVD"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "fd95bb6830d2df61a457e181f3ba2633523db65e",
+      "task_ids": [
+        "202609061750-Z0XXVD"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "b8b77e4e755036c2f5e8cdff829533ec1f9d5298",
+      "task_ids": [
+        "202609061750-Z0XXVD"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "6e300c95e95be8e3e538d9e6469ca309f9fbe87f",
+      "task_ids": [
+        "202609061750-Z0XXVD"
+      ]
+    },
+    {
+      "service_only": false,
+      "sha": "b9c18bde3de689c8a57f7abeafee6d69c77ca346",
+      "task_ids": [
+        "202609061750-Z0XXVD"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "e66cbb2a9345224810fd3f6b2489162de2d4b80c",
+      "task_ids": [
+        "202609061750-Z0XXVD"
+      ]
+    },
+    {
+      "service_only": false,
+      "sha": "8ba826b53de8ed163c203fc0d0ada8fb020ca642",
+      "task_ids": [
+        "202609061750-Z0XXVD"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "d6c9f8252eda2990c81abade61064f74ff5ab430",
+      "task_ids": [
+        "202609061750-Z0XXVD"
+      ]
+    },
+    {
+      "service_only": false,
+      "sha": "0530dc68ca31bc8a5b87ab091482bfd06081c873",
+      "task_ids": [
+        "202609061750-Z0XXVD"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "9404b8fc5e74dfa5f93d81a03c7e13b55a06cc13",
+      "task_ids": [
+        "202609061750-Z0XXVD"
+      ]
+    },
+    {
+      "service_only": false,
+      "sha": "86665790e1faee831ccd7dc4d21c111e3af953bf",
+      "task_ids": [
+        "202609061750-Z0XXVD"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "e3a8e6658b2966f0b8ee5d81d4b79a750d2e07ae",
+      "task_ids": [
+        "202609061750-Z0XXVD"
+      ]
+    },
+    {
+      "service_only": false,
+      "sha": "e070a79cd2466cb8b02d91a3731aac63b805cab2",
+      "task_ids": [
+        "202609061750-Z0XXVD"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "9f0dadafc8fb2ccb892503ffd54ac6bfeded1a85",
+      "task_ids": [
+        "202609061750-Z0XXVD"
+      ]
+    },
+    {
+      "service_only": false,
+      "sha": "1f6d5b06fccdc864d4a3721d7891c663d8442ff6",
+      "task_ids": [
+        "202609061750-Z0XXVD"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "196b416399ccb385636b01aacf7e2940d358db69",
+      "task_ids": [
+        "202609061750-Z0XXVD"
+      ]
+    },
+    {
+      "service_only": false,
+      "sha": "41415058404d73e8cd439c088d169637f0ef0d7f",
+      "task_ids": [
+        "202609061750-Z0XXVD"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "a6b00ad7e8d4bc1adadcbbc7083bc14e6882feed",
+      "task_ids": [
+        "202609061750-Z0XXVD"
+      ]
+    },
+    {
+      "service_only": false,
+      "sha": "ddf06df251b8acb3189390793d747741dd0f3e3c",
+      "task_ids": [
+        "202609061750-Z0XXVD"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "eaafbc7886d2b588b83e154815229c85e48ddc46",
+      "task_ids": [
+        "202609061750-Z0XXVD"
+      ]
+    },
+    {
+      "service_only": false,
+      "sha": "c1b560eb0ce149a3a5e5200b192b7128265a62e4",
+      "task_ids": [
+        "202609061750-Z0XXVD"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "2cf836db0fe3ad72ddc751b906f7ac1b436beb4d",
+      "task_ids": [
+        "202609061750-Z0XXVD"
+      ]
+    },
+    {
+      "service_only": false,
+      "sha": "19239f9e62e172de9e679b57e6cb786a2f6970f3",
+      "task_ids": [
+        "202609061750-Z0XXVD"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "da01e181e27bf3cd7bdede1c328e6b2bcdf689ff",
+      "task_ids": [
+        "202609061750-Z0XXVD"
+      ]
+    },
+    {
+      "service_only": false,
+      "sha": "a24cfb6c87e6e2945d587e1a3c7614ce71b8fb4b",
+      "task_ids": [
+        "202609061750-Z0XXVD"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "262da3130bc5628a7641c400c74368ae355000bf",
+      "task_ids": [
+        "202609061636-BW11J6"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "11b53e5f844d8d41b7fd5b5ec082ad7937c0721c",
+      "task_ids": [
+        "202609061636-BW11J6"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "a2564340a3ab3600f2c1278e39293a4499c155c7",
+      "task_ids": [
+        "202609061636-BW11J6"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "ca2bb87f77bbc3ae09edf571e483e98a44f4a9bf",
+      "task_ids": [
+        "202609061636-BW11J6"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "60244110592975d2f933a2384252083080fcf3d1",
+      "task_ids": [
+        "202609061636-BW11J6"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "ba8874a888de07be56ca1ec88c3954c7a0972bd9",
+      "task_ids": [
+        "202609061636-BW11J6"
+      ]
+    },
+    {
+      "service_only": false,
+      "sha": "a4aedd5a03255a560eebe6f6e62ae8328dd7a84b",
+      "task_ids": [
+        "202609061636-BW11J6"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "ec95c2e8030affdc7562c26c2f41dc098b9dc173",
+      "task_ids": [
+        "202609061636-BW11J6"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "19ce338e6fb63ee55c79de6d56a72c7a837fc8f7",
+      "task_ids": [
+        "202609061636-BW11J6"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "f3d1eb3130ab9c067a0503d63e3b043bb6885d3f",
+      "task_ids": [
+        "202609061636-BW11J6"
+      ]
+    },
+    {
+      "service_only": false,
+      "sha": "ad9e51536785a9d31279a2964e4c7f537badc7db",
+      "task_ids": [
+        "202609061636-BW11J6"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "b1e13dec007f8251957c77a887b9a887cc789a82",
+      "task_ids": [
+        "202609060720-NZXQ0E"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "ba67d24ab800fa59b097a563b65a47ddd2df3040",
+      "task_ids": [
+        "202609060720-NZXQ0E"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "467a21903b1ad3bc886702db47454d80834ba4cc",
+      "task_ids": [
+        "202609060720-NZXQ0E"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "e4955798705acb39b67decdd38d8d5555822cce6",
+      "task_ids": [
+        "202609060720-NZXQ0E"
+      ]
+    },
+    {
+      "service_only": false,
+      "sha": "48dda1e008438f65ba6e8a2253b723bde5994751",
+      "task_ids": [
+        "202609060720-NZXQ0E"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "430befb9567c4b34d393fd65aa84e2272ffa266e",
+      "task_ids": [
+        "202609060720-NZXQ0E"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "0183bdf929e4f1287f1a9eab47da83c48aff3fc7",
+      "task_ids": [
+        "202609060720-NZXQ0E"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "66ced0b68f08d835a762267662c2bf82d71ca16a",
+      "task_ids": [
+        "202609060720-NZXQ0E"
+      ]
+    },
+    {
+      "service_only": false,
+      "sha": "7d5e2ef3bac557d785b7ec613eaedbefc656e379",
+      "task_ids": [
+        "202609060720-NZXQ0E"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "ac565f6fb1e401686c6566f8fcf654799be258e6",
+      "task_ids": [
+        "202609060720-NZXQ0E"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "898d06351bcf8975bcec3d321e6a418899d7c6c6",
+      "task_ids": [
+        "202609060720-NZXQ0E"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "ec418b1b334b4efc934fa1a7506a149a7007441c",
+      "task_ids": [
+        "202609060720-NZXQ0E"
+      ]
+    },
+    {
+      "service_only": false,
+      "sha": "8f77e8033e63f503c06801cd8af358cc57f1aa2a",
+      "task_ids": [
+        "202609060720-NZXQ0E"
+      ]
+    },
+    {
+      "service_only": false,
+      "sha": "c74e8f1cddd60375b63cb30d0c3d62538b7fc702",
+      "task_ids": [
+        "202609060720-NZXQ0E"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "7a1731ccc2784fc5d4a1573fc8b8adbacf704689",
+      "task_ids": [
+        "202609060720-NZXQ0E"
+      ]
+    },
+    {
+      "service_only": false,
+      "sha": "736fba555b20672162360b9d5bc5d9205ffc3262",
+      "task_ids": [
+        "202609060720-NZXQ0E"
+      ]
+    },
+    {
+      "service_only": false,
+      "sha": "b33a39fb7c4ae579a74e6550f93ef557307ae645",
+      "task_ids": [
+        "202609060720-NZXQ0E"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "33d00156ba1063f607e4e823d4de714d6466390d",
+      "task_ids": [
+        "202609060720-NZXQ0E"
+      ]
+    },
+    {
+      "service_only": false,
+      "sha": "8ad0c158c5b4a6a9940b7bb62c321f84289f5e6d",
+      "task_ids": [
+        "202609060720-NZXQ0E"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "43f3ba86b40cfae0555ec7775d85d97b5d4c2377",
+      "task_ids": [
+        "202609060720-NZXQ0E"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "e7aae1f7418195dc506b00aef74c951d8831390a",
+      "task_ids": [
+        "202609042327-PH5N6S"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "fdf2dd5b358c2f17aa248a5e90bda436bcdef235",
+      "task_ids": [
+        "202609042327-PH5N6S"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "424c7e7e1659d29ce2963f1ea7981566949430b2",
+      "task_ids": [
+        "202609042327-PH5N6S"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "367024bb03d41c45982ef45ec4d87b058913a265",
+      "task_ids": [
+        "202609042327-PH5N6S"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "801dbd096b1f1b5a6735c3fb24220f38a5067e2f",
+      "task_ids": [
+        "202609042327-PH5N6S"
+      ]
+    },
+    {
+      "service_only": false,
+      "sha": "a25edd68b3639f22fe74be7476df9397c588b304",
+      "task_ids": [
+        "202609042327-PH5N6S"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "86505007bb7171bcfaafd4d0ee2ed1f1e8fab783",
+      "task_ids": [
+        "202609042327-PH5N6S"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "f15f2914fd02ed0372c4c65aced04639cb938f2f",
+      "task_ids": [
+        "202609042327-PH5N6S"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "9626c6364f0aab2a7f7efb3d05b4757a8207c156",
+      "task_ids": [
+        "202609042327-PH5N6S"
+      ]
+    },
+    {
+      "service_only": false,
+      "sha": "572353c8ad3dffbbf455bfcb82ce24d40574ae28",
+      "task_ids": [
+        "202609042327-PH5N6S"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "48d2e75856c3da7d3635946ad7d48f717afb5104",
+      "task_ids": [
+        "202609042327-PH5N6S"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "de6df111e267e997f5056fbfc7c0a2844e0576a0",
+      "task_ids": [
+        "202609042327-PH5N6S"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "ea8830b4bee74c656ed888384625f95046df2218",
+      "task_ids": [
+        "202609042327-PH5N6S"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "5d65025e875e3d533d5b1ad3196b566ee00d0efe",
+      "task_ids": [
+        "202609042327-PH5N6S"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "1c14163429fc67acdeb98b34a7fae404d68ddc38",
+      "task_ids": [
+        "202609042327-PH5N6S"
+      ]
+    },
+    {
+      "service_only": false,
+      "sha": "2e9f7df5ebad103bf6ade9d4cffb750da2dd0318",
+      "task_ids": [
+        "202609042327-PH5N6S"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "a8648b4c439676621ded1296f62b4eeb6720efe0",
+      "task_ids": [
+        "202609042327-PH5N6S"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "1438fcf8c4a38ea3456682c77fc4532dde2c7251",
+      "task_ids": [
+        "202609042327-PH5N6S"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "a5846b477ce0b3bde2fdf4f35a0bd973780bc886",
+      "task_ids": [
+        "202609042327-PH5N6S"
+      ]
+    },
+    {
+      "service_only": false,
+      "sha": "d8298cfe7b38b3b085a44810a4000ad323e67afd",
+      "task_ids": [
+        "202609042327-PH5N6S"
+      ]
+    },
+    {
+      "service_only": false,
+      "sha": "1981b974568071c65b8c0c3f971311de59758d83",
+      "task_ids": [
+        "202609042327-PH5N6S"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "cf909f3246f9227135813776df941f7740094e89",
+      "task_ids": [
+        "202609042327-PH5N6S"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "6bf388900d2c64a1849d2fb396268a67081d021d",
+      "task_ids": [
+        "202609042327-PH5N6S"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "b82739de719c160acb631be6d771c69ccaba1590",
+      "task_ids": [
+        "202609042327-PH5N6S"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "86e9343e668a2aa52883cab40c176b118ad33ffd",
+      "task_ids": [
+        "202609042327-PH5N6S"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "4b0c941f98ae31152ddef4aa925c439e57505225",
+      "task_ids": [
+        "202609042327-PH5N6S"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "e72029c56f3a62185c8af0c88e7cb944e717fa5e",
+      "task_ids": [
+        "202609042327-PH5N6S"
+      ]
+    },
+    {
+      "service_only": false,
+      "sha": "6764bc96f86b48a697e3fdc63ed7f96d6ee15cf1",
+      "task_ids": [
+        "202609042327-PH5N6S"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "556bd57198b1b3c70d3a242dc3e7f3e16f9edd01",
+      "task_ids": [
+        "202609041801-ZVX69C"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "e81a82df8905e1cd2b70e707edaeb54b540afa72",
+      "task_ids": [
+        "202609041801-ZVX69C"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "a4cbbf112295aba5da065449ecaa50394c2efed6",
+      "task_ids": [
+        "202609041801-ZVX69C"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "50d0834079f967679fd56ba98fa311eb7e457335",
+      "task_ids": [
+        "202609041801-ZVX69C"
+      ]
+    },
+    {
+      "service_only": false,
+      "sha": "8701b4ee14a0566d0c1fe97401604fa973847db4",
+      "task_ids": [
+        "202609041801-ZVX69C"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "e01b34f44379df3c04a5956e838aab85129dc8fa",
+      "task_ids": [
+        "202609041801-ZVX69C"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "1e3a1d54e7c1caaed49e899df8d16a28a32290c8",
+      "task_ids": [
+        "202609041801-ZVX69C"
+      ]
+    },
+    {
+      "service_only": false,
+      "sha": "2613ab498a2142b112afcd42351dbe6bb273a223",
+      "task_ids": []
+    },
+    {
+      "service_only": true,
+      "sha": "fbf8853c500b57ab28d42f6e140e6bbe03603f8e",
+      "task_ids": [
+        "202609041801-ZVX69C"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "2b0bcb6d5b595b8c0d9e70281d95a97f4cf1b917",
+      "task_ids": [
+        "202609041801-ZVX69C"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "8f7b0706b69c104806f4591567750ceb58697ce2",
+      "task_ids": [
+        "202609041801-ZVX69C"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "ad262173f6ee46b72668f12bc8b6ab40798338a3",
+      "task_ids": [
+        "202609041801-ZVX69C"
+      ]
+    },
+    {
+      "service_only": false,
+      "sha": "5e35370df7bd24be3cf0c5d59bd17bb1fd99f856",
+      "task_ids": [
+        "202609041801-ZVX69C"
+      ]
+    },
+    {
+      "service_only": false,
+      "sha": "b255ea521a19c0861a939284bc9fa8bdd5816325",
+      "task_ids": [
+        "202609041801-ZVX69C"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "ac91f8bfdd5718221a949f82c607936b77150cf1",
+      "task_ids": [
+        "202609041801-ZVX69C"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "baae32a2e3c5e0c45c1afa823009df3436d2fe67",
+      "task_ids": [
+        "202609041801-ZVX69C"
+      ]
+    },
+    {
+      "service_only": false,
+      "sha": "0bc37e5952e2713f665ee69687b4aab45f83fd54",
+      "task_ids": [
+        "202609041801-ZVX69C"
+      ]
+    },
+    {
+      "service_only": false,
+      "sha": "99fdb3c4cc9123982becb3edebb5bd030885fd0e",
+      "task_ids": [
+        "202609041801-ZVX69C"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "6c866e888b5d8af4bc6b10fc308462e56e3deb76",
+      "task_ids": [
+        "202609041801-ZVX69C"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "3fc391c151ab2f1879ea9eae5c2e8cb73469b787",
+      "task_ids": [
+        "202609041801-ZVX69C"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "218df006de80522a871e7d32b4e6b26de6fdb96a",
+      "task_ids": [
+        "202609041801-ZVX69C"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "4c90e955a1e7f6c577966ee4d7bf873a2e3936aa",
+      "task_ids": [
+        "202609041801-ZVX69C"
+      ]
+    },
+    {
+      "service_only": false,
+      "sha": "1050a0f4856603b998283a05f2caa4cc8ebcca96",
+      "task_ids": [
+        "202609041801-ZVX69C"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "11f06801e10fa00f954bd1d3ed22a5d138d0f46f",
+      "task_ids": [
+        "202609041801-ZVX69C"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "3cd9c9fa22be0b70c1f14d2f2100f5c0503aa3be",
+      "task_ids": [
+        "202609041801-ZVX69C"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "8f006bf84e1215d36d1e1182a190a89958cdaacb",
+      "task_ids": [
+        "202609041801-ZVX69C"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "42463c33c80a49eea4445f2aa6a382a6ab6588ac",
+      "task_ids": [
+        "202609041801-ZVX69C"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "4bed92f9eeac21183a2558bab17c9795a20ec6a7",
+      "task_ids": [
+        "202609041801-ZVX69C"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "09c20ba49b88479a3198f73d0989817e3a6f2895",
+      "task_ids": [
+        "202609041801-ZVX69C"
+      ]
+    },
+    {
+      "service_only": false,
+      "sha": "8b1594fdbddea370c02760dd835f4f98f9caf160",
+      "task_ids": [
+        "202609041801-ZVX69C"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "6e49077db61daed5204b514e7d6e071c190edda6",
+      "task_ids": [
+        "202609031717-PX8PZT"
+      ]
+    },
+    {
+      "service_only": true,
+      "sha": "b97f2fe710146f34eeccb1bd57bd66f35390dafb",
+      "task_ids": [
+        "202609031717-PX8PZT"
+      ]
+    }
+  ],
+  "digest": "sha256:60c9be411166e867f42697229a64ec713260e34e0f8b45428b2490af6691ab5c",
+  "kind": "agent_efficiency_repository_snapshot",
+  "method": {
+    "artifact_selection": "All committed blobs under .agentplane/tasks; bytes are uncompressed Git blob sizes",
+    "commit_selection": "Last 200 non-merge commits reachable from source",
+    "duplicate_definition": "Identical Git blob object IDs across task artifact paths; no content migration",
+    "exclusions": [
+      "working tree changes",
+      "untracked artifacts",
+      "submodule contents",
+      "merge commits",
+      "private operational journals",
+      "paid provider capture"
+    ],
+    "limitations": [
+      "Usage is the committed supervisor projection, not a new provider capture",
+      "Prepared, delivered and model-read context are distinct and unavailable in historical projections",
+      "Historical WorkItem, role, episode and semantic-repeat attribution is unavailable",
+      "Service commit counts per task overlap for commits touching multiple tasks",
+      "Token totals sum observed fields only; coverage is reported separately"
+    ],
+    "service_commit_definition": "All changed paths are under .agentplane; classification does not imply a removable checkpoint",
+    "task_selection": "Newest 150 task IDs in committed tree, descending lexicographic path order"
+  },
+  "runtime": {
+    "arch": "arm64",
+    "cli_package_object": "0c8855f9089cef8b8d1f95092c0642e4f8f7b663",
+    "measurement_code_digest": "sha256:d761bbeb4bbdbef49347e90467e97ae9ca64d22b04c3911a0a8efe340511dbb4",
+    "node": "v24.18.0",
+    "platform": "darwin"
+  },
+  "schema_version": 1,
+  "source": {
+    "commit": "92efd467a7b045e7e784597168ac21bd41a975a1",
+    "tree": "2e735588bc3189925cb4651b84acfa21b4cb15f7",
+    "tree_listing_digest": "sha256:74a093dcd1616a759228879ec55b992e79443c2b4c78e702944cf361dc6f7b57"
+  },
+  "tasks": [
+    {
+      "artifact_bytes": 335333,
+      "artifact_count": 35,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 107386,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 129554,
+      "readme_object": "48b102ae68e1430f3312eb2c64621a0c6b07ee0b",
+      "readme_path": ".agentplane/tasks/202609071219-QV0SX9/README.md",
+      "roles": null,
+      "service_commits_in_window": 13,
+      "task_id": "202609071219-QV0SX9",
+      "usage": {
+        "agent_runs": 12,
+        "input_tokens": null,
+        "journal_digest": "sha256:1ebf7115b4879387c94098bdfd9a21e40b05fd466cd40df6ac1d579ecd318529",
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "provider_token_telemetry_unavailable",
+        "updated_at": "2026-09-07T15:04:52.952Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 300854,
+      "artifact_count": 20,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 85771,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 93917,
+      "readme_object": "07e7d77e548f3a7894e07d79409d647520dcd2c8",
+      "readme_path": ".agentplane/tasks/202609071111-Y0Z0VQ/README.md",
+      "roles": null,
+      "service_commits_in_window": 14,
+      "task_id": "202609071111-Y0Z0VQ",
+      "usage": {
+        "agent_runs": 7,
+        "input_tokens": null,
+        "journal_digest": "sha256:3df31ec7e71cd6bbec54168fbce181199c1194781cf9a2e989f8dc143f3c063c",
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "provider_token_telemetry_unavailable",
+        "updated_at": "2026-09-07T13:16:09.371Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 198529,
+      "artifact_count": 20,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 58586,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 66436,
+      "readme_object": "30898bef198a23d0759924c0149458b4de72173f",
+      "readme_path": ".agentplane/tasks/202609070819-M065D1/README.md",
+      "roles": null,
+      "service_commits_in_window": 6,
+      "task_id": "202609070819-M065D1",
+      "usage": {
+        "agent_runs": 3,
+        "input_tokens": null,
+        "journal_digest": "sha256:e0d676d0220d10db905bb16ebe81d8c89536c2b65845729edc891f7497899b8c",
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "provider_token_telemetry_unavailable",
+        "updated_at": "2026-09-07T08:44:29.010Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 290544,
+      "artifact_count": 31,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 73588,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 90844,
+      "readme_object": "13e54804bcd3cdd48aae70dffe9839ef22a9f96f",
+      "readme_path": ".agentplane/tasks/202609070351-6B37B9/README.md",
+      "roles": null,
+      "service_commits_in_window": 13,
+      "task_id": "202609070351-6B37B9",
+      "usage": {
+        "agent_runs": 6,
+        "input_tokens": null,
+        "journal_digest": "sha256:94a89bf3a7b8ef576b95127446c37b417639fb2adb7d3e75eede449ce722e147",
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "provider_token_telemetry_unavailable",
+        "updated_at": "2026-09-07T07:54:19.350Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 200396,
+      "artifact_count": 29,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 56356,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 68055,
+      "readme_object": "9f684d5768d98369096b25c18e606facddfe8ba8",
+      "readme_path": ".agentplane/tasks/202609070233-NG368H/README.md",
+      "roles": null,
+      "service_commits_in_window": 11,
+      "task_id": "202609070233-NG368H",
+      "usage": {
+        "agent_runs": 5,
+        "input_tokens": null,
+        "journal_digest": "sha256:569fda7b6ccba9e4907e8e4279326643f1c16d9b570218f27d97369a438ffcab",
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "provider_token_telemetry_unavailable",
+        "updated_at": "2026-09-07T03:21:32.873Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 1456882,
+      "artifact_count": 23,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 715516,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 733157,
+      "readme_object": "a849bb31efefef899019258ea8acf393734fbd30",
+      "readme_path": ".agentplane/tasks/202609061750-Z0XXVD/README.md",
+      "roles": null,
+      "service_commits_in_window": 21,
+      "task_id": "202609061750-Z0XXVD",
+      "usage": {
+        "agent_runs": 46,
+        "input_tokens": null,
+        "journal_digest": "sha256:9d56022cbb52a72c088d0b1f4fb9f448b96a69d5bd01382acbb38f90d243c317",
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "provider_token_telemetry_unavailable",
+        "updated_at": "2026-09-07T01:01:52.434Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 184113,
+      "artifact_count": 21,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 73011,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 84369,
+      "readme_object": "401b8fe47ce09363f60a74edd0337af57e9ec4d3",
+      "readme_path": ".agentplane/tasks/202609061636-BW11J6/README.md",
+      "roles": null,
+      "service_commits_in_window": 9,
+      "task_id": "202609061636-BW11J6",
+      "usage": {
+        "agent_runs": 6,
+        "input_tokens": null,
+        "journal_digest": "sha256:4e28104c22a036f3e88e82da4981575266058b59c7eea2155f562ec5f27954af",
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "provider_token_telemetry_unavailable",
+        "updated_at": "2026-09-06T17:11:06.855Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 727574,
+      "artifact_count": 40,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 270929,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 293991,
+      "readme_object": "bd1779e9295b3fb23740f1f5a074a7c5a2ec3ccf",
+      "readme_path": ".agentplane/tasks/202609060720-NZXQ0E/README.md",
+      "roles": null,
+      "service_commits_in_window": 13,
+      "task_id": "202609060720-NZXQ0E",
+      "usage": {
+        "agent_runs": 23,
+        "input_tokens": null,
+        "journal_digest": "sha256:5d591dce201889a75a133ddb0d5489d3b7aa1fac7b796e9db5f2c75594e52107",
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "provider_token_telemetry_unavailable",
+        "updated_at": "2026-09-06T15:20:16.025Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 724572,
+      "artifact_count": 38,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 190846,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 230583,
+      "readme_object": "9390ac20229fa384c2a716270f957bb3d5590667",
+      "readme_path": ".agentplane/tasks/202609042338-M5G987/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202609042338-M5G987",
+      "usage": {
+        "agent_runs": 16,
+        "input_tokens": null,
+        "journal_digest": "sha256:86fa312617296fc0f3cb42eb917c3099275b0564312c1dda6f904a8d40ea611d",
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "provider_token_telemetry_unavailable",
+        "updated_at": "2026-09-05T03:23:32.408Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 14865306,
+      "artifact_count": 61,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 233044,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 265039,
+      "readme_object": "17006c9c8705bc5c9e676ae45cc36ee2fccb4132",
+      "readme_path": ".agentplane/tasks/202609042327-PH5N6S/README.md",
+      "roles": null,
+      "service_commits_in_window": 22,
+      "task_id": "202609042327-PH5N6S",
+      "usage": {
+        "agent_runs": 17,
+        "input_tokens": null,
+        "journal_digest": "sha256:374e6d9c26f4150c8b0a3e2a3a512cad6fac813484f76b18c6543318f9b7e640",
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "provider_token_telemetry_unavailable",
+        "updated_at": "2026-09-06T16:19:31.818Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 178781,
+      "artifact_count": 20,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 67730,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 76035,
+      "readme_object": "61cf089c6c88e4d1ebcc752c5ae53fba0f01558a",
+      "readme_path": ".agentplane/tasks/202609042212-XR979S/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202609042212-XR979S",
+      "usage": {
+        "agent_runs": 5,
+        "input_tokens": null,
+        "journal_digest": "sha256:1c7111246c156a8e3693b566a7b11f31092f4aa85a26e77d77bb4b1517f88a59",
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "provider_token_telemetry_unavailable",
+        "updated_at": "2026-09-04T23:06:37.186Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 11350833,
+      "artifact_count": 122,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 546704,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 755610,
+      "readme_object": "6d32b78415c3f88231a1291e9bd3ad175564cc19",
+      "readme_path": ".agentplane/tasks/202609041801-ZVX69C/README.md",
+      "roles": null,
+      "service_commits_in_window": 22,
+      "task_id": "202609041801-ZVX69C",
+      "usage": {
+        "agent_runs": 45,
+        "input_tokens": null,
+        "journal_digest": "sha256:3e9beefc524d6313bc447c8d87dd04b15b07eb518d1bdf2a0e9867c31a884db2",
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "provider_token_telemetry_unavailable",
+        "updated_at": "2026-09-06T02:34:32.684Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 195954,
+      "artifact_count": 20,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 54536,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 64542,
+      "readme_object": "902e889165a437170fa307f6ad38285394ef8467",
+      "readme_path": ".agentplane/tasks/202609041447-YHERVV/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202609041447-YHERVV",
+      "usage": {
+        "agent_runs": 3,
+        "input_tokens": null,
+        "journal_digest": "sha256:7bd03cccd5c028f0e3b09cd7834ba47a176362b0b1f8d0502872ef5233164c41",
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "provider_token_telemetry_unavailable",
+        "updated_at": "2026-09-04T16:01:54.018Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 211851,
+      "artifact_count": 20,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 73443,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 85018,
+      "readme_object": "b0b7298b08c6965dc3448a2cf1fcaaee73b1a2bd",
+      "readme_path": ".agentplane/tasks/202609040943-X0G51D/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202609040943-X0G51D",
+      "usage": {
+        "agent_runs": 4,
+        "input_tokens": null,
+        "journal_digest": "sha256:a1ec56e03e5a3db998cc035fd48e7571b9c3739c3f83bc1add4959f669e6acc4",
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "provider_token_telemetry_unavailable",
+        "updated_at": "2026-09-04T10:55:03.882Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 1394271,
+      "artifact_count": 53,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 297849,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 355573,
+      "readme_object": "879762e55d83d59f45160e6c64c40ccf78cb67c9",
+      "readme_path": ".agentplane/tasks/202609032308-F31YXS/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202609032308-F31YXS",
+      "usage": {
+        "agent_runs": 35,
+        "input_tokens": 253622,
+        "journal_digest": "sha256:efa098f833c605e231fbad765ee0dc1a162a0e8f7eb4b2094ef32d867b198195",
+        "observed_agent_runs": 1,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "partial",
+        "total_tokens": 256772,
+        "unavailable_reason": "some_agent_runs_lack_provider_token_telemetry",
+        "updated_at": "2026-09-04T17:29:07.201Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 283990,
+      "artifact_count": 30,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 108640,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 127137,
+      "readme_object": "9c8db4639861c6749240b4ec16a9c6bcef60c51d",
+      "readme_path": ".agentplane/tasks/202609031902-8SH7ZM/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202609031902-8SH7ZM",
+      "usage": {
+        "agent_runs": 9,
+        "input_tokens": null,
+        "journal_digest": "sha256:e49b303a13bb08a26e25f43b9148d27a0c5e62021bc93c25f427680a6083583f",
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "provider_token_telemetry_unavailable",
+        "updated_at": "2026-09-03T20:41:34.018Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 4212631,
+      "artifact_count": 85,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 357653,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 424128,
+      "readme_object": "59df8eba6e092a4b3315a38b706c38f525c5376d",
+      "readme_path": ".agentplane/tasks/202609031717-PX8PZT/README.md",
+      "roles": null,
+      "service_commits_in_window": 2,
+      "task_id": "202609031717-PX8PZT",
+      "usage": {
+        "agent_runs": 34,
+        "input_tokens": null,
+        "journal_digest": "sha256:9de1a0c3092b04ee2dcab5c4472da3c18fd13f4a44e83e9e833c7df9d1e5f33d",
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "provider_token_telemetry_unavailable",
+        "updated_at": "2026-09-05T13:16:23.796Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 667176,
+      "artifact_count": 35,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 281619,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 316445,
+      "readme_object": "ea54a703f626d21fd6024a6c878bccb0baeda1cb",
+      "readme_path": ".agentplane/tasks/202609030849-925NNG/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202609030849-925NNG",
+      "usage": {
+        "agent_runs": 20,
+        "input_tokens": null,
+        "journal_digest": "sha256:d64d42523a8afdcdc6753557f046f4545cfa15c98634613ec4ea9d9868c64ba6",
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "provider_token_telemetry_unavailable",
+        "updated_at": "2026-09-03T14:22:45.670Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 1329223,
+      "artifact_count": 32,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 304951,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 322931,
+      "readme_object": "c452d97e35dcac1fc198d7d86421ef22ae0a9373",
+      "readme_path": ".agentplane/tasks/202609021331-5FPZAB/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202609021331-5FPZAB",
+      "usage": {
+        "agent_runs": 29,
+        "input_tokens": null,
+        "journal_digest": "sha256:5177cceb4fd6aa8798ff4080f682260ac782db9df25f2b20daa9041c7cb958b4",
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "provider_token_telemetry_unavailable",
+        "updated_at": "2026-09-03T16:49:00.615Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 320154,
+      "artifact_count": 41,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 54449,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 71314,
+      "readme_object": "a6f4248326c7fbae717964cfe4b3b16982316a2d",
+      "readme_path": ".agentplane/tasks/202608311713-A0F906/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608311713-A0F906",
+      "usage": {
+        "agent_runs": 9,
+        "input_tokens": null,
+        "journal_digest": "sha256:a82d5441e4f47bd9b88e9d42330c5f4b595740f306ef5bff0957d6e65d86fbc1",
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "provider_token_telemetry_unavailable",
+        "updated_at": "2026-08-31T20:41:07.196Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 494916,
+      "artifact_count": 42,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 109743,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 140927,
+      "readme_object": "82cf1f24fcea7623a773c9632f2b318403385470",
+      "readme_path": ".agentplane/tasks/202608301851-5W3XW6/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608301851-5W3XW6",
+      "usage": {
+        "agent_runs": 11,
+        "input_tokens": null,
+        "journal_digest": "sha256:3abc1a9514524a15e93ae1a4641af4b1c18029c015e7fc351cd1a69354467bcf",
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "provider_token_telemetry_unavailable",
+        "updated_at": "2026-08-30T21:16:04.108Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 209792,
+      "artifact_count": 30,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 45833,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 57621,
+      "readme_object": "21861c941840595f583374fb86fe76c56d2572f4",
+      "readme_path": ".agentplane/tasks/202608300559-3MDRBH/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608300559-3MDRBH",
+      "usage": {
+        "agent_runs": 6,
+        "input_tokens": null,
+        "journal_digest": "sha256:fdd4c5704ed3c2d591155fdb0f4c65e58c1b3ac7bdaa8dc204739d80a267fa59",
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "provider_token_telemetry_unavailable",
+        "updated_at": "2026-08-30T07:43:53.401Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 213675,
+      "artifact_count": 31,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 47100,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 60064,
+      "readme_object": "db472fbad0b905b0f3bf52c05ac3d5533f9a4f52",
+      "readme_path": ".agentplane/tasks/202608300119-ZHYXRS/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608300119-ZHYXRS",
+      "usage": {
+        "agent_runs": 8,
+        "input_tokens": null,
+        "journal_digest": "sha256:d1f250e4f614bd128cf4e4617f8768d04c7a905c47a976f05c03fed20ff0896f",
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "provider_token_telemetry_unavailable",
+        "updated_at": "2026-08-30T02:48:49.112Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 212906,
+      "artifact_count": 24,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 66522,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 81424,
+      "readme_object": "1075b1ef34f51061872110a15fe90c5fc5ddcc7b",
+      "readme_path": ".agentplane/tasks/202608292218-3N0FBK/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608292218-3N0FBK",
+      "usage": {
+        "agent_runs": 8,
+        "input_tokens": null,
+        "journal_digest": "sha256:3844627695bfd74e2bc0da44f2be58ec972b64a3d6af02dbec2b7c19c11ef45a",
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "provider_token_telemetry_unavailable",
+        "updated_at": "2026-08-29T23:38:37.475Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 1132108,
+      "artifact_count": 67,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 182854,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 246639,
+      "readme_object": "765fcde5752fcaa0913f9b92b920d2a27fb9f120",
+      "readme_path": ".agentplane/tasks/202608292032-1K47B8/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608292032-1K47B8",
+      "usage": {
+        "agent_runs": 26,
+        "input_tokens": null,
+        "journal_digest": "sha256:61db20777e166dcbd2c94367dd81b85697ff77d9136c98ce0a125e02b552d892",
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "provider_token_telemetry_unavailable",
+        "updated_at": "2026-08-30T03:20:06.529Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 133077,
+      "artifact_count": 20,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 40312,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 47963,
+      "readme_object": "4f424f3cf32f9492bd1b7c58018ca7bc8164a342",
+      "readme_path": ".agentplane/tasks/202608291505-F5AN0W/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608291505-F5AN0W",
+      "usage": {
+        "agent_runs": 3,
+        "input_tokens": null,
+        "journal_digest": "sha256:4ee2354ae7cecba29a857a501029a80ef26019a08e96481c2d2fd2baaa4d532c",
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "provider_token_telemetry_unavailable",
+        "updated_at": "2026-08-29T15:17:52.774Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 37792815,
+      "artifact_count": 66,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 696273,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 812944,
+      "readme_object": "ad4b2f976cc6ee5d9283be4c928c07aa911e26e1",
+      "readme_path": ".agentplane/tasks/202608291006-2A6BJC/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608291006-2A6BJC",
+      "usage": {
+        "agent_runs": 32,
+        "input_tokens": null,
+        "journal_digest": "sha256:3a4d6be99d1f2f8223e62c686eec544b25fdd647eee9e5ab21c5213abfb59d0c",
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "provider_token_telemetry_unavailable",
+        "updated_at": "2026-08-30T17:02:15.665Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 6322852,
+      "artifact_count": 79,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 1146037,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 1246542,
+      "readme_object": "f50bef650e0949b39ee02ce24866dae2874d4c14",
+      "readme_path": ".agentplane/tasks/202608291006-255K66/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608291006-255K66",
+      "usage": {
+        "agent_runs": 51,
+        "input_tokens": 378921,
+        "journal_digest": "sha256:c42029f7a79c6cf993ee1b971a08d66023df46eb3cbdf127b7e9c4ed2a83998b",
+        "observed_agent_runs": 1,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "partial",
+        "total_tokens": 383800,
+        "unavailable_reason": "some_agent_runs_lack_provider_token_telemetry",
+        "updated_at": "2026-09-02T13:03:09.273Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 2429477,
+      "artifact_count": 74,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 172133,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 221508,
+      "readme_object": "8966e3c252372274551a8e3fef2aaca2fad6a693",
+      "readme_path": ".agentplane/tasks/202608291005-K5TG4D/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608291005-K5TG4D",
+      "usage": {
+        "agent_runs": 18,
+        "input_tokens": null,
+        "journal_digest": "sha256:7cb63dac8eb93aa11606f9340deb46446e7d72e69cec176312e57b3444ee7aeb",
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "provider_token_telemetry_unavailable",
+        "updated_at": "2026-08-29T18:59:28.010Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 250092,
+      "artifact_count": 34,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 66609,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 83132,
+      "readme_object": "5c96676a5c579ecc9e9cc2fdae35e852caa92fba",
+      "readme_path": ".agentplane/tasks/202608290920-1PZGG8/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608290920-1PZGG8",
+      "usage": {
+        "agent_runs": 11,
+        "input_tokens": null,
+        "journal_digest": "sha256:ee3858dd95f6eca0f0bfc7f8c6249802bbe20c5d20d1cfce3595da7e5df45b43",
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "provider_token_telemetry_unavailable",
+        "updated_at": "2026-08-29T11:21:43.145Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 867735,
+      "artifact_count": 63,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 155422,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 194291,
+      "readme_object": "e90f63474840a6ea9e46e6da9c107d6986f2103e",
+      "readme_path": ".agentplane/tasks/202608290844-7JCQPF/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608290844-7JCQPF",
+      "usage": {
+        "agent_runs": 20,
+        "input_tokens": null,
+        "journal_digest": "sha256:f53569e941d84e69a595c3bc60e4bc4fb690b7a8145fac97df1b7c6d82241bde",
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "provider_token_telemetry_unavailable",
+        "updated_at": "2026-08-29T17:02:27.493Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 174482,
+      "artifact_count": 20,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 49422,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 60080,
+      "readme_object": "91d09c32291763a6c05354e0ff8ad66c4c64bd45",
+      "readme_path": ".agentplane/tasks/202608281151-WQ89A1/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608281151-WQ89A1",
+      "usage": {
+        "agent_runs": 3,
+        "input_tokens": null,
+        "journal_digest": "sha256:8035c8f0b458e8a032c7ed05e67f77a4c82a40d6ec54d8481f6e32e39becf586",
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "provider_token_telemetry_unavailable",
+        "updated_at": "2026-08-28T15:07:18.312Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 190859,
+      "artifact_count": 20,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 48143,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 58388,
+      "readme_object": "4b76ad30a085b619c43b56cf9fd871cc8cac5117",
+      "readme_path": ".agentplane/tasks/202608280614-PCBY2N/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608280614-PCBY2N",
+      "usage": {
+        "agent_runs": 3,
+        "input_tokens": null,
+        "journal_digest": "sha256:77b78e7becf42113506c88beae6b8f61a94b57a5d88e69f4b8c84b8a37a821d7",
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "provider_token_telemetry_unavailable",
+        "updated_at": "2026-08-28T11:30:30.152Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 1144203,
+      "artifact_count": 49,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 160849,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 191215,
+      "readme_object": "f0de59044ebc5fda0a337e16f73b9cd2db367384",
+      "readme_path": ".agentplane/tasks/202608280529-59VB06/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608280529-59VB06",
+      "usage": {
+        "agent_runs": 15,
+        "input_tokens": null,
+        "journal_digest": "sha256:6f969edb54bf02f93dd5f4311ceeb920b5690dbbeed129c4e51e4bb254f825fe",
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "provider_token_telemetry_unavailable",
+        "updated_at": "2026-08-28T18:53:55.196Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 416732,
+      "artifact_count": 40,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 73745,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 94134,
+      "readme_object": "dd9cab8492599421f09a94156831ed8e79f3fac8",
+      "readme_path": ".agentplane/tasks/202608280009-QMVHM2/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608280009-QMVHM2",
+      "usage": {
+        "agent_runs": 8,
+        "input_tokens": null,
+        "journal_digest": "sha256:96cf94f0249350e2c53de8107945ff138fd5986793589379b3eb5c4f54017432",
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "provider_token_telemetry_unavailable",
+        "updated_at": "2026-08-28T05:15:15.433Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 295323,
+      "artifact_count": 39,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 61419,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 78533,
+      "readme_object": "ffaf203753002e9a3892e1d7c6d949add8d4011c",
+      "readme_path": ".agentplane/tasks/202608272229-CFKR4P/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608272229-CFKR4P",
+      "usage": {
+        "agent_runs": 8,
+        "input_tokens": null,
+        "journal_digest": "sha256:7ab16ec17e1da9654da60cef68af47b2e77dc17a0892578524251fc796e2b176",
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "provider_token_telemetry_unavailable",
+        "updated_at": "2026-08-28T05:39:28.449Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 251953,
+      "artifact_count": 32,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 63083,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 82374,
+      "readme_object": "9c7dd7528efa2b17e9118726b4f24d642cc21b73",
+      "readme_path": ".agentplane/tasks/202608271659-AD3030/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608271659-AD3030",
+      "usage": {
+        "agent_runs": 9,
+        "input_tokens": null,
+        "journal_digest": "sha256:b8d0fa39dd7f4b40d44b47d85b8fdf5cef75236190ea6208aef25b4e4a047e6a",
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "provider_token_telemetry_unavailable",
+        "updated_at": "2026-08-27T23:33:45.947Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 169614,
+      "artifact_count": 20,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 45022,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 53773,
+      "readme_object": "e53c28f179f6f643bdc4553730eafdadbac9e9c2",
+      "readme_path": ".agentplane/tasks/202608271649-DVNTRR/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608271649-DVNTRR",
+      "usage": {
+        "agent_runs": 3,
+        "input_tokens": null,
+        "journal_digest": "sha256:4edd76474f8b59ac1ebd4e6ec8b9d2a3e8562a1579fff6d994a98967d24cebec",
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "provider_token_telemetry_unavailable",
+        "updated_at": "2026-08-27T17:09:25.567Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 188937,
+      "artifact_count": 21,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 56406,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 66341,
+      "readme_object": "6c04611f25773303728c8959cfc0cb19e0d7d89a",
+      "readme_path": ".agentplane/tasks/202608271544-1TDVPJ/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608271544-1TDVPJ",
+      "usage": {
+        "agent_runs": 5,
+        "input_tokens": null,
+        "journal_digest": "sha256:71f7f8c2a407745cd3fdaabead59b12e7a3e2580bd12f8cbe03428da32a6bfa0",
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "provider_token_telemetry_unavailable",
+        "updated_at": "2026-08-27T16:29:31.721Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 700365,
+      "artifact_count": 41,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 185442,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 208423,
+      "readme_object": "aeebb7c5b55d82c506061e8ed2149315df740101",
+      "readme_path": ".agentplane/tasks/202608271538-T21JCA/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608271538-T21JCA",
+      "usage": {
+        "agent_runs": 15,
+        "input_tokens": null,
+        "journal_digest": "sha256:580e23750edaa054bac4944baf4e0a8532f10ef031e66e60dd435b7b28d3683c",
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "provider_token_telemetry_unavailable",
+        "updated_at": "2026-08-27T19:45:26.431Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 206260,
+      "artifact_count": 20,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 50272,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 59717,
+      "readme_object": "fa9fc54ef18ffc39bb737f08ecb187cd4729d352",
+      "readme_path": ".agentplane/tasks/202608271520-175BQX/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608271520-175BQX",
+      "usage": {
+        "agent_runs": 3,
+        "input_tokens": null,
+        "journal_digest": "sha256:8326489c4df2fae4178e4d31870acafd831b9db4210b1ea1181f37567df3aff8",
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "provider_token_telemetry_unavailable",
+        "updated_at": "2026-08-27T16:37:02.017Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 162680,
+      "artifact_count": 20,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 43995,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 52484,
+      "readme_object": "35ac3b118629b3b2ea9961ffe0159556ea7712ac",
+      "readme_path": ".agentplane/tasks/202608271502-J6B4RW/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608271502-J6B4RW",
+      "usage": {
+        "agent_runs": 3,
+        "input_tokens": null,
+        "journal_digest": "sha256:13cdb8cf898d2c83789882ca945655c7279564d46fd140f508b6981e6f59047f",
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "provider_token_telemetry_unavailable",
+        "updated_at": "2026-08-27T15:47:46.664Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 177629,
+      "artifact_count": 21,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 44238,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 53670,
+      "readme_object": "7c221a23cdbe2242ce613e4eddd4e449b9fd4ee2",
+      "readme_path": ".agentplane/tasks/202608271450-TZHW4C/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608271450-TZHW4C",
+      "usage": {
+        "agent_runs": 4,
+        "input_tokens": null,
+        "journal_digest": "sha256:33058237068e9ae133af9c29bf1d8d54420ea06951925dcc82fbde3f828a03da",
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "provider_token_telemetry_unavailable",
+        "updated_at": "2026-08-27T16:48:47.224Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 162005,
+      "artifact_count": 21,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 44580,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 53667,
+      "readme_object": "464e8f26ece0389eae7d3910fdbb2fe559cff272",
+      "readme_path": ".agentplane/tasks/202608271441-DVEMAE/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608271441-DVEMAE",
+      "usage": {
+        "agent_runs": 4,
+        "input_tokens": null,
+        "journal_digest": "sha256:d2e9f65afdb146821e771e1da46af50c9d6aaf52c45ddf2b2563d0eac95df5bc",
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "provider_token_telemetry_unavailable",
+        "updated_at": "2026-08-27T16:16:59.917Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 202615,
+      "artifact_count": 20,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 65766,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 75328,
+      "readme_object": "5b4c7a0132cc3f3bdd286aab83537a23189ea802",
+      "readme_path": ".agentplane/tasks/202608271425-9EWJA1/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608271425-9EWJA1",
+      "usage": {
+        "agent_runs": 4,
+        "input_tokens": null,
+        "journal_digest": "sha256:41d8d4b0f0a9f3d895e8d4c6c212e967275d790fb6faf6535861f2b9135a432a",
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "provider_token_telemetry_unavailable",
+        "updated_at": "2026-08-27T14:53:45.543Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 177147,
+      "artifact_count": 22,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 48376,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 59492,
+      "readme_object": "dbe1cc90cde1c2da97a615f93bbba9741f6538ad",
+      "readme_path": ".agentplane/tasks/202608271358-G0N9P4/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608271358-G0N9P4",
+      "usage": {
+        "agent_runs": 5,
+        "input_tokens": null,
+        "journal_digest": "sha256:4dccf2d36623fbccb76c3d7f5b39076f849c7e75020d2127a588f854e57d0dd4",
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "provider_token_telemetry_unavailable",
+        "updated_at": "2026-08-27T14:47:16.004Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 201047,
+      "artifact_count": 21,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 70516,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 79640,
+      "readme_object": "6c42d42b25d3dd271eb41d0c79cbe0e0af5713af",
+      "readme_path": ".agentplane/tasks/202608271251-GHHA0Q/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608271251-GHHA0Q",
+      "usage": {
+        "agent_runs": 10,
+        "input_tokens": null,
+        "journal_digest": "sha256:58f7e89a395f4ceacf1e7bce2220179d6bc95d99c70c57145dee4666b14c89a1",
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "provider_token_telemetry_unavailable",
+        "updated_at": "2026-08-27T13:27:17.131Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 209489,
+      "artifact_count": 27,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 54906,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 74312,
+      "readme_object": "22a8d11d6b1bc3816a5535335041b0959c0ecca1",
+      "readme_path": ".agentplane/tasks/202608262034-QVVB66/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608262034-QVVB66",
+      "usage": {
+        "agent_runs": 11,
+        "input_tokens": null,
+        "journal_digest": "sha256:912d4a5921d3b1e167f0f843a774d278f69e08f8bd5d18256a195ae1c4b875ec",
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "provider_token_telemetry_unavailable",
+        "updated_at": "2026-08-26T23:26:37.373Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 714030,
+      "artifact_count": 60,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 137519,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 184498,
+      "readme_object": "86d156e38a961308e054eb3050816186058ab763",
+      "readme_path": ".agentplane/tasks/202608261249-BXQZ97/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608261249-BXQZ97",
+      "usage": {
+        "agent_runs": 24,
+        "input_tokens": null,
+        "journal_digest": "sha256:d03cc743b4dc72c9ce144204f1f13efec8616c80c8c721b6eb0edd25fab55164",
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "provider_token_telemetry_unavailable",
+        "updated_at": "2026-08-26T18:51:44.214Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 203840,
+      "artifact_count": 23,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 67772,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 82300,
+      "readme_object": "5b01df36e934fed38170e32e5ddd0d7bce29fac2",
+      "readme_path": ".agentplane/tasks/202608260947-C6WV4T/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608260947-C6WV4T",
+      "usage": {
+        "agent_runs": 10,
+        "input_tokens": null,
+        "journal_digest": "sha256:6f086f5a7d313f1c5a2efed04cf4376c79f4bc85b76efe03b59cb471248794ab",
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "provider_token_telemetry_unavailable",
+        "updated_at": "2026-08-26T10:56:47.786Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 8174016,
+      "artifact_count": 69,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 619551,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 656327,
+      "readme_object": "d2ee7a916910b79a0a54d7731c2108cf7bdf756b",
+      "readme_path": ".agentplane/tasks/202608251706-V287W1/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608251706-V287W1",
+      "usage": {
+        "agent_runs": 17,
+        "input_tokens": null,
+        "journal_digest": "sha256:3e77aec96705bedc6e6e028141e8b94e69f78eaec25b71de66b87f10cbe4ee19",
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "provider_token_telemetry_unavailable",
+        "updated_at": "2026-08-30T08:38:51.059Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 155138,
+      "artifact_count": 20,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 43074,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 50990,
+      "readme_object": "4dbe4941bbe77f02bb67d45c58dca1008688066a",
+      "readme_path": ".agentplane/tasks/202608250015-DZ61YB/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608250015-DZ61YB",
+      "usage": {
+        "agent_runs": 3,
+        "input_tokens": null,
+        "journal_digest": "sha256:92c2fbbe8c9ec2fa16b890c8baf842262b525db5acf94aa39f13f6690942352e",
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "provider_token_telemetry_unavailable",
+        "updated_at": "2026-08-25T01:06:09.566Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 313056,
+      "artifact_count": 36,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 65188,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 85949,
+      "readme_object": "812cf26bea2df1ce1c491a92f7fc0fb2b02ca942",
+      "readme_path": ".agentplane/tasks/202608242233-KTFFN7/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608242233-KTFFN7",
+      "usage": {
+        "agent_runs": 11,
+        "input_tokens": null,
+        "journal_digest": "sha256:cc5b9c84383874bcab421f6b9a160bb1a359d62fd4e7e6a7dd45b3335559de7c",
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "provider_token_telemetry_unavailable",
+        "updated_at": "2026-08-25T03:30:42.794Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 205047,
+      "artifact_count": 23,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 55657,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 67452,
+      "readme_object": "43be63fad5ac946b1762936a8059dd20d876b48d",
+      "readme_path": ".agentplane/tasks/202608230243-BCEYJ9/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608230243-BCEYJ9",
+      "usage": {
+        "agent_runs": 7,
+        "input_tokens": null,
+        "journal_digest": "sha256:6e5848ff48b5d2852b47bd81123bee66f5b42f41f60ebe567be59fb9c69f0793",
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "provider_token_telemetry_unavailable",
+        "updated_at": "2026-08-23T04:20:13.087Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 304930,
+      "artifact_count": 57,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 64971,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 80404,
+      "readme_object": "dc59ababdef8f7c785f07342981c2ee3dc9c06e6",
+      "readme_path": ".agentplane/tasks/202608230020-TEK7WE/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608230020-TEK7WE",
+      "usage": {
+        "agent_runs": 18,
+        "input_tokens": null,
+        "journal_digest": "sha256:544d7274c067f301893acf279ef48c87accd794e07662dfaf60b42094d6107c9",
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "provider_token_telemetry_unavailable",
+        "updated_at": "2026-08-23T05:06:19.996Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 127643,
+      "artifact_count": 13,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 49529,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 65495,
+      "readme_object": "d2c144f038c50ce032d8b96e12d461f21478fbfc",
+      "readme_path": ".agentplane/tasks/202608222129-K0TGS4/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608222129-K0TGS4",
+      "usage": {
+        "agent_runs": 0,
+        "input_tokens": null,
+        "journal_digest": null,
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "unavailable",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "supervisor_journal_missing",
+        "updated_at": "2026-08-23T06:55:16.559Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 888273,
+      "artifact_count": 23,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 115210,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 129893,
+      "readme_object": "6c1bc194d076f5ad3d4b6a77df4bc7850eaa19c7",
+      "readme_path": ".agentplane/tasks/202608222117-HQ5AA4/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608222117-HQ5AA4",
+      "usage": {
+        "agent_runs": 8,
+        "input_tokens": null,
+        "journal_digest": "sha256:83ff0775f9cb01685a777d1798a6bf52e88909136a6c18e41657b56fde0da6fb",
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "provider_token_telemetry_unavailable",
+        "updated_at": "2026-08-23T07:53:10.371Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 2196345,
+      "artifact_count": 47,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 139810,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 159122,
+      "readme_object": "b2d164cd68b6a2a13e79b44785cb399144c6fb0d",
+      "readme_path": ".agentplane/tasks/202608222055-1DKNTY/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608222055-1DKNTY",
+      "usage": {
+        "agent_runs": 10,
+        "input_tokens": null,
+        "journal_digest": "sha256:00c4290283d4e17b969d1bc888f2248e0b80f513860d5e26733b738242aa06cf",
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "provider_token_telemetry_unavailable",
+        "updated_at": "2026-08-23T08:54:28.157Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 221304,
+      "artifact_count": 41,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 42488,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 54393,
+      "readme_object": "8556d1402c3a62e213fce817d8ffde58cfd1ee7c",
+      "readme_path": ".agentplane/tasks/202608221939-911DRN/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608221939-911DRN",
+      "usage": {
+        "agent_runs": 5,
+        "input_tokens": null,
+        "journal_digest": "sha256:27b7c3cd72a00801f1dab2d2c29f51ab8a5bfd58f2fa43bd71d4595a7b51950f",
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "provider_token_telemetry_unavailable",
+        "updated_at": "2026-08-22T20:09:25.399Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 288332,
+      "artifact_count": 35,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 58530,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 77927,
+      "readme_object": "be69de1ae16dfdb2b1691223acf765e9dfaeb1c3",
+      "readme_path": ".agentplane/tasks/202608221545-ZCYV3B/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608221545-ZCYV3B",
+      "usage": {
+        "agent_runs": 11,
+        "input_tokens": null,
+        "journal_digest": "sha256:b31726556c46954a585f075555cee9f59d66414a8effd3d87f7227ce2e902f5a",
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "provider_token_telemetry_unavailable",
+        "updated_at": "2026-08-22T18:42:25.588Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 140466,
+      "artifact_count": 21,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 33829,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 42670,
+      "readme_object": "f6f3ceb6e478b2df033999e628caea6d720f6985",
+      "readme_path": ".agentplane/tasks/202608221511-ZD76VS/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608221511-ZD76VS",
+      "usage": {
+        "agent_runs": 3,
+        "input_tokens": null,
+        "journal_digest": "sha256:28242aaf23353da51dc7a6f0a54070c7b20bdde16f23940b6f391cb43e5ab9b8",
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "provider_token_telemetry_unavailable",
+        "updated_at": "2026-08-22T19:08:39.137Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 287663,
+      "artifact_count": 44,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 57414,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 80295,
+      "readme_object": "b6cf22ce735ab141c7b9e525a4de4be3e2455e0a",
+      "readme_path": ".agentplane/tasks/202608221335-6DSF3R/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608221335-6DSF3R",
+      "usage": {
+        "agent_runs": 11,
+        "input_tokens": null,
+        "journal_digest": "sha256:540610484ede76f2785e5cb41b5b1ac48d955107357f91969aa60f759cde80a7",
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "provider_token_telemetry_unavailable",
+        "updated_at": "2026-08-22T14:42:04.478Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 120337,
+      "artifact_count": 20,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 29922,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 34928,
+      "readme_object": "a54cb1a5fb14e2597c4e8d8b55e60855a537168f",
+      "readme_path": ".agentplane/tasks/202608221158-P5RSA8/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608221158-P5RSA8",
+      "usage": {
+        "agent_runs": 3,
+        "input_tokens": null,
+        "journal_digest": "sha256:5e459e1bef5981caa90cbe4cea520ad48f876e54438297331fd783ba4e0851e9",
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "provider_token_telemetry_unavailable",
+        "updated_at": "2026-08-22T12:06:26.132Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 122545,
+      "artifact_count": 20,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 31714,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 37328,
+      "readme_object": "a414ea5dfe588753a268a6dae8bc1ab2092335b7",
+      "readme_path": ".agentplane/tasks/202608221115-2H0QP2/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608221115-2H0QP2",
+      "usage": {
+        "agent_runs": 3,
+        "input_tokens": null,
+        "journal_digest": "sha256:7c0aada38fdbd7bd3be93720700e367f122e5ba22fe0480693fd28328660a7a2",
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "provider_token_telemetry_unavailable",
+        "updated_at": "2026-08-22T11:21:39.038Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 217052,
+      "artifact_count": 30,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 43981,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 58355,
+      "readme_object": "1f211c49e1014071bfec1850be46ea2d2ef7325b",
+      "readme_path": ".agentplane/tasks/202608221017-2HT3N7/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608221017-2HT3N7",
+      "usage": {
+        "agent_runs": 3,
+        "input_tokens": null,
+        "journal_digest": "sha256:f3e333f2e58c10d8953fb2a5aeb9fd084ded223580061927fe1f8778e11808e2",
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "provider_token_telemetry_unavailable",
+        "updated_at": "2026-08-22T11:00:04.544Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 505872,
+      "artifact_count": 55,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 101351,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 130840,
+      "readme_object": "920a89c4fbf2dbf023d566d1a0a1e98cc79483e5",
+      "readme_path": ".agentplane/tasks/202608220538-SVC324/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608220538-SVC324",
+      "usage": {
+        "agent_runs": 13,
+        "input_tokens": null,
+        "journal_digest": "sha256:f58a665570e5bf447f81c114a3a126de7727361f7ee741b4beb8bb5a84631c4e",
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "provider_token_telemetry_unavailable",
+        "updated_at": "2026-08-22T07:35:51.339Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 203946,
+      "artifact_count": 26,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 45535,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 75098,
+      "readme_object": "7157e9b9fa8bf8722799e896fd43d2d30a709909",
+      "readme_path": ".agentplane/tasks/202608212254-WR57ZD/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608212254-WR57ZD",
+      "usage": {
+        "agent_runs": 0,
+        "input_tokens": null,
+        "journal_digest": null,
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "unavailable",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "supervisor_journal_missing",
+        "updated_at": "2026-08-22T01:02:18.659Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 6386926,
+      "artifact_count": 154,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 161810,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 265178,
+      "readme_object": "a7daf894594cfe897714baddba2bd3297422e9bc",
+      "readme_path": ".agentplane/tasks/202608212244-6XZAYD/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608212244-6XZAYD",
+      "usage": {
+        "agent_runs": 38,
+        "input_tokens": null,
+        "journal_digest": "sha256:d5351cf3f7e2c390c53d69a27859984e5cfbd42863a76219522de4a646088720",
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "provider_token_telemetry_unavailable",
+        "updated_at": "2026-08-22T04:47:58.149Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 248725,
+      "artifact_count": 44,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 36038,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 52353,
+      "readme_object": "6d6397138fdc5edb127554984c66e5c6455e9833",
+      "readme_path": ".agentplane/tasks/202608211236-XEC2NE/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608211236-XEC2NE",
+      "usage": {
+        "agent_runs": 9,
+        "input_tokens": null,
+        "journal_digest": "sha256:d42a81a64557047ce6aa8183cb6560d24e43b1954e7b4b4ab6d3b4991f9a0bad",
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "provider_token_telemetry_unavailable",
+        "updated_at": "2026-08-21T21:37:38.539Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 6785172,
+      "artifact_count": 205,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 221078,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 333712,
+      "readme_object": "5e8f677b51d33435e60919253428e1f90df18b74",
+      "readme_path": ".agentplane/tasks/202608211020-FGAPJC/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608211020-FGAPJC",
+      "usage": {
+        "agent_runs": 60,
+        "input_tokens": null,
+        "journal_digest": "sha256:142f2183f77e6c69f744cc68de25bb554863b5c10e6a4f3bbd0604de2247d6ea",
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "provider_token_telemetry_unavailable",
+        "updated_at": "2026-08-21T19:33:27.415Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 288837,
+      "artifact_count": 50,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 39846,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 55709,
+      "readme_object": "bebdbec480e44f1d01bdec8730a5a5fd0a70c4b4",
+      "readme_path": ".agentplane/tasks/202608211010-X9X57M/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608211010-X9X57M",
+      "usage": {
+        "agent_runs": 11,
+        "input_tokens": null,
+        "journal_digest": "sha256:96b7f6a20630be6f37355fbcd53cf82b2926dc5b12ecd94af26f9eec80161e53",
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "provider_token_telemetry_unavailable",
+        "updated_at": "2026-08-21T12:21:38.456Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 106650,
+      "artifact_count": 20,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 16253,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 21807,
+      "readme_object": "46c23052619880fc2d11da02c2996f18d42a5d95",
+      "readme_path": ".agentplane/tasks/202608210853-0FYGE3/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608210853-0FYGE3",
+      "usage": {
+        "agent_runs": 3,
+        "input_tokens": null,
+        "journal_digest": "sha256:fa5a997bd8bffb700c8afefcecaff5ead33652c097aff552485bf67ce0e3ef63",
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "provider_token_telemetry_unavailable",
+        "updated_at": "2026-08-21T09:17:15.920Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 259416,
+      "artifact_count": 43,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 30225,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 44496,
+      "readme_object": "c11438e122ae3e29e0f023270adf4b123d021f97",
+      "readme_path": ".agentplane/tasks/202608202141-WC5RF1/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608202141-WC5RF1",
+      "usage": {
+        "agent_runs": 15,
+        "input_tokens": null,
+        "journal_digest": "sha256:6f5d505bb50917d70f67256f250ae51a791a3a53ac42993353809b59637d947e",
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "provider_token_telemetry_unavailable",
+        "updated_at": "2026-08-20T23:22:34.417Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 195278,
+      "artifact_count": 19,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 16285,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 21789,
+      "readme_object": "994c7b84a4eeeb3301bebe4a435539e92e300c37",
+      "readme_path": ".agentplane/tasks/202608202133-1C8P0N/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608202133-1C8P0N",
+      "usage": {
+        "agent_runs": 4,
+        "input_tokens": null,
+        "journal_digest": "sha256:eb490356f874554d49919e317f508fcc1a82ad140642d9d7dc7bd979f602c0d9",
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "provider_token_telemetry_unavailable",
+        "updated_at": "2026-08-20T22:15:57.621Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 345898,
+      "artifact_count": 42,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 73783,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 106115,
+      "readme_object": "ccf38ee7a168344eb3a53bcb48931350f4b76e92",
+      "readme_path": ".agentplane/tasks/202608202112-E6CDHP/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608202112-E6CDHP",
+      "usage": {
+        "agent_runs": 15,
+        "input_tokens": null,
+        "journal_digest": "sha256:838aafe1ecd3ef40bcb91848725baaac2a16e4949875625b8c0d7526b20dfb12",
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "provider_token_telemetry_unavailable",
+        "updated_at": "2026-08-21T22:15:02.975Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 1084228,
+      "artifact_count": 51,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 50484,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 71928,
+      "readme_object": "9554d862941aadef5faa90fe253e58ffafca397b",
+      "readme_path": ".agentplane/tasks/202608201524-TRM5DT/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608201524-TRM5DT",
+      "usage": {
+        "agent_runs": 11,
+        "input_tokens": null,
+        "journal_digest": "sha256:a51837e7fffd9c4a7e3945678eb097a11e15fe9cc90103d8a522831ca61c0dc9",
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "provider_token_telemetry_unavailable",
+        "updated_at": "2026-08-20T20:31:57.781Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 3666533,
+      "artifact_count": 93,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 194703,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 253713,
+      "readme_object": "46fa4f9f72f09980c6415f3154f701f7ed11bee1",
+      "readme_path": ".agentplane/tasks/202608200903-J459C2/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608200903-J459C2",
+      "usage": {
+        "agent_runs": 25,
+        "input_tokens": null,
+        "journal_digest": "sha256:a250d29f6daca6abbe1170dbf2f6beb74fcda1cc59b1c940e7f511c38b5727c5",
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "provider_token_telemetry_unavailable",
+        "updated_at": "2026-08-21T00:34:18.036Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 188376,
+      "artifact_count": 27,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 17907,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 25518,
+      "readme_object": "5458f4622ea7ab7f9ad401790befa36b0e2a55de",
+      "readme_path": ".agentplane/tasks/202608182243-NMAHN5/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608182243-NMAHN5",
+      "usage": {
+        "agent_runs": 2,
+        "input_tokens": null,
+        "journal_digest": "sha256:d0ea8b94c8015c823e8d40de8e63193464d63a41bbf0cba76919dabdf9ee95b0",
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "provider_token_telemetry_unavailable",
+        "updated_at": "2026-08-19T12:29:56.236Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 366150,
+      "artifact_count": 37,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 49077,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 77851,
+      "readme_object": "4bd210d87334953c1926a51a6838f7853e12e01d",
+      "readme_path": ".agentplane/tasks/202608181819-Z3GWTA/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608181819-Z3GWTA",
+      "usage": {
+        "agent_runs": 3,
+        "input_tokens": null,
+        "journal_digest": "sha256:d6dff919df7fa83ae189da687cd94bf7654cdeff45c466725c5b9f0a7a67091f",
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "provider_token_telemetry_unavailable",
+        "updated_at": "2026-08-18T20:43:44.308Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 3147228,
+      "artifact_count": 114,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 137763,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 207413,
+      "readme_object": "0f389aa4283af7639f292fc49cc65ebc05c54697",
+      "readme_path": ".agentplane/tasks/202608181750-CRZNFC/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608181750-CRZNFC",
+      "usage": {
+        "agent_runs": 35,
+        "input_tokens": null,
+        "journal_digest": "sha256:49509c6d7effdc8b34177b0c96b991ed34ba294fcb786c934af03d498e03c2a9",
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "provider_token_telemetry_unavailable",
+        "updated_at": "2026-08-19T04:31:36.772Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 786266,
+      "artifact_count": 49,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 50844,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 72020,
+      "readme_object": "92293122c2b8ce73488dddaa1137bc07cc85d672",
+      "readme_path": ".agentplane/tasks/202608181634-3EHFWF/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608181634-3EHFWF",
+      "usage": {
+        "agent_runs": 10,
+        "input_tokens": null,
+        "journal_digest": "sha256:5a48cb83a408c36f4d206d81a3f035c73a32fac14c61bfd951337e69f7cb6096",
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "provider_token_telemetry_unavailable",
+        "updated_at": "2026-08-18T17:39:35.708Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 758316,
+      "artifact_count": 48,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 40125,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 57602,
+      "readme_object": "4112d9da02985c1a013ab22bf21f3d440239db5e",
+      "readme_path": ".agentplane/tasks/202608181404-CR1F9W/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608181404-CR1F9W",
+      "usage": {
+        "agent_runs": 9,
+        "input_tokens": null,
+        "journal_digest": "sha256:b02ba3476bfad8355f330ec15a840592609aedaffac97c120eafa8dcca28c7f8",
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "provider_token_telemetry_unavailable",
+        "updated_at": "2026-08-18T15:42:35.725Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 1795089,
+      "artifact_count": 117,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 99877,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 167785,
+      "readme_object": "d4a97a1ffd8ed83f6dd3ba6f497d81b83c16d17b",
+      "readme_path": ".agentplane/tasks/202608171853-X3FD5M/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608171853-X3FD5M",
+      "usage": {
+        "agent_runs": 26,
+        "input_tokens": null,
+        "journal_digest": "sha256:6341c0b696b4bad9de4e1b43bf71090bb2cb5893fc04102054e294f0e6bd2366",
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "provider_token_telemetry_unavailable",
+        "updated_at": "2026-08-17T21:27:52.463Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 983493,
+      "artifact_count": 75,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 89398,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 148455,
+      "readme_object": "a820e2a307f03ae6efe0a24417b13d011ce6158e",
+      "readme_path": ".agentplane/tasks/202608171106-XFN696/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608171106-XFN696",
+      "usage": {
+        "agent_runs": 19,
+        "input_tokens": null,
+        "journal_digest": "sha256:922b75e5e58e96a6424c527e7b35568a8943a8fb5fce1eab4b4f499d0dd3b617",
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "provider_token_telemetry_unavailable",
+        "updated_at": "2026-08-17T18:03:12.936Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 698231,
+      "artifact_count": 81,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 65075,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 103222,
+      "readme_object": "7e007563df2212e74ca82c5d32c1869821e3d069",
+      "readme_path": ".agentplane/tasks/202608170928-8Y24PK/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608170928-8Y24PK",
+      "usage": {
+        "agent_runs": 16,
+        "input_tokens": null,
+        "journal_digest": "sha256:7d23b93cb9d0df73e88f30845d28d160e5183106a359379c03b068585dafe4f8",
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "provider_token_telemetry_unavailable",
+        "updated_at": "2026-08-17T23:14:12.743Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 340569,
+      "artifact_count": 77,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 35819,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 58651,
+      "readme_object": "8d9c7f320814f65898ab62d7a832810b19f5fb33",
+      "readme_path": ".agentplane/tasks/202608131733-KECD7J/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608131733-KECD7J",
+      "usage": {
+        "agent_runs": 5,
+        "input_tokens": 639700,
+        "journal_digest": "sha256:34363f3528d9bb5d2e30e2b64747a10551c9bd95801c4aa0937cd32f89f3402a",
+        "observed_agent_runs": 5,
+        "observed_by": "agentplane",
+        "output_tokens": 10844,
+        "reasoning_tokens": 2662,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "observed",
+        "total_tokens": 653206,
+        "unavailable_reason": null,
+        "updated_at": "2026-08-13T18:19:01.100Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 1189923,
+      "artifact_count": 65,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 57586,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 76731,
+      "readme_object": "5404dde653fbd9114f9dd9dbb6af7c136721f3b3",
+      "readme_path": ".agentplane/tasks/202608131730-BHEAQT/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608131730-BHEAQT",
+      "usage": {
+        "agent_runs": 3,
+        "input_tokens": 490474,
+        "journal_digest": "sha256:80f1a8b35a769ad8299141d552937a2375a08627ebc4e49a088e8957faa258f8",
+        "observed_agent_runs": 3,
+        "observed_by": "agentplane",
+        "output_tokens": 6459,
+        "reasoning_tokens": 1516,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "observed",
+        "total_tokens": 498449,
+        "unavailable_reason": null,
+        "updated_at": "2026-08-13T23:29:33.865Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 351845,
+      "artifact_count": 27,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 32765,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 49285,
+      "readme_object": "769a822e1318a1bc2170c3b52beb26e445490be3",
+      "readme_path": ".agentplane/tasks/202608122156-EZZZYH/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608122156-EZZZYH",
+      "usage": {
+        "agent_runs": 2,
+        "input_tokens": null,
+        "journal_digest": "sha256:4d0511c8b46d51691b0e9251e65cc32e0944a8efd1076840a4cd97249958b2a2",
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "provider_token_telemetry_unavailable",
+        "updated_at": "2026-08-13T17:11:23.534Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 258984,
+      "artifact_count": 30,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 31518,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 50223,
+      "readme_object": "43bccf832197ffa6c2828c0877c98cefbd5d81b8",
+      "readme_path": ".agentplane/tasks/202608120643-75ZFHW/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608120643-75ZFHW",
+      "usage": {
+        "agent_runs": 1,
+        "input_tokens": null,
+        "journal_digest": "sha256:6ce45672f0a42f80738af2416150b21af6e71d8ca4258ab6fbf39920af2ce841",
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "provider_token_telemetry_unavailable",
+        "updated_at": "2026-08-12T08:17:55.742Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 9314022,
+      "artifact_count": 169,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 99655,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 154881,
+      "readme_object": "bd0aee0534ecc0f5263c4a87f0ae67d60c1b4080",
+      "readme_path": ".agentplane/tasks/202608112259-T3ZDDM/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608112259-T3ZDDM",
+      "usage": {
+        "agent_runs": 11,
+        "input_tokens": 2103219,
+        "journal_digest": "sha256:03e6fa53f280c7e0e892ae6fd512478d296a02ef4e003494abd7ed49bdef51f7",
+        "observed_agent_runs": 10,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "partial",
+        "total_tokens": 2135814,
+        "unavailable_reason": "some_agent_runs_lack_provider_token_telemetry",
+        "updated_at": "2026-08-13T15:17:31.561Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 2314851,
+      "artifact_count": 99,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 38420,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 67569,
+      "readme_object": "87456dfe2438165756ab45f66c3079873eb72a64",
+      "readme_path": ".agentplane/tasks/202608112232-3NC7Y4/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608112232-3NC7Y4",
+      "usage": {
+        "agent_runs": 7,
+        "input_tokens": 1424631,
+        "journal_digest": "sha256:93cca0c3baf85202d0b79e5e560c922b6e0f4d110061e53eab303b043756d65d",
+        "observed_agent_runs": 7,
+        "observed_by": "agentplane",
+        "output_tokens": 17741,
+        "reasoning_tokens": 3755,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "observed",
+        "total_tokens": 1446127,
+        "unavailable_reason": null,
+        "updated_at": "2026-08-12T06:20:10.545Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 908433,
+      "artifact_count": 51,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 34052,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 58159,
+      "readme_object": "88320c5d9496a912963605c9bb29376d29644892",
+      "readme_path": ".agentplane/tasks/202608112213-NWJCBW/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608112213-NWJCBW",
+      "usage": {
+        "agent_runs": 0,
+        "input_tokens": null,
+        "journal_digest": null,
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "unavailable",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "supervisor_journal_missing",
+        "updated_at": "2026-08-12T00:17:22.153Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 378359,
+      "artifact_count": 49,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 21321,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 34411,
+      "readme_object": "03aa5cc450bda21874a2b787df91b6a30f4ba900",
+      "readme_path": ".agentplane/tasks/202608111922-W4ZM7J/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608111922-W4ZM7J",
+      "usage": {
+        "agent_runs": 1,
+        "input_tokens": null,
+        "journal_digest": "sha256:af2921d2c54ba16356be575bbdeb7b6d8a6bd05b0f05b4374affe3e3521c5483",
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "provider_token_telemetry_unavailable",
+        "updated_at": "2026-08-11T21:47:06.143Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 481623,
+      "artifact_count": 78,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 38296,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 66765,
+      "readme_object": "8f663b64a8ba30fabf08203f71047a92e9b82ed9",
+      "readme_path": ".agentplane/tasks/202608111036-QHR892/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608111036-QHR892",
+      "usage": {
+        "agent_runs": 5,
+        "input_tokens": 806967,
+        "journal_digest": "sha256:a47202ef0108833c2b0cd85a756602eea6e60c3a14fcbccee46bf4f11aff16e2",
+        "observed_agent_runs": 5,
+        "observed_by": "agentplane",
+        "output_tokens": 11436,
+        "reasoning_tokens": 3261,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "observed",
+        "total_tokens": 821664,
+        "unavailable_reason": null,
+        "updated_at": "2026-08-11T16:15:34.694Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 27120,
+      "artifact_count": 7,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 5518,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 8021,
+      "readme_object": "72e7dd76a29c759d7fac6a8a3154e45da7bfb389",
+      "readme_path": ".agentplane/tasks/202608111010-2M6168/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608111010-2M6168",
+      "usage": {
+        "agent_runs": 0,
+        "input_tokens": null,
+        "journal_digest": null,
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "unavailable",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "supervisor_journal_missing",
+        "updated_at": "2026-08-11T10:32:32.799Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 461013,
+      "artifact_count": 47,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 40003,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 68352,
+      "readme_object": "e82b0017fe714f53828d732867f3e5ce768b76be",
+      "readme_path": ".agentplane/tasks/202608110235-WCJJRD/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608110235-WCJJRD",
+      "usage": {
+        "agent_runs": 0,
+        "input_tokens": null,
+        "journal_digest": null,
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "unavailable",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "supervisor_journal_missing",
+        "updated_at": "2026-08-11T09:08:45.721Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 325276,
+      "artifact_count": 45,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 28933,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 48820,
+      "readme_object": "de905ddc6929128a73f70cfd626d3f58fa2f4f46",
+      "readme_path": ".agentplane/tasks/202608110110-3QTGFQ/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608110110-3QTGFQ",
+      "usage": {
+        "agent_runs": 1,
+        "input_tokens": null,
+        "journal_digest": "sha256:90eda43765582f18f2d4797a05eca613f69ac87dbfdd9a6f76ca52656db29c1d",
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "provider_token_telemetry_unavailable",
+        "updated_at": "2026-08-11T02:24:22.807Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 428375,
+      "artifact_count": 36,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 27442,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 45533,
+      "readme_object": "73efe2673e97b9208c186e485b0c9e2ab48d69d3",
+      "readme_path": ".agentplane/tasks/202608102243-1RG86M/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608102243-1RG86M",
+      "usage": {
+        "agent_runs": 0,
+        "input_tokens": null,
+        "journal_digest": null,
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "unavailable",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "supervisor_journal_missing",
+        "updated_at": "2026-08-11T00:55:58.628Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 32374,
+      "artifact_count": 7,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 9369,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 15804,
+      "readme_object": "95d3e7da915d224bdb313420e1bbb289f5f5ecb4",
+      "readme_path": ".agentplane/tasks/202608102115-7XGP97/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608102115-7XGP97",
+      "usage": {
+        "agent_runs": 0,
+        "input_tokens": null,
+        "journal_digest": null,
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "unavailable",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "supervisor_journal_missing",
+        "updated_at": "2026-08-11T20:30:35.360Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 57914,
+      "artifact_count": 12,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 21139,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 33299,
+      "readme_object": "8bc8c12d649794614d9ff0c329673119afabdcf2",
+      "readme_path": ".agentplane/tasks/202608102112-AY0H1F/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608102112-AY0H1F",
+      "usage": {
+        "agent_runs": 0,
+        "input_tokens": null,
+        "journal_digest": null,
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "unavailable",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "supervisor_journal_missing",
+        "updated_at": "2026-08-10T22:40:58.248Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 172247,
+      "artifact_count": 30,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 15596,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 23424,
+      "readme_object": "d34bde6f798c300368cf03763e1e2564dd2a1f64",
+      "readme_path": ".agentplane/tasks/202608101850-25R7W2/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608101850-25R7W2",
+      "usage": {
+        "agent_runs": 4,
+        "input_tokens": null,
+        "journal_digest": "sha256:03a6bdb4e5196933c6edaffd906e7bd946efe1cd7883dc197599eef17ded042f",
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "provider_token_telemetry_unavailable",
+        "updated_at": "2026-08-10T19:51:03.479Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 244568,
+      "artifact_count": 48,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 22017,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 34926,
+      "readme_object": "431da62aa44ac54c7398227d639df0641fdcd801",
+      "readme_path": ".agentplane/tasks/202608101506-4Y8ZY0/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608101506-4Y8ZY0",
+      "usage": {
+        "agent_runs": 8,
+        "input_tokens": null,
+        "journal_digest": "sha256:6dc3b13f1a782984d971dedde60f6f25a0cb8600fe9408b722c012bf6414de5b",
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "provider_token_telemetry_unavailable",
+        "updated_at": "2026-08-10T16:34:31.084Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 428904,
+      "artifact_count": 74,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 41227,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 69514,
+      "readme_object": "9c18c4fb66a52b8a1308dcd16ad887c70e97284d",
+      "readme_path": ".agentplane/tasks/202608101410-4GSCYN/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608101410-4GSCYN",
+      "usage": {
+        "agent_runs": 10,
+        "input_tokens": null,
+        "journal_digest": "sha256:b21e7f22b33c81ca8cb818ac571b1e5e2772be68b41776e9d8073c31cd4215dd",
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "provider_token_telemetry_unavailable",
+        "updated_at": "2026-08-10T18:06:34.082Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 377773,
+      "artifact_count": 13,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 11807,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 18834,
+      "readme_object": "95e36c322c542775c3f63286a66f960946d2727a",
+      "readme_path": ".agentplane/tasks/202608101357-58FSYQ/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608101357-58FSYQ",
+      "usage": {
+        "agent_runs": 0,
+        "input_tokens": null,
+        "journal_digest": null,
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "unavailable",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "supervisor_journal_missing",
+        "updated_at": "2026-08-10T21:47:55.696Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 165259,
+      "artifact_count": 38,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 21017,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 33992,
+      "readme_object": "43306c1e0838914c395c91813f486dfb8ae9c918",
+      "readme_path": ".agentplane/tasks/202608101223-ZCA7JG/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608101223-ZCA7JG",
+      "usage": {
+        "agent_runs": 0,
+        "input_tokens": null,
+        "journal_digest": null,
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "unavailable",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "supervisor_journal_missing",
+        "updated_at": "2026-08-10T13:02:53.365Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 125672,
+      "artifact_count": 30,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 24112,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 40151,
+      "readme_object": "b32ab1423614a14a12a9ecfb5e7e66fe722c01cd",
+      "readme_path": ".agentplane/tasks/202608101159-Y4H8N5/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608101159-Y4H8N5",
+      "usage": {
+        "agent_runs": 0,
+        "input_tokens": null,
+        "journal_digest": null,
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "unavailable",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "supervisor_journal_missing",
+        "updated_at": "2026-08-10T13:50:03.974Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 185935,
+      "artifact_count": 19,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 17677,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 27264,
+      "readme_object": "92b5c724f546e263838584313c0ce2266d015501",
+      "readme_path": ".agentplane/tasks/202608082119-P6SHBN/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608082119-P6SHBN",
+      "usage": {
+        "agent_runs": 0,
+        "input_tokens": null,
+        "journal_digest": null,
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "unavailable",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "supervisor_journal_missing",
+        "updated_at": "2026-08-08T22:35:08.762Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 650153,
+      "artifact_count": 103,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 47691,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 79988,
+      "readme_object": "02ec3ff955a8106c88faf0b1b98042bbe495e6fb",
+      "readme_path": ".agentplane/tasks/202608081216-YAN7DW/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608081216-YAN7DW",
+      "usage": {
+        "agent_runs": 19,
+        "input_tokens": 1396922,
+        "journal_digest": "sha256:7d9612127f1d813a883f008531b36733522cf22fa54c437c40b42691db16ab02",
+        "observed_agent_runs": 6,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "partial",
+        "total_tokens": 1416964,
+        "unavailable_reason": "some_agent_runs_lack_provider_token_telemetry",
+        "updated_at": "2026-08-08T15:28:59.590Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 200555,
+      "artifact_count": 32,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 17841,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 28144,
+      "readme_object": "3bb598a1706e729ef2e535bcf283d89979b242fc",
+      "readme_path": ".agentplane/tasks/202608080805-KPWPAV/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608080805-KPWPAV",
+      "usage": {
+        "agent_runs": 5,
+        "input_tokens": null,
+        "journal_digest": "sha256:d78024e0a294f93ba571a0c118622bef7af70aa65afe317282ae0bec101bdc52",
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "provider_token_telemetry_unavailable",
+        "updated_at": "2026-08-08T08:46:55.558Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 475895,
+      "artifact_count": 77,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 33600,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 54661,
+      "readme_object": "8970043bef0dfa9a6f3580dac9ab97ed08e0313e",
+      "readme_path": ".agentplane/tasks/202608080551-8BH6HY/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608080551-8BH6HY",
+      "usage": {
+        "agent_runs": 17,
+        "input_tokens": 706977,
+        "journal_digest": "sha256:1236223dc07895b49e0e74b4d897e468ee19a1239f09b4062fc844cf393db86a",
+        "observed_agent_runs": 4,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "partial",
+        "total_tokens": 717365,
+        "unavailable_reason": "some_agent_runs_lack_provider_token_telemetry",
+        "updated_at": "2026-08-08T07:50:44.670Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 75902,
+      "artifact_count": 19,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 12899,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 20563,
+      "readme_object": "d77802ec74a05b0de321bfcd43ef1e0af3d4d634",
+      "readme_path": ".agentplane/tasks/202608080431-541KC2/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608080431-541KC2",
+      "usage": {
+        "agent_runs": 1,
+        "input_tokens": 79043,
+        "journal_digest": "sha256:a233a090ab6935a0912b2f6efe7ad5041feabdee3d4d09114e40c897b8cc6a70",
+        "observed_agent_runs": 1,
+        "observed_by": "agentplane",
+        "output_tokens": 1554,
+        "reasoning_tokens": 197,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "observed",
+        "total_tokens": 80794,
+        "unavailable_reason": null,
+        "updated_at": "2026-08-08T04:48:55.677Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 207865,
+      "artifact_count": 49,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 28868,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 50051,
+      "readme_object": "ebe276972d506e48ccfd2c877afb5e7692b78ba5",
+      "readme_path": ".agentplane/tasks/202608080403-N0VXJ0/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608080403-N0VXJ0",
+      "usage": {
+        "agent_runs": 5,
+        "input_tokens": 399652,
+        "journal_digest": "sha256:fa729f74c80917cfd327bc5cb3419db4ec868aa36b97de5b6f150f5326bb6b5c",
+        "observed_agent_runs": 4,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "partial",
+        "total_tokens": 406925,
+        "unavailable_reason": "some_agent_runs_lack_provider_token_telemetry",
+        "updated_at": "2026-08-08T05:02:19.640Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 199645,
+      "artifact_count": 42,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 24444,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 41258,
+      "readme_object": "d14ed2402d650ea0d84d8904e00dcfb7c5746fd5",
+      "readme_path": ".agentplane/tasks/202608080355-G5FXDA/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608080355-G5FXDA",
+      "usage": {
+        "agent_runs": 4,
+        "input_tokens": 322930,
+        "journal_digest": "sha256:1a5747708942ec97bb6fdde6a751af451488a335fb119c9cdec664e1950e5653",
+        "observed_agent_runs": 3,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "partial",
+        "total_tokens": 329045,
+        "unavailable_reason": "some_agent_runs_lack_provider_token_telemetry",
+        "updated_at": "2026-08-08T05:34:53.467Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 139762,
+      "artifact_count": 39,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 17505,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 26998,
+      "readme_object": "40aba1afaa6a2275dc955ed788ce8ec33c4cec51",
+      "readme_path": ".agentplane/tasks/202608070235-JPPAMT/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608070235-JPPAMT",
+      "usage": {
+        "agent_runs": 3,
+        "input_tokens": 304222,
+        "journal_digest": "sha256:e19f5f864b620f8fc15dedcc8c2b55d16957e111c9967dcb1ffa72578858be62",
+        "observed_agent_runs": 3,
+        "observed_by": "agentplane",
+        "output_tokens": 4885,
+        "reasoning_tokens": 947,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "observed",
+        "total_tokens": 310054,
+        "unavailable_reason": null,
+        "updated_at": "2026-08-07T02:49:08.114Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 250818,
+      "artifact_count": 59,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 23494,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 39598,
+      "readme_object": "6de701dafbdde2ea20ab565c1359748318d1b09e",
+      "readme_path": ".agentplane/tasks/202608070209-J3DEJ1/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608070209-J3DEJ1",
+      "usage": {
+        "agent_runs": 5,
+        "input_tokens": 925359,
+        "journal_digest": "sha256:af2d0eccd5435027e4ac2b85e8f97a88b73c31078133c1e2a4fbffec56c8ecdd",
+        "observed_agent_runs": 5,
+        "observed_by": "agentplane",
+        "output_tokens": 10339,
+        "reasoning_tokens": 2405,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "observed",
+        "total_tokens": 938103,
+        "unavailable_reason": null,
+        "updated_at": "2026-08-08T03:26:04.314Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 421821,
+      "artifact_count": 43,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 23354,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 38291,
+      "readme_object": "31053bda32dc1a02c718b9d56e8bf7ad08d43fe6",
+      "readme_path": ".agentplane/tasks/202608062023-V3WHE9/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608062023-V3WHE9",
+      "usage": {
+        "agent_runs": 3,
+        "input_tokens": 650741,
+        "journal_digest": "sha256:e80609f90fa8087e6195eedd2feffde8f96b2c38677175d784bcf6c370248ede",
+        "observed_agent_runs": 3,
+        "observed_by": "agentplane",
+        "output_tokens": 7002,
+        "reasoning_tokens": 1631,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "observed",
+        "total_tokens": 659374,
+        "unavailable_reason": null,
+        "updated_at": "2026-08-08T01:56:12.385Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 1548099,
+      "artifact_count": 86,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 45118,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 78285,
+      "readme_object": "7567385d134494ad61ee4f86588a1ecd5d940126",
+      "readme_path": ".agentplane/tasks/202608062021-Z0X584/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608062021-Z0X584",
+      "usage": {
+        "agent_runs": 7,
+        "input_tokens": 1308554,
+        "journal_digest": "sha256:9c903fdc1fdb6b6b868591098316983ad91965d775bf31e9790ae7401ba9f331",
+        "observed_agent_runs": 7,
+        "observed_by": "agentplane",
+        "output_tokens": 15059,
+        "reasoning_tokens": 3199,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "observed",
+        "total_tokens": 1326812,
+        "unavailable_reason": null,
+        "updated_at": "2026-08-07T04:11:18.794Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 1334082,
+      "artifact_count": 157,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 56192,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 99608,
+      "readme_object": "dc6ca5059d9894742842ab09edfc63185411db43",
+      "readme_path": ".agentplane/tasks/202608062021-V2EESE/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608062021-V2EESE",
+      "usage": {
+        "agent_runs": 16,
+        "input_tokens": 2432588,
+        "journal_digest": "sha256:5bd80b9e2b0b39567ef7c2b005375b0346a9498d11ae144bbd2216234a184e8e",
+        "observed_agent_runs": 12,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "partial",
+        "total_tokens": 2469058,
+        "unavailable_reason": "some_agent_runs_lack_provider_token_telemetry",
+        "updated_at": "2026-08-07T22:12:07.578Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 875669,
+      "artifact_count": 97,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 51542,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 90695,
+      "readme_object": "a646968daab28509c78115b23b579bd8906a2ef5",
+      "readme_path": ".agentplane/tasks/202608062021-MCY8ZC/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608062021-MCY8ZC",
+      "usage": {
+        "agent_runs": 8,
+        "input_tokens": 2139084,
+        "journal_digest": "sha256:b9641c27eacd5c189c74908e22db0334266eb08cb837727e4a1dfe5975e68ff2",
+        "observed_agent_runs": 8,
+        "observed_by": "agentplane",
+        "output_tokens": 21305,
+        "reasoning_tokens": 5279,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "observed",
+        "total_tokens": 2165668,
+        "unavailable_reason": null,
+        "updated_at": "2026-08-07T23:59:48.692Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 187949,
+      "artifact_count": 34,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 27781,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 45936,
+      "readme_object": "076ff06603ca3ef753397eb1279d0bad267c6bdf",
+      "readme_path": ".agentplane/tasks/202608062021-HTRP5J/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608062021-HTRP5J",
+      "usage": {
+        "agent_runs": 2,
+        "input_tokens": 344979,
+        "journal_digest": "sha256:bf906bbf2a05fe15e280679e88afb75da668322f2195a69318df0e1cbe157bb2",
+        "observed_agent_runs": 2,
+        "observed_by": "agentplane",
+        "output_tokens": 4062,
+        "reasoning_tokens": 948,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "observed",
+        "total_tokens": 349989,
+        "unavailable_reason": null,
+        "updated_at": "2026-08-08T00:47:37.214Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 177336,
+      "artifact_count": 42,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 25249,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 41630,
+      "readme_object": "2810c81035bc3f27107ff8fdf925224660358298",
+      "readme_path": ".agentplane/tasks/202608061925-KANFC0/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608061925-KANFC0",
+      "usage": {
+        "agent_runs": 3,
+        "input_tokens": 249760,
+        "journal_digest": "sha256:1706725a4dad5788e39b4b24d91ed316d0a912c3bcb50304ae0aa9151ddb9ec0",
+        "observed_agent_runs": 3,
+        "observed_by": "agentplane",
+        "output_tokens": 4630,
+        "reasoning_tokens": 918,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "observed",
+        "total_tokens": 255308,
+        "unavailable_reason": null,
+        "updated_at": "2026-08-07T03:01:13.392Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 314832,
+      "artifact_count": 49,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 18420,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 29606,
+      "readme_object": "326dc5368797db8bb4782eb4d04cdc64f8623363",
+      "readme_path": ".agentplane/tasks/202608061850-BZT3D9/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608061850-BZT3D9",
+      "usage": {
+        "agent_runs": 5,
+        "input_tokens": 446755,
+        "journal_digest": "sha256:3d316f5315a02663da97b9cd2ffa3b363b18fdce1595d5d31d33fe49fa6692e6",
+        "observed_agent_runs": 4,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "partial",
+        "total_tokens": 454322,
+        "unavailable_reason": "some_agent_runs_lack_provider_token_telemetry",
+        "updated_at": "2026-08-06T23:41:10.152Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 911950,
+      "artifact_count": 43,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 20002,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 31628,
+      "readme_object": "7702048bf4fb94e491470b852d6793f8d6b653a0",
+      "readme_path": ".agentplane/tasks/202608061742-G2ZA4T/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608061742-G2ZA4T",
+      "usage": {
+        "agent_runs": 3,
+        "input_tokens": 389542,
+        "journal_digest": "sha256:6bc1a4dc2d8ce1399bc4b3998c053fb95e25b735deaa9a9ec4340a7f0865fe35",
+        "observed_agent_runs": 2,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "partial",
+        "total_tokens": 395884,
+        "unavailable_reason": "some_agent_runs_lack_provider_token_telemetry",
+        "updated_at": "2026-08-07T02:01:16.433Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 284237,
+      "artifact_count": 39,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 22897,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 38377,
+      "readme_object": "2dcb84dc73c53fa672ab1812a8f99b658877d871",
+      "readme_path": ".agentplane/tasks/202608061646-WCARQG/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608061646-WCARQG",
+      "usage": {
+        "agent_runs": 0,
+        "input_tokens": null,
+        "journal_digest": null,
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "unavailable",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "supervisor_journal_missing",
+        "updated_at": "2026-08-06T17:16:44.392Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 535587,
+      "artifact_count": 67,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 90241,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 150470,
+      "readme_object": "e9e7fe03b9f8dbcbec8d99b7e748c9c5310e1d80",
+      "readme_path": ".agentplane/tasks/202608061646-BYY8A1/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608061646-BYY8A1",
+      "usage": {
+        "agent_runs": 0,
+        "input_tokens": null,
+        "journal_digest": null,
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "unavailable",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "supervisor_journal_missing",
+        "updated_at": "2026-08-08T21:18:02.612Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 1437091,
+      "artifact_count": 173,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 76101,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 133099,
+      "readme_object": "d7fdc6598525a6e05891e64a263de68baee0dff9",
+      "readme_path": ".agentplane/tasks/202608061646-30TKV4/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608061646-30TKV4",
+      "usage": {
+        "agent_runs": 16,
+        "input_tokens": 3071303,
+        "journal_digest": "sha256:d666e3c3c8ddc62d92de0c27839b519ad9e07f53fe8833a7256b59bfbfb8fed4",
+        "observed_agent_runs": 14,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "partial",
+        "total_tokens": 3112038,
+        "unavailable_reason": "some_agent_runs_lack_provider_token_telemetry",
+        "updated_at": "2026-08-07T01:41:11.948Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 166228,
+      "artifact_count": 18,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 14933,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 23694,
+      "readme_object": "dd63575503f28826f770bb5ed8f3b44268685e9f",
+      "readme_path": ".agentplane/tasks/202608061244-J3EC6A/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608061244-J3EC6A",
+      "usage": {
+        "agent_runs": 0,
+        "input_tokens": null,
+        "journal_digest": null,
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "unavailable",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "supervisor_journal_missing",
+        "updated_at": "2026-08-06T13:17:34.604Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 910612,
+      "artifact_count": 60,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 40766,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 70902,
+      "readme_object": "5c3a617b9c9f16e688f8c36c910084419c7c13d9",
+      "readme_path": ".agentplane/tasks/202608052127-XWDY4R/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608052127-XWDY4R",
+      "usage": {
+        "agent_runs": 2,
+        "input_tokens": null,
+        "journal_digest": "sha256:e741a0246ea10957965db0ba00782575bb9d51a9edd6a9a9cde921bc29bf9b84",
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "provider_token_telemetry_unavailable",
+        "updated_at": "2026-08-06T12:33:08.974Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 2138984,
+      "artifact_count": 122,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 57294,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 100787,
+      "readme_object": "17ce9c1b87b3bda2f71205ae6d796f71e590cd5d",
+      "readme_path": ".agentplane/tasks/202608041322-M26FS0/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608041322-M26FS0",
+      "usage": {
+        "agent_runs": 6,
+        "input_tokens": 956291,
+        "journal_digest": "sha256:53ae3c9292126416b0b4c24babe9dcf70493d65a626564a804e5bb229e2f8604",
+        "observed_agent_runs": 6,
+        "observed_by": "agentplane",
+        "output_tokens": 12440,
+        "reasoning_tokens": 2434,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "observed",
+        "total_tokens": 971165,
+        "unavailable_reason": null,
+        "updated_at": "2026-08-05T20:56:17.055Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 454900,
+      "artifact_count": 47,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 24369,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 41472,
+      "readme_object": "05cfaf1988bd4e603e6a93592fe8a9c455a6390b",
+      "readme_path": ".agentplane/tasks/202608041057-WZRXEX/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608041057-WZRXEX",
+      "usage": {
+        "agent_runs": 0,
+        "input_tokens": null,
+        "journal_digest": null,
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "unavailable",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "supervisor_journal_missing",
+        "updated_at": "2026-08-04T12:49:00.184Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 100600,
+      "artifact_count": 21,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 19034,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 30532,
+      "readme_object": "4e743fddf11c995e1f0844cefcb647fcd2429b07",
+      "readme_path": ".agentplane/tasks/202608040748-7Z0401/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608040748-7Z0401",
+      "usage": {
+        "agent_runs": 0,
+        "input_tokens": null,
+        "journal_digest": null,
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "unavailable",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "supervisor_journal_missing",
+        "updated_at": "2026-08-04T08:00:43.433Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 97603,
+      "artifact_count": 19,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 13380,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 21205,
+      "readme_object": "5878530857d8623119a7c376c792127312288128",
+      "readme_path": ".agentplane/tasks/202608040215-0Z0C92/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608040215-0Z0C92",
+      "usage": {
+        "agent_runs": 0,
+        "input_tokens": null,
+        "journal_digest": null,
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "unavailable",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "supervisor_journal_missing",
+        "updated_at": "2026-08-04T02:28:38.820Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 80596,
+      "artifact_count": 17,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 11164,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 16385,
+      "readme_object": "1d520701d33760ae3ce2b6611bf60616e78c2969",
+      "readme_path": ".agentplane/tasks/202608040106-CC1TAP/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608040106-CC1TAP",
+      "usage": {
+        "agent_runs": 0,
+        "input_tokens": null,
+        "journal_digest": null,
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "unavailable",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "supervisor_journal_missing",
+        "updated_at": "2026-08-04T01:11:17.800Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 392800,
+      "artifact_count": 47,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 30333,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 49692,
+      "readme_object": "5d63f4c060cb07101984c997262cd32f021e0cef",
+      "readme_path": ".agentplane/tasks/202608040031-4XD57R/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608040031-4XD57R",
+      "usage": {
+        "agent_runs": 0,
+        "input_tokens": null,
+        "journal_digest": "sha256:02d6502e608a3c5bd4e29d8e1f1745b8f8499ec912a55fb418466611dc9c7fd0",
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "no_supervised_agent_runs",
+        "updated_at": "2026-08-04T01:28:35.267Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 145895,
+      "artifact_count": 35,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 18498,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 29724,
+      "readme_object": "473d776ca66e0f9326ff08c4a950813c915aba59",
+      "readme_path": ".agentplane/tasks/202608032336-A9H6WR/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608032336-A9H6WR",
+      "usage": {
+        "agent_runs": 0,
+        "input_tokens": null,
+        "journal_digest": null,
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "unavailable",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "supervisor_journal_missing",
+        "updated_at": "2026-08-03T23:54:40.874Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 147539,
+      "artifact_count": 21,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 14607,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 23976,
+      "readme_object": "2eface6c5411643602a549aa81f8a420efc61a8d",
+      "readme_path": ".agentplane/tasks/202608032250-WDRW1E/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608032250-WDRW1E",
+      "usage": {
+        "agent_runs": 0,
+        "input_tokens": null,
+        "journal_digest": null,
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "unavailable",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "supervisor_journal_missing",
+        "updated_at": "2026-08-03T23:01:11.683Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 131662,
+      "artifact_count": 31,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 22480,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 37002,
+      "readme_object": "85e08c52abac99021501315d969c0e70a5820922",
+      "readme_path": ".agentplane/tasks/202608032207-V8HMV8/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608032207-V8HMV8",
+      "usage": {
+        "agent_runs": 0,
+        "input_tokens": null,
+        "journal_digest": null,
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "unavailable",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "supervisor_journal_missing",
+        "updated_at": "2026-08-03T22:22:01.090Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 90731,
+      "artifact_count": 18,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 13841,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 21331,
+      "readme_object": "2c8c258d775c396797e24dd76cf24f601f0472f9",
+      "readme_path": ".agentplane/tasks/202608032116-V9DBA5/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608032116-V9DBA5",
+      "usage": {
+        "agent_runs": 0,
+        "input_tokens": null,
+        "journal_digest": null,
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "unavailable",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "supervisor_journal_missing",
+        "updated_at": "2026-08-03T21:46:10.871Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 171667,
+      "artifact_count": 21,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 11625,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 17065,
+      "readme_object": "3de70e2b4c765a700937ed4ea26a253c87241ed2",
+      "readme_path": ".agentplane/tasks/202608032116-QFBVB5/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608032116-QFBVB5",
+      "usage": {
+        "agent_runs": 0,
+        "input_tokens": null,
+        "journal_digest": null,
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "unavailable",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "supervisor_journal_missing",
+        "updated_at": "2026-08-03T21:26:21.704Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 112752,
+      "artifact_count": 26,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 15917,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 25200,
+      "readme_object": "22b68622e669a243e9eb0e36356a25b2579762df",
+      "readme_path": ".agentplane/tasks/202608032042-DAMQDM/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608032042-DAMQDM",
+      "usage": {
+        "agent_runs": 0,
+        "input_tokens": null,
+        "journal_digest": null,
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "unavailable",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "supervisor_journal_missing",
+        "updated_at": "2026-08-03T20:57:18.103Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 179409,
+      "artifact_count": 30,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 15549,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 25165,
+      "readme_object": "6ba0ef0cad579dc0f9ec6f32dadfdecc4fa76555",
+      "readme_path": ".agentplane/tasks/202608031426-0BY4B4/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608031426-0BY4B4",
+      "usage": {
+        "agent_runs": 2,
+        "input_tokens": 459781,
+        "journal_digest": "sha256:e520e8a0da6f7bfd59e6f571d0cdef2c89ecbd54daa33bacd0c6a86c28d3ab44",
+        "observed_agent_runs": 2,
+        "observed_by": "agentplane",
+        "output_tokens": 4285,
+        "reasoning_tokens": 939,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "observed",
+        "total_tokens": 465005,
+        "unavailable_reason": null,
+        "updated_at": "2026-08-03T14:55:34.914Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 131711,
+      "artifact_count": 18,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 18666,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 30505,
+      "readme_object": "42fb766c57c408d79f159d5bc9cc36fc4e9729d1",
+      "readme_path": ".agentplane/tasks/202608031321-5GK3DD/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608031321-5GK3DD",
+      "usage": {
+        "agent_runs": 0,
+        "input_tokens": null,
+        "journal_digest": null,
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "unavailable",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "supervisor_journal_missing",
+        "updated_at": "2026-08-03T14:10:09.820Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 107030,
+      "artifact_count": 24,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 10286,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 15682,
+      "readme_object": "1d7f93a90616705304de9a0ee4a59fa0d0e4ba4b",
+      "readme_path": ".agentplane/tasks/202608031303-B5Q5NM/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608031303-B5Q5NM",
+      "usage": {
+        "agent_runs": 0,
+        "input_tokens": null,
+        "journal_digest": null,
+        "observed_agent_runs": 0,
+        "observed_by": "agentplane",
+        "output_tokens": null,
+        "reasoning_tokens": null,
+        "schema_version": 1,
+        "source": "unavailable",
+        "state": "unavailable",
+        "total_tokens": null,
+        "unavailable_reason": "supervisor_journal_missing",
+        "updated_at": "2026-08-03T13:12:49.933Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 180433,
+      "artifact_count": 17,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 14749,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 23149,
+      "readme_object": "607273901a9c640d01fed1fca5ba08744fdc36d7",
+      "readme_path": ".agentplane/tasks/202608022324-Y26ENH/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608022324-Y26ENH",
+      "usage": null,
+      "usage_source": "not_recorded",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 885103,
+      "artifact_count": 66,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 27677,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 46980,
+      "readme_object": "429cdd7887e52183c48e16d991bfa759689a45f9",
+      "readme_path": ".agentplane/tasks/202608022324-9VCYWG/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608022324-9VCYWG",
+      "usage": null,
+      "usage_source": "not_recorded",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 125911,
+      "artifact_count": 26,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 15218,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 24584,
+      "readme_object": "2fb98b59ee7a92712091f451f0c0d0467fa27f51",
+      "readme_path": ".agentplane/tasks/202608022236-AWTDJ9/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608022236-AWTDJ9",
+      "usage": null,
+      "usage_source": "not_recorded",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 268024,
+      "artifact_count": 44,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 18045,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 29857,
+      "readme_object": "eb6655281d61de441e4b0f19115674623cb4e2b0",
+      "readme_path": ".agentplane/tasks/202608022128-39YSZ1/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608022128-39YSZ1",
+      "usage": null,
+      "usage_source": "not_recorded",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 711180,
+      "artifact_count": 84,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 37429,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 65032,
+      "readme_object": "6e88f0049e98f1449b9c03e72b3abb1961c912c3",
+      "readme_path": ".agentplane/tasks/202608021535-CNQKXP/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608021535-CNQKXP",
+      "usage": {
+        "agent_runs": 7,
+        "input_tokens": 1307728,
+        "journal_digest": "sha256:0ec99c20f41c5c63af56637ab566b94b4e536029f9853b83ec813d5d09920527",
+        "observed_agent_runs": 7,
+        "observed_by": "agentplane",
+        "output_tokens": 15843,
+        "reasoning_tokens": 3307,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "observed",
+        "total_tokens": 1326878,
+        "unavailable_reason": null,
+        "updated_at": "2026-08-03T20:24:43.867Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 844064,
+      "artifact_count": 78,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 51132,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 88928,
+      "readme_object": "078931502bd1d630da4c52f54fa8fb8905ff4718",
+      "readme_path": ".agentplane/tasks/202608021535-9EWFAB/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608021535-9EWFAB",
+      "usage": {
+        "agent_runs": 5,
+        "input_tokens": 1198550,
+        "journal_digest": "sha256:23943ac709581889b7ab87fada067c62d133886b88ff3f2511939a92710574e3",
+        "observed_agent_runs": 5,
+        "observed_by": "agentplane",
+        "output_tokens": 11596,
+        "reasoning_tokens": 2687,
+        "schema_version": 1,
+        "source": "supervisor_journal",
+        "state": "observed",
+        "total_tokens": 1212833,
+        "unavailable_reason": null,
+        "updated_at": "2026-08-03T18:12:49.189Z"
+      },
+      "usage_source": "committed_task_projection",
+      "work_items": null
+    },
+    {
+      "artifact_bytes": 706509,
+      "artifact_count": 53,
+      "delivered_context_bytes": null,
+      "episodes": null,
+      "frontmatter_bytes": 20780,
+      "model_read_context_bytes": null,
+      "no_progress_semantic_repeats": null,
+      "prepared_context_bytes": null,
+      "readme_bytes": 32650,
+      "readme_object": "da77df9ebc1c50e9887308ca79a5d9822102bafc",
+      "readme_path": ".agentplane/tasks/202608021534-YN84E1/README.md",
+      "roles": null,
+      "service_commits_in_window": 0,
+      "task_id": "202608021534-YN84E1",
+      "usage": null,
+      "usage_source": "not_recorded",
+      "work_items": null
+    }
+  ],
+  "totals": {
+    "agent_runs": {
+      "tasks_observed": 145,
+      "value": 1314
+    },
+    "artifact_bytes": 311912258,
+    "artifact_count": 23405,
+    "cached_input_tokens": {
+      "tasks_observed": 0,
+      "value": null
+    },
+    "duplicate_bytes": 23267340,
+    "duplicate_paths": 2329,
+    "input_tokens": {
+      "tasks_observed": 27,
+      "value": 25188295
+    },
+    "observed_agent_runs": {
+      "tasks_observed": 145,
+      "value": 133
+    },
+    "output_tokens": {
+      "tasks_observed": 16,
+      "value": 159480
+    },
+    "reasoning_tokens": {
+      "tasks_observed": 16,
+      "value": 36085
+    },
+    "sampled_commits": 200,
+    "sampled_tasks": 150,
+    "service_commits": 146,
+    "tasks_with_usage": 145,
+    "usage_states": {
+      "not_recorded": 5,
+      "observed": 16,
+      "partial": 11,
+      "unavailable": 118
+    }
+  }
+}

--- a/scripts/baselines/agent-efficiency-VN1FN4-before.json
+++ b/scripts/baselines/agent-efficiency-VN1FN4-before.json
@@ -3,16 +3,12 @@
     {
       "service_only": true,
       "sha": "9e0f99960120a41e4056c62403407b76759c2584",
-      "task_ids": [
-        "202609071219-QV0SX9"
-      ]
+      "task_ids": ["202609071219-QV0SX9"]
     },
     {
       "service_only": true,
       "sha": "3c45166b31d0a9960f52aa11c3259afd472dd691",
-      "task_ids": [
-        "202609071219-QV0SX9"
-      ]
+      "task_ids": ["202609071219-QV0SX9"]
     },
     {
       "service_only": false,
@@ -27,373 +23,267 @@
     {
       "service_only": true,
       "sha": "080bfea10e63472c9d895c7880d1f4a4dc720bc4",
-      "task_ids": [
-        "202609071219-QV0SX9"
-      ]
+      "task_ids": ["202609071219-QV0SX9"]
     },
     {
       "service_only": true,
       "sha": "07e2ff7d228879b9a14a416c261c8f97f38ae287",
-      "task_ids": [
-        "202609071219-QV0SX9"
-      ]
+      "task_ids": ["202609071219-QV0SX9"]
     },
     {
       "service_only": true,
       "sha": "082de2c2ca742fd4150dbf7439a2b1fb9f5f79ed",
-      "task_ids": [
-        "202609071219-QV0SX9"
-      ]
+      "task_ids": ["202609071219-QV0SX9"]
     },
     {
       "service_only": true,
       "sha": "b36211390f5a1593bccfb1726991120573211292",
-      "task_ids": [
-        "202609071219-QV0SX9"
-      ]
+      "task_ids": ["202609071219-QV0SX9"]
     },
     {
       "service_only": true,
       "sha": "c8ce954a6375a78add2fb33b23441ed7ce9b79d4",
-      "task_ids": [
-        "202609071219-QV0SX9"
-      ]
+      "task_ids": ["202609071219-QV0SX9"]
     },
     {
       "service_only": true,
       "sha": "36ebe1d928d9f323ed134a1766acba485780b995",
-      "task_ids": [
-        "202609071219-QV0SX9"
-      ]
+      "task_ids": ["202609071219-QV0SX9"]
     },
     {
       "service_only": false,
       "sha": "b847aa915f64886905be06ccfb30e37544f35d25",
-      "task_ids": [
-        "202609071219-QV0SX9"
-      ]
+      "task_ids": ["202609071219-QV0SX9"]
     },
     {
       "service_only": true,
       "sha": "b010b904ce131e171ea19346f91334b32d5de8a0",
-      "task_ids": [
-        "202609071219-QV0SX9"
-      ]
+      "task_ids": ["202609071219-QV0SX9"]
     },
     {
       "service_only": false,
       "sha": "4e57fd16b87422e1d88b96e7cce2aa85ac8d3c0e",
-      "task_ids": [
-        "202609071219-QV0SX9"
-      ]
+      "task_ids": ["202609071219-QV0SX9"]
     },
     {
       "service_only": true,
       "sha": "0b3e88e60f2e34030fefc8b61cba391f236b2c55",
-      "task_ids": [
-        "202609071219-QV0SX9"
-      ]
+      "task_ids": ["202609071219-QV0SX9"]
     },
     {
       "service_only": true,
       "sha": "7a9d567a1292a0a8d47bb41a8ba232301946f872",
-      "task_ids": [
-        "202609071219-QV0SX9"
-      ]
+      "task_ids": ["202609071219-QV0SX9"]
     },
     {
       "service_only": false,
       "sha": "cdaf72b1fa42660466fe8dd986ff87b2bd093f88",
-      "task_ids": [
-        "202609071219-QV0SX9"
-      ]
+      "task_ids": ["202609071219-QV0SX9"]
     },
     {
       "service_only": false,
       "sha": "cea8e6f8708be9f3f246a21459176543d5bbe7e0",
-      "task_ids": [
-        "202609071219-QV0SX9"
-      ]
+      "task_ids": ["202609071219-QV0SX9"]
     },
     {
       "service_only": true,
       "sha": "2639130b3181867f53fa37121783c67c9ef1d064",
-      "task_ids": [
-        "202609071111-Y0Z0VQ"
-      ]
+      "task_ids": ["202609071111-Y0Z0VQ"]
     },
     {
       "service_only": true,
       "sha": "d065bf6221d1362a88c8b8054041316bc507ea42",
-      "task_ids": [
-        "202609071111-Y0Z0VQ"
-      ]
+      "task_ids": ["202609071111-Y0Z0VQ"]
     },
     {
       "service_only": true,
       "sha": "21f0360ecd16c1065a1088c8b8383bf27a88cf23",
-      "task_ids": [
-        "202609071111-Y0Z0VQ"
-      ]
+      "task_ids": ["202609071111-Y0Z0VQ"]
     },
     {
       "service_only": true,
       "sha": "faf628b0b1a989a7196fc768bdd13d47c03f08c8",
-      "task_ids": [
-        "202609071111-Y0Z0VQ"
-      ]
+      "task_ids": ["202609071111-Y0Z0VQ"]
     },
     {
       "service_only": true,
       "sha": "03a3f8cae62a7bff1990edd6e63cae1e94b3f860",
-      "task_ids": [
-        "202609071111-Y0Z0VQ"
-      ]
+      "task_ids": ["202609071111-Y0Z0VQ"]
     },
     {
       "service_only": true,
       "sha": "9a6fc0dc06200b626d95c9e0d1a060b80fe1e077",
-      "task_ids": [
-        "202609071111-Y0Z0VQ"
-      ]
+      "task_ids": ["202609071111-Y0Z0VQ"]
     },
     {
       "service_only": false,
       "sha": "cde1de7f515f73fb4324b5064446d87b9e6ce598",
-      "task_ids": [
-        "202609071111-Y0Z0VQ"
-      ]
+      "task_ids": ["202609071111-Y0Z0VQ"]
     },
     {
       "service_only": true,
       "sha": "87b4cf46dcddead7252f413367d163adb06aca92",
-      "task_ids": [
-        "202609071111-Y0Z0VQ"
-      ]
+      "task_ids": ["202609071111-Y0Z0VQ"]
     },
     {
       "service_only": true,
       "sha": "68df2e923cd9a382998a9f892243d2421b64ec17",
-      "task_ids": [
-        "202609071111-Y0Z0VQ"
-      ]
+      "task_ids": ["202609071111-Y0Z0VQ"]
     },
     {
       "service_only": false,
       "sha": "d0efb4b12add163221a45b68759fa85847fe0372",
-      "task_ids": [
-        "202609071111-Y0Z0VQ"
-      ]
+      "task_ids": ["202609071111-Y0Z0VQ"]
     },
     {
       "service_only": true,
       "sha": "f8a0e2fdaf2f0a9f7f328cc13679681707733b6f",
-      "task_ids": [
-        "202609071111-Y0Z0VQ"
-      ]
+      "task_ids": ["202609071111-Y0Z0VQ"]
     },
     {
       "service_only": true,
       "sha": "aa0ab4813d33e56363804d7225ab4052f180bb0c",
-      "task_ids": [
-        "202609071111-Y0Z0VQ"
-      ]
+      "task_ids": ["202609071111-Y0Z0VQ"]
     },
     {
       "service_only": false,
       "sha": "1e4add62bb52962cd618a55bcef3553b37111ffd",
-      "task_ids": [
-        "202609071111-Y0Z0VQ"
-      ]
+      "task_ids": ["202609071111-Y0Z0VQ"]
     },
     {
       "service_only": true,
       "sha": "6142ca0b0f3562f631319bc03aea2db45d8643c9",
-      "task_ids": [
-        "202609071111-Y0Z0VQ"
-      ]
+      "task_ids": ["202609071111-Y0Z0VQ"]
     },
     {
       "service_only": true,
       "sha": "a080783870ced46d2f2c11f536bd5daba9b296fa",
-      "task_ids": [
-        "202609071111-Y0Z0VQ"
-      ]
+      "task_ids": ["202609071111-Y0Z0VQ"]
     },
     {
       "service_only": false,
       "sha": "996e8a5174cfb8a880c8b7bc51be471440b8e325",
-      "task_ids": [
-        "202609071111-Y0Z0VQ"
-      ]
+      "task_ids": ["202609071111-Y0Z0VQ"]
     },
     {
       "service_only": true,
       "sha": "9b99271d55b0a1306942eead89a4b2974e3bdc1d",
-      "task_ids": [
-        "202609071111-Y0Z0VQ"
-      ]
+      "task_ids": ["202609071111-Y0Z0VQ"]
     },
     {
       "service_only": true,
       "sha": "db12f98164a34e35c88e9e89e87513ca2efab9d2",
-      "task_ids": [
-        "202609071111-Y0Z0VQ"
-      ]
+      "task_ids": ["202609071111-Y0Z0VQ"]
     },
     {
       "service_only": false,
       "sha": "8456da808bbaf774a54ab0eca19d8ea76769f960",
-      "task_ids": [
-        "202609071111-Y0Z0VQ"
-      ]
+      "task_ids": ["202609071111-Y0Z0VQ"]
     },
     {
       "service_only": true,
       "sha": "70c146493dab30a859788ae20cfdeab3cf57f1fd",
-      "task_ids": [
-        "202609071219-QV0SX9"
-      ]
+      "task_ids": ["202609071219-QV0SX9"]
     },
     {
       "service_only": true,
       "sha": "c70cf8be9f7315dcd7300e95556bcbf3cdc47cb3",
-      "task_ids": [
-        "202609071219-QV0SX9"
-      ]
+      "task_ids": ["202609071219-QV0SX9"]
     },
     {
       "service_only": false,
       "sha": "dad52228edd14a7ae9d798c0f5ae03fa5610e141",
-      "task_ids": [
-        "202609061750-Z0XXVD"
-      ]
+      "task_ids": ["202609061750-Z0XXVD"]
     },
     {
       "service_only": true,
       "sha": "b162edd7b2ee722b0c6f7cb063947975a001765c",
-      "task_ids": [
-        "202609070819-M065D1"
-      ]
+      "task_ids": ["202609070819-M065D1"]
     },
     {
       "service_only": true,
       "sha": "55e59a4dd5df6ea3de516fe2523b40a8ffb52d21",
-      "task_ids": [
-        "202609070819-M065D1"
-      ]
+      "task_ids": ["202609070819-M065D1"]
     },
     {
       "service_only": true,
       "sha": "a67fd07cc71439718b114325138b6a08b44b13e4",
-      "task_ids": [
-        "202609070819-M065D1"
-      ]
+      "task_ids": ["202609070819-M065D1"]
     },
     {
       "service_only": true,
       "sha": "565b0f13273d1c282c141bb7e9be499303e583bd",
-      "task_ids": [
-        "202609070819-M065D1"
-      ]
+      "task_ids": ["202609070819-M065D1"]
     },
     {
       "service_only": true,
       "sha": "ad68f7a96f1abd2126b9a2c3e61acf57f4384be8",
-      "task_ids": [
-        "202609070819-M065D1"
-      ]
+      "task_ids": ["202609070819-M065D1"]
     },
     {
       "service_only": true,
       "sha": "57702f371e5a91cc780176f52984bec33a9890b6",
-      "task_ids": [
-        "202609070819-M065D1"
-      ]
+      "task_ids": ["202609070819-M065D1"]
     },
     {
       "service_only": false,
       "sha": "929b932be46d528c36e9083eccbf5fc86d3b7cdc",
-      "task_ids": [
-        "202609070819-M065D1"
-      ]
+      "task_ids": ["202609070819-M065D1"]
     },
     {
       "service_only": true,
       "sha": "b99c7d87348d22b54cb2a36445fd94cddd732bf5",
-      "task_ids": [
-        "202609070351-6B37B9"
-      ]
+      "task_ids": ["202609070351-6B37B9"]
     },
     {
       "service_only": true,
       "sha": "d2353ae4c6cf5552443e9a60e63cbcfbb99e1e7b",
-      "task_ids": [
-        "202609070351-6B37B9"
-      ]
+      "task_ids": ["202609070351-6B37B9"]
     },
     {
       "service_only": true,
       "sha": "8d9ca51b4fb36ab8adfd85e9729b0adf8147c59c",
-      "task_ids": [
-        "202609070351-6B37B9"
-      ]
+      "task_ids": ["202609070351-6B37B9"]
     },
     {
       "service_only": true,
       "sha": "348a3600a37b39d61ebb4a4ac3f93c642de77198",
-      "task_ids": [
-        "202609070351-6B37B9"
-      ]
+      "task_ids": ["202609070351-6B37B9"]
     },
     {
       "service_only": true,
       "sha": "62a5710867e2fe3158f664a96e832151e91de8db",
-      "task_ids": [
-        "202609070351-6B37B9"
-      ]
+      "task_ids": ["202609070351-6B37B9"]
     },
     {
       "service_only": false,
       "sha": "168fe0d0d1c98e97657094c4eb6ad7096848fac1",
-      "task_ids": [
-        "202609070351-6B37B9"
-      ]
+      "task_ids": ["202609070351-6B37B9"]
     },
     {
       "service_only": true,
       "sha": "8c1384303cc702fff2fb881c441cacc6c1c523c2",
-      "task_ids": [
-        "202609070351-6B37B9"
-      ]
+      "task_ids": ["202609070351-6B37B9"]
     },
     {
       "service_only": true,
       "sha": "2f8590f913eaa2cde9184811d7ad2820be33f453",
-      "task_ids": [
-        "202609070351-6B37B9"
-      ]
+      "task_ids": ["202609070351-6B37B9"]
     },
     {
       "service_only": true,
       "sha": "3f7059fbed9fd2fd3a3fbbaedf7af77c14a17233",
-      "task_ids": [
-        "202609070351-6B37B9"
-      ]
+      "task_ids": ["202609070351-6B37B9"]
     },
     {
       "service_only": true,
       "sha": "47dab7082e31791ca89c9fb1cafd0d6afad3dd57",
-      "task_ids": [
-        "202609070351-6B37B9"
-      ]
+      "task_ids": ["202609070351-6B37B9"]
     },
     {
       "service_only": true,
       "sha": "e1f7c52ef394a46eb5e490291ba409a22cccaf6f",
-      "task_ids": [
-        "202609070351-6B37B9"
-      ]
+      "task_ids": ["202609070351-6B37B9"]
     },
     {
       "service_only": false,
@@ -403,821 +293,587 @@
     {
       "service_only": true,
       "sha": "f8505e8e0edb6d3e420e22cef1620bae2bbdab1d",
-      "task_ids": [
-        "202609070351-6B37B9"
-      ]
+      "task_ids": ["202609070351-6B37B9"]
     },
     {
       "service_only": true,
       "sha": "43227b631a4f7593b60997908519bbb475e4860f",
-      "task_ids": [
-        "202609070351-6B37B9"
-      ]
+      "task_ids": ["202609070351-6B37B9"]
     },
     {
       "service_only": true,
       "sha": "33859c98d6e2dc4cc5a3528b73e7046ea2a96a98",
-      "task_ids": [
-        "202609070351-6B37B9"
-      ]
+      "task_ids": ["202609070351-6B37B9"]
     },
     {
       "service_only": false,
       "sha": "68cf65a08ac1a380accf9821c9d3853069011248",
-      "task_ids": [
-        "202609070351-6B37B9"
-      ]
+      "task_ids": ["202609070351-6B37B9"]
     },
     {
       "service_only": false,
       "sha": "304f02dc7966f75f74ea2aec083a337572350f0f",
-      "task_ids": [
-        "202609061750-Z0XXVD"
-      ]
+      "task_ids": ["202609061750-Z0XXVD"]
     },
     {
       "service_only": true,
       "sha": "68b7b240362fe005e4ea5c63ee214c37fc545212",
-      "task_ids": [
-        "202609070233-NG368H"
-      ]
+      "task_ids": ["202609070233-NG368H"]
     },
     {
       "service_only": true,
       "sha": "b1783ceed8823238095113776d82647763ffbe1b",
-      "task_ids": [
-        "202609070233-NG368H"
-      ]
+      "task_ids": ["202609070233-NG368H"]
     },
     {
       "service_only": true,
       "sha": "30d74ffe38dc78012602381b811ea4fcd1e4a855",
-      "task_ids": [
-        "202609070233-NG368H"
-      ]
+      "task_ids": ["202609070233-NG368H"]
     },
     {
       "service_only": true,
       "sha": "185dc17c7eaa22c91fa82b9e481e98bfbb43fe1a",
-      "task_ids": [
-        "202609070233-NG368H"
-      ]
+      "task_ids": ["202609070233-NG368H"]
     },
     {
       "service_only": true,
       "sha": "201859728a179ded09e43484cfbba117069d48a0",
-      "task_ids": [
-        "202609070233-NG368H"
-      ]
+      "task_ids": ["202609070233-NG368H"]
     },
     {
       "service_only": false,
       "sha": "93ed9b9899f35fb9e4c141f700c28eeb517808b7",
-      "task_ids": [
-        "202609070233-NG368H"
-      ]
+      "task_ids": ["202609070233-NG368H"]
     },
     {
       "service_only": true,
       "sha": "8ebc48d745af6bbd72540f96c0f8c62748d168c6",
-      "task_ids": [
-        "202609070233-NG368H"
-      ]
+      "task_ids": ["202609070233-NG368H"]
     },
     {
       "service_only": true,
       "sha": "4f04ff897849a85601dd7dcab7ca1eeceab1f1ee",
-      "task_ids": [
-        "202609070233-NG368H"
-      ]
+      "task_ids": ["202609070233-NG368H"]
     },
     {
       "service_only": true,
       "sha": "2cab17c9542c83e8dfa4d3dd5bc186cc11e15394",
-      "task_ids": [
-        "202609070233-NG368H"
-      ]
+      "task_ids": ["202609070233-NG368H"]
     },
     {
       "service_only": true,
       "sha": "b4d0e7acd0b9e47d751e135d47ef4eeaa358e66f",
-      "task_ids": [
-        "202609070233-NG368H"
-      ]
+      "task_ids": ["202609070233-NG368H"]
     },
     {
       "service_only": true,
       "sha": "492136f731dc3b3c7583f37b22d83f4e6387320b",
-      "task_ids": [
-        "202609070233-NG368H"
-      ]
+      "task_ids": ["202609070233-NG368H"]
     },
     {
       "service_only": true,
       "sha": "bf210e93cc9bab5d26e9cbc829b6007c70fe51eb",
-      "task_ids": [
-        "202609070233-NG368H"
-      ]
+      "task_ids": ["202609070233-NG368H"]
     },
     {
       "service_only": false,
       "sha": "8afecc9522106f828eda13bd768c00b0c523a6e8",
-      "task_ids": [
-        "202609070233-NG368H"
-      ]
+      "task_ids": ["202609070233-NG368H"]
     },
     {
       "service_only": true,
       "sha": "81b3fe507426d82ea903d7a63fd6335b583d81b5",
-      "task_ids": [
-        "202609061750-Z0XXVD"
-      ]
+      "task_ids": ["202609061750-Z0XXVD"]
     },
     {
       "service_only": true,
       "sha": "eba01eac5a6b6c347f7850b4736ae620559b5115",
-      "task_ids": [
-        "202609061750-Z0XXVD"
-      ]
+      "task_ids": ["202609061750-Z0XXVD"]
     },
     {
       "service_only": true,
       "sha": "327a2b4b31957f9e989449a20b693dca2e444309",
-      "task_ids": [
-        "202609061750-Z0XXVD"
-      ]
+      "task_ids": ["202609061750-Z0XXVD"]
     },
     {
       "service_only": true,
       "sha": "f0131533865be689bef06bdf41cbe2730ecb0fc4",
-      "task_ids": [
-        "202609061750-Z0XXVD"
-      ]
+      "task_ids": ["202609061750-Z0XXVD"]
     },
     {
       "service_only": true,
       "sha": "ab635aca8893944fa51ef0ffb0b17afe8630f097",
-      "task_ids": [
-        "202609061750-Z0XXVD"
-      ]
+      "task_ids": ["202609061750-Z0XXVD"]
     },
     {
       "service_only": true,
       "sha": "59b81b8ee097844214dc09ca89d95caefd5a1fa5",
-      "task_ids": [
-        "202609061750-Z0XXVD"
-      ]
+      "task_ids": ["202609061750-Z0XXVD"]
     },
     {
       "service_only": true,
       "sha": "60f5e39b85594ff837ab6b719445d4615cd5f42a",
-      "task_ids": [
-        "202609061750-Z0XXVD"
-      ]
+      "task_ids": ["202609061750-Z0XXVD"]
     },
     {
       "service_only": true,
       "sha": "a2c83d96760c064af9677245abc2535b6b33f68d",
-      "task_ids": [
-        "202609061750-Z0XXVD"
-      ]
+      "task_ids": ["202609061750-Z0XXVD"]
     },
     {
       "service_only": false,
       "sha": "69dff6a91be8ea2832e5065504e0b70d0fa9709f",
-      "task_ids": [
-        "202609061750-Z0XXVD"
-      ]
+      "task_ids": ["202609061750-Z0XXVD"]
     },
     {
       "service_only": true,
       "sha": "fd95bb6830d2df61a457e181f3ba2633523db65e",
-      "task_ids": [
-        "202609061750-Z0XXVD"
-      ]
+      "task_ids": ["202609061750-Z0XXVD"]
     },
     {
       "service_only": true,
       "sha": "b8b77e4e755036c2f5e8cdff829533ec1f9d5298",
-      "task_ids": [
-        "202609061750-Z0XXVD"
-      ]
+      "task_ids": ["202609061750-Z0XXVD"]
     },
     {
       "service_only": true,
       "sha": "6e300c95e95be8e3e538d9e6469ca309f9fbe87f",
-      "task_ids": [
-        "202609061750-Z0XXVD"
-      ]
+      "task_ids": ["202609061750-Z0XXVD"]
     },
     {
       "service_only": false,
       "sha": "b9c18bde3de689c8a57f7abeafee6d69c77ca346",
-      "task_ids": [
-        "202609061750-Z0XXVD"
-      ]
+      "task_ids": ["202609061750-Z0XXVD"]
     },
     {
       "service_only": true,
       "sha": "e66cbb2a9345224810fd3f6b2489162de2d4b80c",
-      "task_ids": [
-        "202609061750-Z0XXVD"
-      ]
+      "task_ids": ["202609061750-Z0XXVD"]
     },
     {
       "service_only": false,
       "sha": "8ba826b53de8ed163c203fc0d0ada8fb020ca642",
-      "task_ids": [
-        "202609061750-Z0XXVD"
-      ]
+      "task_ids": ["202609061750-Z0XXVD"]
     },
     {
       "service_only": true,
       "sha": "d6c9f8252eda2990c81abade61064f74ff5ab430",
-      "task_ids": [
-        "202609061750-Z0XXVD"
-      ]
+      "task_ids": ["202609061750-Z0XXVD"]
     },
     {
       "service_only": false,
       "sha": "0530dc68ca31bc8a5b87ab091482bfd06081c873",
-      "task_ids": [
-        "202609061750-Z0XXVD"
-      ]
+      "task_ids": ["202609061750-Z0XXVD"]
     },
     {
       "service_only": true,
       "sha": "9404b8fc5e74dfa5f93d81a03c7e13b55a06cc13",
-      "task_ids": [
-        "202609061750-Z0XXVD"
-      ]
+      "task_ids": ["202609061750-Z0XXVD"]
     },
     {
       "service_only": false,
       "sha": "86665790e1faee831ccd7dc4d21c111e3af953bf",
-      "task_ids": [
-        "202609061750-Z0XXVD"
-      ]
+      "task_ids": ["202609061750-Z0XXVD"]
     },
     {
       "service_only": true,
       "sha": "e3a8e6658b2966f0b8ee5d81d4b79a750d2e07ae",
-      "task_ids": [
-        "202609061750-Z0XXVD"
-      ]
+      "task_ids": ["202609061750-Z0XXVD"]
     },
     {
       "service_only": false,
       "sha": "e070a79cd2466cb8b02d91a3731aac63b805cab2",
-      "task_ids": [
-        "202609061750-Z0XXVD"
-      ]
+      "task_ids": ["202609061750-Z0XXVD"]
     },
     {
       "service_only": true,
       "sha": "9f0dadafc8fb2ccb892503ffd54ac6bfeded1a85",
-      "task_ids": [
-        "202609061750-Z0XXVD"
-      ]
+      "task_ids": ["202609061750-Z0XXVD"]
     },
     {
       "service_only": false,
       "sha": "1f6d5b06fccdc864d4a3721d7891c663d8442ff6",
-      "task_ids": [
-        "202609061750-Z0XXVD"
-      ]
+      "task_ids": ["202609061750-Z0XXVD"]
     },
     {
       "service_only": true,
       "sha": "196b416399ccb385636b01aacf7e2940d358db69",
-      "task_ids": [
-        "202609061750-Z0XXVD"
-      ]
+      "task_ids": ["202609061750-Z0XXVD"]
     },
     {
       "service_only": false,
       "sha": "41415058404d73e8cd439c088d169637f0ef0d7f",
-      "task_ids": [
-        "202609061750-Z0XXVD"
-      ]
+      "task_ids": ["202609061750-Z0XXVD"]
     },
     {
       "service_only": true,
       "sha": "a6b00ad7e8d4bc1adadcbbc7083bc14e6882feed",
-      "task_ids": [
-        "202609061750-Z0XXVD"
-      ]
+      "task_ids": ["202609061750-Z0XXVD"]
     },
     {
       "service_only": false,
       "sha": "ddf06df251b8acb3189390793d747741dd0f3e3c",
-      "task_ids": [
-        "202609061750-Z0XXVD"
-      ]
+      "task_ids": ["202609061750-Z0XXVD"]
     },
     {
       "service_only": true,
       "sha": "eaafbc7886d2b588b83e154815229c85e48ddc46",
-      "task_ids": [
-        "202609061750-Z0XXVD"
-      ]
+      "task_ids": ["202609061750-Z0XXVD"]
     },
     {
       "service_only": false,
       "sha": "c1b560eb0ce149a3a5e5200b192b7128265a62e4",
-      "task_ids": [
-        "202609061750-Z0XXVD"
-      ]
+      "task_ids": ["202609061750-Z0XXVD"]
     },
     {
       "service_only": true,
       "sha": "2cf836db0fe3ad72ddc751b906f7ac1b436beb4d",
-      "task_ids": [
-        "202609061750-Z0XXVD"
-      ]
+      "task_ids": ["202609061750-Z0XXVD"]
     },
     {
       "service_only": false,
       "sha": "19239f9e62e172de9e679b57e6cb786a2f6970f3",
-      "task_ids": [
-        "202609061750-Z0XXVD"
-      ]
+      "task_ids": ["202609061750-Z0XXVD"]
     },
     {
       "service_only": true,
       "sha": "da01e181e27bf3cd7bdede1c328e6b2bcdf689ff",
-      "task_ids": [
-        "202609061750-Z0XXVD"
-      ]
+      "task_ids": ["202609061750-Z0XXVD"]
     },
     {
       "service_only": false,
       "sha": "a24cfb6c87e6e2945d587e1a3c7614ce71b8fb4b",
-      "task_ids": [
-        "202609061750-Z0XXVD"
-      ]
+      "task_ids": ["202609061750-Z0XXVD"]
     },
     {
       "service_only": true,
       "sha": "262da3130bc5628a7641c400c74368ae355000bf",
-      "task_ids": [
-        "202609061636-BW11J6"
-      ]
+      "task_ids": ["202609061636-BW11J6"]
     },
     {
       "service_only": true,
       "sha": "11b53e5f844d8d41b7fd5b5ec082ad7937c0721c",
-      "task_ids": [
-        "202609061636-BW11J6"
-      ]
+      "task_ids": ["202609061636-BW11J6"]
     },
     {
       "service_only": true,
       "sha": "a2564340a3ab3600f2c1278e39293a4499c155c7",
-      "task_ids": [
-        "202609061636-BW11J6"
-      ]
+      "task_ids": ["202609061636-BW11J6"]
     },
     {
       "service_only": true,
       "sha": "ca2bb87f77bbc3ae09edf571e483e98a44f4a9bf",
-      "task_ids": [
-        "202609061636-BW11J6"
-      ]
+      "task_ids": ["202609061636-BW11J6"]
     },
     {
       "service_only": true,
       "sha": "60244110592975d2f933a2384252083080fcf3d1",
-      "task_ids": [
-        "202609061636-BW11J6"
-      ]
+      "task_ids": ["202609061636-BW11J6"]
     },
     {
       "service_only": true,
       "sha": "ba8874a888de07be56ca1ec88c3954c7a0972bd9",
-      "task_ids": [
-        "202609061636-BW11J6"
-      ]
+      "task_ids": ["202609061636-BW11J6"]
     },
     {
       "service_only": false,
       "sha": "a4aedd5a03255a560eebe6f6e62ae8328dd7a84b",
-      "task_ids": [
-        "202609061636-BW11J6"
-      ]
+      "task_ids": ["202609061636-BW11J6"]
     },
     {
       "service_only": true,
       "sha": "ec95c2e8030affdc7562c26c2f41dc098b9dc173",
-      "task_ids": [
-        "202609061636-BW11J6"
-      ]
+      "task_ids": ["202609061636-BW11J6"]
     },
     {
       "service_only": true,
       "sha": "19ce338e6fb63ee55c79de6d56a72c7a837fc8f7",
-      "task_ids": [
-        "202609061636-BW11J6"
-      ]
+      "task_ids": ["202609061636-BW11J6"]
     },
     {
       "service_only": true,
       "sha": "f3d1eb3130ab9c067a0503d63e3b043bb6885d3f",
-      "task_ids": [
-        "202609061636-BW11J6"
-      ]
+      "task_ids": ["202609061636-BW11J6"]
     },
     {
       "service_only": false,
       "sha": "ad9e51536785a9d31279a2964e4c7f537badc7db",
-      "task_ids": [
-        "202609061636-BW11J6"
-      ]
+      "task_ids": ["202609061636-BW11J6"]
     },
     {
       "service_only": true,
       "sha": "b1e13dec007f8251957c77a887b9a887cc789a82",
-      "task_ids": [
-        "202609060720-NZXQ0E"
-      ]
+      "task_ids": ["202609060720-NZXQ0E"]
     },
     {
       "service_only": true,
       "sha": "ba67d24ab800fa59b097a563b65a47ddd2df3040",
-      "task_ids": [
-        "202609060720-NZXQ0E"
-      ]
+      "task_ids": ["202609060720-NZXQ0E"]
     },
     {
       "service_only": true,
       "sha": "467a21903b1ad3bc886702db47454d80834ba4cc",
-      "task_ids": [
-        "202609060720-NZXQ0E"
-      ]
+      "task_ids": ["202609060720-NZXQ0E"]
     },
     {
       "service_only": true,
       "sha": "e4955798705acb39b67decdd38d8d5555822cce6",
-      "task_ids": [
-        "202609060720-NZXQ0E"
-      ]
+      "task_ids": ["202609060720-NZXQ0E"]
     },
     {
       "service_only": false,
       "sha": "48dda1e008438f65ba6e8a2253b723bde5994751",
-      "task_ids": [
-        "202609060720-NZXQ0E"
-      ]
+      "task_ids": ["202609060720-NZXQ0E"]
     },
     {
       "service_only": true,
       "sha": "430befb9567c4b34d393fd65aa84e2272ffa266e",
-      "task_ids": [
-        "202609060720-NZXQ0E"
-      ]
+      "task_ids": ["202609060720-NZXQ0E"]
     },
     {
       "service_only": true,
       "sha": "0183bdf929e4f1287f1a9eab47da83c48aff3fc7",
-      "task_ids": [
-        "202609060720-NZXQ0E"
-      ]
+      "task_ids": ["202609060720-NZXQ0E"]
     },
     {
       "service_only": true,
       "sha": "66ced0b68f08d835a762267662c2bf82d71ca16a",
-      "task_ids": [
-        "202609060720-NZXQ0E"
-      ]
+      "task_ids": ["202609060720-NZXQ0E"]
     },
     {
       "service_only": false,
       "sha": "7d5e2ef3bac557d785b7ec613eaedbefc656e379",
-      "task_ids": [
-        "202609060720-NZXQ0E"
-      ]
+      "task_ids": ["202609060720-NZXQ0E"]
     },
     {
       "service_only": true,
       "sha": "ac565f6fb1e401686c6566f8fcf654799be258e6",
-      "task_ids": [
-        "202609060720-NZXQ0E"
-      ]
+      "task_ids": ["202609060720-NZXQ0E"]
     },
     {
       "service_only": true,
       "sha": "898d06351bcf8975bcec3d321e6a418899d7c6c6",
-      "task_ids": [
-        "202609060720-NZXQ0E"
-      ]
+      "task_ids": ["202609060720-NZXQ0E"]
     },
     {
       "service_only": true,
       "sha": "ec418b1b334b4efc934fa1a7506a149a7007441c",
-      "task_ids": [
-        "202609060720-NZXQ0E"
-      ]
+      "task_ids": ["202609060720-NZXQ0E"]
     },
     {
       "service_only": false,
       "sha": "8f77e8033e63f503c06801cd8af358cc57f1aa2a",
-      "task_ids": [
-        "202609060720-NZXQ0E"
-      ]
+      "task_ids": ["202609060720-NZXQ0E"]
     },
     {
       "service_only": false,
       "sha": "c74e8f1cddd60375b63cb30d0c3d62538b7fc702",
-      "task_ids": [
-        "202609060720-NZXQ0E"
-      ]
+      "task_ids": ["202609060720-NZXQ0E"]
     },
     {
       "service_only": true,
       "sha": "7a1731ccc2784fc5d4a1573fc8b8adbacf704689",
-      "task_ids": [
-        "202609060720-NZXQ0E"
-      ]
+      "task_ids": ["202609060720-NZXQ0E"]
     },
     {
       "service_only": false,
       "sha": "736fba555b20672162360b9d5bc5d9205ffc3262",
-      "task_ids": [
-        "202609060720-NZXQ0E"
-      ]
+      "task_ids": ["202609060720-NZXQ0E"]
     },
     {
       "service_only": false,
       "sha": "b33a39fb7c4ae579a74e6550f93ef557307ae645",
-      "task_ids": [
-        "202609060720-NZXQ0E"
-      ]
+      "task_ids": ["202609060720-NZXQ0E"]
     },
     {
       "service_only": true,
       "sha": "33d00156ba1063f607e4e823d4de714d6466390d",
-      "task_ids": [
-        "202609060720-NZXQ0E"
-      ]
+      "task_ids": ["202609060720-NZXQ0E"]
     },
     {
       "service_only": false,
       "sha": "8ad0c158c5b4a6a9940b7bb62c321f84289f5e6d",
-      "task_ids": [
-        "202609060720-NZXQ0E"
-      ]
+      "task_ids": ["202609060720-NZXQ0E"]
     },
     {
       "service_only": true,
       "sha": "43f3ba86b40cfae0555ec7775d85d97b5d4c2377",
-      "task_ids": [
-        "202609060720-NZXQ0E"
-      ]
+      "task_ids": ["202609060720-NZXQ0E"]
     },
     {
       "service_only": true,
       "sha": "e7aae1f7418195dc506b00aef74c951d8831390a",
-      "task_ids": [
-        "202609042327-PH5N6S"
-      ]
+      "task_ids": ["202609042327-PH5N6S"]
     },
     {
       "service_only": true,
       "sha": "fdf2dd5b358c2f17aa248a5e90bda436bcdef235",
-      "task_ids": [
-        "202609042327-PH5N6S"
-      ]
+      "task_ids": ["202609042327-PH5N6S"]
     },
     {
       "service_only": true,
       "sha": "424c7e7e1659d29ce2963f1ea7981566949430b2",
-      "task_ids": [
-        "202609042327-PH5N6S"
-      ]
+      "task_ids": ["202609042327-PH5N6S"]
     },
     {
       "service_only": true,
       "sha": "367024bb03d41c45982ef45ec4d87b058913a265",
-      "task_ids": [
-        "202609042327-PH5N6S"
-      ]
+      "task_ids": ["202609042327-PH5N6S"]
     },
     {
       "service_only": true,
       "sha": "801dbd096b1f1b5a6735c3fb24220f38a5067e2f",
-      "task_ids": [
-        "202609042327-PH5N6S"
-      ]
+      "task_ids": ["202609042327-PH5N6S"]
     },
     {
       "service_only": false,
       "sha": "a25edd68b3639f22fe74be7476df9397c588b304",
-      "task_ids": [
-        "202609042327-PH5N6S"
-      ]
+      "task_ids": ["202609042327-PH5N6S"]
     },
     {
       "service_only": true,
       "sha": "86505007bb7171bcfaafd4d0ee2ed1f1e8fab783",
-      "task_ids": [
-        "202609042327-PH5N6S"
-      ]
+      "task_ids": ["202609042327-PH5N6S"]
     },
     {
       "service_only": true,
       "sha": "f15f2914fd02ed0372c4c65aced04639cb938f2f",
-      "task_ids": [
-        "202609042327-PH5N6S"
-      ]
+      "task_ids": ["202609042327-PH5N6S"]
     },
     {
       "service_only": true,
       "sha": "9626c6364f0aab2a7f7efb3d05b4757a8207c156",
-      "task_ids": [
-        "202609042327-PH5N6S"
-      ]
+      "task_ids": ["202609042327-PH5N6S"]
     },
     {
       "service_only": false,
       "sha": "572353c8ad3dffbbf455bfcb82ce24d40574ae28",
-      "task_ids": [
-        "202609042327-PH5N6S"
-      ]
+      "task_ids": ["202609042327-PH5N6S"]
     },
     {
       "service_only": true,
       "sha": "48d2e75856c3da7d3635946ad7d48f717afb5104",
-      "task_ids": [
-        "202609042327-PH5N6S"
-      ]
+      "task_ids": ["202609042327-PH5N6S"]
     },
     {
       "service_only": true,
       "sha": "de6df111e267e997f5056fbfc7c0a2844e0576a0",
-      "task_ids": [
-        "202609042327-PH5N6S"
-      ]
+      "task_ids": ["202609042327-PH5N6S"]
     },
     {
       "service_only": true,
       "sha": "ea8830b4bee74c656ed888384625f95046df2218",
-      "task_ids": [
-        "202609042327-PH5N6S"
-      ]
+      "task_ids": ["202609042327-PH5N6S"]
     },
     {
       "service_only": true,
       "sha": "5d65025e875e3d533d5b1ad3196b566ee00d0efe",
-      "task_ids": [
-        "202609042327-PH5N6S"
-      ]
+      "task_ids": ["202609042327-PH5N6S"]
     },
     {
       "service_only": true,
       "sha": "1c14163429fc67acdeb98b34a7fae404d68ddc38",
-      "task_ids": [
-        "202609042327-PH5N6S"
-      ]
+      "task_ids": ["202609042327-PH5N6S"]
     },
     {
       "service_only": false,
       "sha": "2e9f7df5ebad103bf6ade9d4cffb750da2dd0318",
-      "task_ids": [
-        "202609042327-PH5N6S"
-      ]
+      "task_ids": ["202609042327-PH5N6S"]
     },
     {
       "service_only": true,
       "sha": "a8648b4c439676621ded1296f62b4eeb6720efe0",
-      "task_ids": [
-        "202609042327-PH5N6S"
-      ]
+      "task_ids": ["202609042327-PH5N6S"]
     },
     {
       "service_only": true,
       "sha": "1438fcf8c4a38ea3456682c77fc4532dde2c7251",
-      "task_ids": [
-        "202609042327-PH5N6S"
-      ]
+      "task_ids": ["202609042327-PH5N6S"]
     },
     {
       "service_only": true,
       "sha": "a5846b477ce0b3bde2fdf4f35a0bd973780bc886",
-      "task_ids": [
-        "202609042327-PH5N6S"
-      ]
+      "task_ids": ["202609042327-PH5N6S"]
     },
     {
       "service_only": false,
       "sha": "d8298cfe7b38b3b085a44810a4000ad323e67afd",
-      "task_ids": [
-        "202609042327-PH5N6S"
-      ]
+      "task_ids": ["202609042327-PH5N6S"]
     },
     {
       "service_only": false,
       "sha": "1981b974568071c65b8c0c3f971311de59758d83",
-      "task_ids": [
-        "202609042327-PH5N6S"
-      ]
+      "task_ids": ["202609042327-PH5N6S"]
     },
     {
       "service_only": true,
       "sha": "cf909f3246f9227135813776df941f7740094e89",
-      "task_ids": [
-        "202609042327-PH5N6S"
-      ]
+      "task_ids": ["202609042327-PH5N6S"]
     },
     {
       "service_only": true,
       "sha": "6bf388900d2c64a1849d2fb396268a67081d021d",
-      "task_ids": [
-        "202609042327-PH5N6S"
-      ]
+      "task_ids": ["202609042327-PH5N6S"]
     },
     {
       "service_only": true,
       "sha": "b82739de719c160acb631be6d771c69ccaba1590",
-      "task_ids": [
-        "202609042327-PH5N6S"
-      ]
+      "task_ids": ["202609042327-PH5N6S"]
     },
     {
       "service_only": true,
       "sha": "86e9343e668a2aa52883cab40c176b118ad33ffd",
-      "task_ids": [
-        "202609042327-PH5N6S"
-      ]
+      "task_ids": ["202609042327-PH5N6S"]
     },
     {
       "service_only": true,
       "sha": "4b0c941f98ae31152ddef4aa925c439e57505225",
-      "task_ids": [
-        "202609042327-PH5N6S"
-      ]
+      "task_ids": ["202609042327-PH5N6S"]
     },
     {
       "service_only": true,
       "sha": "e72029c56f3a62185c8af0c88e7cb944e717fa5e",
-      "task_ids": [
-        "202609042327-PH5N6S"
-      ]
+      "task_ids": ["202609042327-PH5N6S"]
     },
     {
       "service_only": false,
       "sha": "6764bc96f86b48a697e3fdc63ed7f96d6ee15cf1",
-      "task_ids": [
-        "202609042327-PH5N6S"
-      ]
+      "task_ids": ["202609042327-PH5N6S"]
     },
     {
       "service_only": true,
       "sha": "556bd57198b1b3c70d3a242dc3e7f3e16f9edd01",
-      "task_ids": [
-        "202609041801-ZVX69C"
-      ]
+      "task_ids": ["202609041801-ZVX69C"]
     },
     {
       "service_only": true,
       "sha": "e81a82df8905e1cd2b70e707edaeb54b540afa72",
-      "task_ids": [
-        "202609041801-ZVX69C"
-      ]
+      "task_ids": ["202609041801-ZVX69C"]
     },
     {
       "service_only": true,
       "sha": "a4cbbf112295aba5da065449ecaa50394c2efed6",
-      "task_ids": [
-        "202609041801-ZVX69C"
-      ]
+      "task_ids": ["202609041801-ZVX69C"]
     },
     {
       "service_only": true,
       "sha": "50d0834079f967679fd56ba98fa311eb7e457335",
-      "task_ids": [
-        "202609041801-ZVX69C"
-      ]
+      "task_ids": ["202609041801-ZVX69C"]
     },
     {
       "service_only": false,
       "sha": "8701b4ee14a0566d0c1fe97401604fa973847db4",
-      "task_ids": [
-        "202609041801-ZVX69C"
-      ]
+      "task_ids": ["202609041801-ZVX69C"]
     },
     {
       "service_only": true,
       "sha": "e01b34f44379df3c04a5956e838aab85129dc8fa",
-      "task_ids": [
-        "202609041801-ZVX69C"
-      ]
+      "task_ids": ["202609041801-ZVX69C"]
     },
     {
       "service_only": true,
       "sha": "1e3a1d54e7c1caaed49e899df8d16a28a32290c8",
-      "task_ids": [
-        "202609041801-ZVX69C"
-      ]
+      "task_ids": ["202609041801-ZVX69C"]
     },
     {
       "service_only": false,
@@ -1227,170 +883,122 @@
     {
       "service_only": true,
       "sha": "fbf8853c500b57ab28d42f6e140e6bbe03603f8e",
-      "task_ids": [
-        "202609041801-ZVX69C"
-      ]
+      "task_ids": ["202609041801-ZVX69C"]
     },
     {
       "service_only": true,
       "sha": "2b0bcb6d5b595b8c0d9e70281d95a97f4cf1b917",
-      "task_ids": [
-        "202609041801-ZVX69C"
-      ]
+      "task_ids": ["202609041801-ZVX69C"]
     },
     {
       "service_only": true,
       "sha": "8f7b0706b69c104806f4591567750ceb58697ce2",
-      "task_ids": [
-        "202609041801-ZVX69C"
-      ]
+      "task_ids": ["202609041801-ZVX69C"]
     },
     {
       "service_only": true,
       "sha": "ad262173f6ee46b72668f12bc8b6ab40798338a3",
-      "task_ids": [
-        "202609041801-ZVX69C"
-      ]
+      "task_ids": ["202609041801-ZVX69C"]
     },
     {
       "service_only": false,
       "sha": "5e35370df7bd24be3cf0c5d59bd17bb1fd99f856",
-      "task_ids": [
-        "202609041801-ZVX69C"
-      ]
+      "task_ids": ["202609041801-ZVX69C"]
     },
     {
       "service_only": false,
       "sha": "b255ea521a19c0861a939284bc9fa8bdd5816325",
-      "task_ids": [
-        "202609041801-ZVX69C"
-      ]
+      "task_ids": ["202609041801-ZVX69C"]
     },
     {
       "service_only": true,
       "sha": "ac91f8bfdd5718221a949f82c607936b77150cf1",
-      "task_ids": [
-        "202609041801-ZVX69C"
-      ]
+      "task_ids": ["202609041801-ZVX69C"]
     },
     {
       "service_only": true,
       "sha": "baae32a2e3c5e0c45c1afa823009df3436d2fe67",
-      "task_ids": [
-        "202609041801-ZVX69C"
-      ]
+      "task_ids": ["202609041801-ZVX69C"]
     },
     {
       "service_only": false,
       "sha": "0bc37e5952e2713f665ee69687b4aab45f83fd54",
-      "task_ids": [
-        "202609041801-ZVX69C"
-      ]
+      "task_ids": ["202609041801-ZVX69C"]
     },
     {
       "service_only": false,
       "sha": "99fdb3c4cc9123982becb3edebb5bd030885fd0e",
-      "task_ids": [
-        "202609041801-ZVX69C"
-      ]
+      "task_ids": ["202609041801-ZVX69C"]
     },
     {
       "service_only": true,
       "sha": "6c866e888b5d8af4bc6b10fc308462e56e3deb76",
-      "task_ids": [
-        "202609041801-ZVX69C"
-      ]
+      "task_ids": ["202609041801-ZVX69C"]
     },
     {
       "service_only": true,
       "sha": "3fc391c151ab2f1879ea9eae5c2e8cb73469b787",
-      "task_ids": [
-        "202609041801-ZVX69C"
-      ]
+      "task_ids": ["202609041801-ZVX69C"]
     },
     {
       "service_only": true,
       "sha": "218df006de80522a871e7d32b4e6b26de6fdb96a",
-      "task_ids": [
-        "202609041801-ZVX69C"
-      ]
+      "task_ids": ["202609041801-ZVX69C"]
     },
     {
       "service_only": true,
       "sha": "4c90e955a1e7f6c577966ee4d7bf873a2e3936aa",
-      "task_ids": [
-        "202609041801-ZVX69C"
-      ]
+      "task_ids": ["202609041801-ZVX69C"]
     },
     {
       "service_only": false,
       "sha": "1050a0f4856603b998283a05f2caa4cc8ebcca96",
-      "task_ids": [
-        "202609041801-ZVX69C"
-      ]
+      "task_ids": ["202609041801-ZVX69C"]
     },
     {
       "service_only": true,
       "sha": "11f06801e10fa00f954bd1d3ed22a5d138d0f46f",
-      "task_ids": [
-        "202609041801-ZVX69C"
-      ]
+      "task_ids": ["202609041801-ZVX69C"]
     },
     {
       "service_only": true,
       "sha": "3cd9c9fa22be0b70c1f14d2f2100f5c0503aa3be",
-      "task_ids": [
-        "202609041801-ZVX69C"
-      ]
+      "task_ids": ["202609041801-ZVX69C"]
     },
     {
       "service_only": true,
       "sha": "8f006bf84e1215d36d1e1182a190a89958cdaacb",
-      "task_ids": [
-        "202609041801-ZVX69C"
-      ]
+      "task_ids": ["202609041801-ZVX69C"]
     },
     {
       "service_only": true,
       "sha": "42463c33c80a49eea4445f2aa6a382a6ab6588ac",
-      "task_ids": [
-        "202609041801-ZVX69C"
-      ]
+      "task_ids": ["202609041801-ZVX69C"]
     },
     {
       "service_only": true,
       "sha": "4bed92f9eeac21183a2558bab17c9795a20ec6a7",
-      "task_ids": [
-        "202609041801-ZVX69C"
-      ]
+      "task_ids": ["202609041801-ZVX69C"]
     },
     {
       "service_only": true,
       "sha": "09c20ba49b88479a3198f73d0989817e3a6f2895",
-      "task_ids": [
-        "202609041801-ZVX69C"
-      ]
+      "task_ids": ["202609041801-ZVX69C"]
     },
     {
       "service_only": false,
       "sha": "8b1594fdbddea370c02760dd835f4f98f9caf160",
-      "task_ids": [
-        "202609041801-ZVX69C"
-      ]
+      "task_ids": ["202609041801-ZVX69C"]
     },
     {
       "service_only": true,
       "sha": "6e49077db61daed5204b514e7d6e071c190edda6",
-      "task_ids": [
-        "202609031717-PX8PZT"
-      ]
+      "task_ids": ["202609031717-PX8PZT"]
     },
     {
       "service_only": true,
       "sha": "b97f2fe710146f34eeccb1bd57bd66f35390dafb",
-      "task_ids": [
-        "202609031717-PX8PZT"
-      ]
+      "task_ids": ["202609031717-PX8PZT"]
     }
   ],
   "digest": "sha256:60c9be411166e867f42697229a64ec713260e34e0f8b45428b2490af6691ab5c",

--- a/scripts/baselines/agent-efficiency-VN1FN4-comparison.json
+++ b/scripts/baselines/agent-efficiency-VN1FN4-comparison.json
@@ -1,44 +1,52 @@
 {
   "schema_version": 1,
   "task_id": "202609071501-VN1FN4",
-  "status": "implementation_measured_schema_parity_verified_pending_framework_review",
+  "status": "implementation_measured_schema_parity_verified",
   "source": {
     "committed_head": "92efd467a7b045e7e784597168ac21bd41a975a1",
-    "committed_snapshot_digest": "sha256:6daf20729a4383c5e63e20b3663e81fc2060c0c7416f0c2ec5958665949834ea",
-    "repeated_snapshot_digest": "sha256:6daf20729a4383c5e63e20b3663e81fc2060c0c7416f0c2ec5958665949834ea",
-    "working_source_manifest_digest": "sha256:f73d4b087e863bb00b78d3d4e69c2fa485252d1a0bfea095718c88d55337e4cb",
+    "committed_snapshot_digest": "sha256:8b95e82e98352def1770dc337b06e8cae932ba43b7f1642073c563b741bfe75f",
+    "repeated_snapshot_digest": "sha256:8b95e82e98352def1770dc337b06e8cae932ba43b7f1642073c563b741bfe75f",
+    "working_source_manifest_digest": "sha256:6b0de1ae904a9ced0a146c7eda3a89d84a5dd0f8c0e8fb1a57b3797f6dc3ec06",
     "working_sources": [
       {
         "path": "packages/agentplane/src/adapters/task-backend/kernel-authority-schema.ts",
-        "digest": "sha256:7658d80c8c06380b7bd210406d03671ee4639f7327e0a690a415f4fd91e2c2e2"
+        "digest": "sha256:fd42e3c9e48b39ad71f81a0c9ca08242b1d968b313c71ee3643c7fdbdf0dab0e"
       },
       {
         "path": "packages/agentplane/src/cli/run-cli.core.kernel-transport.test.ts",
-        "digest": "sha256:b1692e989a5dcaabf298707d92edff6094d7fb40e454dceacc95271b650fcd00"
+        "digest": "sha256:3b5493c625a40107959f0c0170bc26a880bece8b2654eb3452c8617aa8ea194f"
       },
       {
         "path": "packages/agentplane/src/cli/run-cli.core.task-advance-effect-recovery.test.ts",
-        "digest": "sha256:cb96171b86a69e566652f5542340e3f2eb738dec5e35b2d131260492f2b6ca48"
+        "digest": "sha256:753e656f5db56c1b5265371b4655068d182474627c230efb5861b8803ae232c5"
       },
       {
         "path": "packages/agentplane/src/cli/run-cli.core.task-advance.evidence-rework.test.ts",
-        "digest": "sha256:82a697849e7d8e8b99d2f50e51ba62d1a2058e73c2d15af72821c3ce903928ea"
+        "digest": "sha256:6de03299362007bad52cc9dab2e42430b382bc88e5203564acd204087c6f1b32"
       },
       {
         "path": "packages/agentplane/src/cli/run-cli.critical.agent-efficiency-baseline.test.ts",
-        "digest": "sha256:ffdfa8cd7ca6de62713fad72d83e2ab332887bf62a6391bd98c31206e9d2227c"
+        "digest": "sha256:5c07a4344def40d2c4689e39cb890125ffe5893a2c228ec96d2737fa64f52276"
       },
       {
         "path": "packages/agentplane/src/commands/evaluator/evaluator-evidence-store.test.ts",
-        "digest": "sha256:ce60d71e9576889b622e771d01a26198bf01fd0d6503d8e3990ff9b68b4dc4c3"
+        "digest": "sha256:e3d0afb547a71607ec2cd3a6efa154565dfa73e33a7e8a61fe9d4103593d4ed8"
       },
       {
         "path": "packages/agentplane/src/commands/evaluator/evaluator-evidence-store.ts",
         "digest": "sha256:79c3afa22aae902c8141a6eaeb9da3f926736000d9220d361b4d5691dcb2afbf"
       },
       {
+        "path": "packages/agentplane/src/commands/release/github-ci-plan.test.ts",
+        "digest": "sha256:978d24986c2875b51e36b964151457eeb82ff4f2fafc83e2e2d4acb621e247d7"
+      },
+      {
         "path": "packages/agentplane/src/commands/shared/quality-review-target.ts",
         "digest": "sha256:384f50ae031d04b69b3e18822886fccd05cfe1d386a97489e4849edcddc7599b"
+      },
+      {
+        "path": "packages/agentplane/src/commands/shared/task-backend.ts",
+        "digest": "sha256:ac69f2c5822deb056d2114eec9fecca5cf1096dc2222b80eb17be2f7366110f7"
       },
       {
         "path": "packages/agentplane/src/commands/task/advance.command.ts",
@@ -54,7 +62,7 @@
       },
       {
         "path": "packages/agentplane/src/commands/task/branch-task-supervisor-artifact-commit.test.ts",
-        "digest": "sha256:3f052e9b5cd2e48e167fd7ce94bc62ac1fb63ab12881ab8d90a4eb8c4f6a1f29"
+        "digest": "sha256:3fad9f358ec5fcb2d992bef20564ff5202d382a04466ecf1b583a61bae3150ea"
       },
       {
         "path": "packages/agentplane/src/commands/task/branch-task-supervisor-artifact-commit.ts",
@@ -69,8 +77,24 @@
         "digest": "sha256:bb697f351ee72a416084cf32aee17390b5686bf09cc74677fa4978369f628af0"
       },
       {
+        "path": "packages/agentplane/src/commands/task/external-agent-implementation-authority.ts",
+        "digest": "sha256:cca7361d879b6362c3e3fba47049091f2bc59f405cb32549a6bea3054ee58dc8"
+      },
+      {
         "path": "packages/agentplane/src/commands/task/external-agent-implementation-finalization.ts",
         "digest": "sha256:7e66d3935ef3b585d628a7b107d2d2ed252bde9aab041e302f59c9ddd7e58ac4"
+      },
+      {
+        "path": "packages/agentplane/src/commands/task/external-agent-implementation-recovery.test.ts",
+        "digest": "sha256:1d9bf5ea0a1dd6ec0b390b2a568a0dd0915f88249d63bc48e9b4e1201b28afd8"
+      },
+      {
+        "path": "packages/agentplane/src/commands/task/external-agent-report-result.test.ts",
+        "digest": "sha256:742a067c8aeb14dd08f5f578763f9e0d61552c1d7b1af63cda67980d0a7091f5"
+      },
+      {
+        "path": "packages/agentplane/src/commands/task/external-agent-report-result.ts",
+        "digest": "sha256:fe4db2105f7413196f56d8386241f549641a8e8b14c36c56cae0aef5a4989f62"
       },
       {
         "path": "packages/agentplane/src/commands/task/external-agent-supervisor-recovery.ts",
@@ -82,15 +106,15 @@
       },
       {
         "path": "packages/agentplane/src/commands/task/kernel-exchange.ts",
-        "digest": "sha256:62ceb5a23aec3c2e3bb51d1470d5d68088947d4d6d21a5804203ab290fd0eae6"
+        "digest": "sha256:a60fbafc3340327aaed78ec42f747eb3563737b58255fda332dafc57199404f5"
       },
       {
         "path": "packages/agentplane/src/commands/task/kernel-final-validation.ts",
-        "digest": "sha256:2ad62f2cd9da41c4edf68cda2eb0bc4ff7fdca0624bc71f79040df94b91200f8"
+        "digest": "sha256:fa960a6bc43e14ab26827c54608870a6e25db1434bc4c71d13bf6c0c5d29c405"
       },
       {
         "path": "packages/agentplane/src/commands/task/kernel-inspection.ts",
-        "digest": "sha256:bd0265d4b4fde547282d8dde667342a6b4f1e18d77f3caf195b45931b2faf09a"
+        "digest": "sha256:8be7578db43024c1e8aa98c7ca2aa7b70cb6f6aa68b610dc07f22ccb601491eb"
       },
       {
         "path": "packages/agentplane/src/commands/task/kernel-run.ts",
@@ -102,7 +126,7 @@
       },
       {
         "path": "packages/agentplane/src/commands/task/task-token-usage.test.ts",
-        "digest": "sha256:11e24c4bd314a2a6ff21fd5537e7a1772b409c526fc11e3dd3890a966b3f43c8"
+        "digest": "sha256:c0bb25ccf5098262a6ab099e1662c4662963c6096ea510ae036ba46482791172"
       },
       {
         "path": "packages/agentplane/src/commands/task/task-token-usage.ts",
@@ -110,7 +134,7 @@
       },
       {
         "path": "packages/agentplane/src/harness/token-accounting.test.ts",
-        "digest": "sha256:b49a79b66ddcac97642bd05bcea44600d45fe49b0f470fa7817b4f58fb50302c"
+        "digest": "sha256:04c1ee668418f41426409739af12d895a4441eec3d34bfbe174d60158199c3c9"
       },
       {
         "path": "packages/agentplane/src/harness/token-accounting.ts",
@@ -134,7 +158,7 @@
       },
       {
         "path": "packages/agentplane/src/runner/adapters/prepared-input.ts",
-        "digest": "sha256:d1cf56ddf05eadc65a1a3638fdd17540c5e4cb3036544e1550e927dd0c479ad0"
+        "digest": "sha256:f818d22cda7d83db62894fffb4c4931fcec115630909bc2222d5f7838b25ed5c"
       },
       {
         "path": "packages/agentplane/src/runner/artifacts.ts",
@@ -146,15 +170,15 @@
       },
       {
         "path": "packages/agentplane/src/runner/context/work-order-context.ts",
-        "digest": "sha256:64e462bc014a7531a4ed7df46a2828988322830475a18742173f1e07f90e5f33"
+        "digest": "sha256:a857743b0fa9ee1e8d9e76f574c5789b94294389430238af3f21a79add4fcacf"
       },
       {
         "path": "packages/agentplane/src/runner/observation/git-snapshot.test.ts",
-        "digest": "sha256:937c84b323bfd100228e778790273137497a1b148377d72e82f18ed1159339b5"
+        "digest": "sha256:2e70d4615213639fa6c54e893233707cc591b05335a3bfee119db78764316c8c"
       },
       {
         "path": "packages/agentplane/src/runner/observation/kernel-repository.ts",
-        "digest": "sha256:e523c859ff9029c8f6e8a2184268e0a0dfe562087f4143203bb1e54b1029192d"
+        "digest": "sha256:e38db1c7662b34e1a2bda78eed4ed2cf0c5b8a8db234442fa03630bf39bcda1f"
       },
       {
         "path": "packages/agentplane/src/runner/types/context.ts",
@@ -162,11 +186,11 @@
       },
       {
         "path": "packages/agentplane/src/runner/usecases/kernel-authority.test.ts",
-        "digest": "sha256:50d7cb99d5105160ed503272aa65548d4116345085af10142cd4d918a6bdf4d1"
+        "digest": "sha256:ce002003b999081a92231f5841dd752066896f7f04bb6eb9cd7e8af6f1f505a7"
       },
       {
         "path": "packages/agentplane/src/runner/usecases/kernel-authority.ts",
-        "digest": "sha256:6a0e990725fdf9e6b3fd1402617eda44ea3aff44d860a9fe366277a8a14551fd"
+        "digest": "sha256:da665a36ca17e9afe7725147cf53172b39b798286c32775019b501dea3bb4b2b"
       },
       {
         "path": "packages/agentplane/src/runner/usecases/kernel-task-lifecycle.test.ts",
@@ -179,6 +203,14 @@
       {
         "path": "packages/agentplane/src/runner/usecases/task-run-bootstrap.ts",
         "digest": "sha256:55f858303c0e8692313750a1ce031e12e8cadf07afb58580f79c887363c1acc3"
+      },
+      {
+        "path": "packages/agentplane/src/shared/package-paths.test.ts",
+        "digest": "sha256:4b48c615481eb3c95be681685066c032804158dbd268afec27f22e2fda635ee5"
+      },
+      {
+        "path": "packages/agentplane/src/shared/package-paths.ts",
+        "digest": "sha256:0f73c9a11c471087ce80ba069d14fec6314676de0d02118bfd100470859575fc"
       },
       {
         "path": "packages/core/schemas/agent-work-order-v2.schema.json",
@@ -206,7 +238,7 @@
       },
       {
         "path": "packages/core/src/runner/supervisor-execution-episode.test.ts",
-        "digest": "sha256:110a4a5a90f94addd815d5d28e92e96163ed2d0f6f9068d749f3fa9b54c3d5be"
+        "digest": "sha256:525a81a74005b2f501f0b8a119c4eb446c8494ead0e60ff1ac3c7660742ec351"
       },
       {
         "path": "packages/core/src/runner/supervisor-execution-episode.ts",
@@ -222,19 +254,19 @@
       },
       {
         "path": "packages/core/src/tasks/task-kernel/authority-lineage.ts",
-        "digest": "sha256:921525ecf69efecdb1c894e8e154dcfb209ac098d5b61111e95d6bcdefca6041"
+        "digest": "sha256:bada1e81b019f5f3fa3939d0d184e8234f78d71627e1a203c0ea14360a6880a4"
       },
       {
         "path": "packages/core/src/tasks/task-kernel/kernel.test.ts",
-        "digest": "sha256:96250577db20891a8d39df91b026229778147cbed9ba66e53aff558d9530d712"
+        "digest": "sha256:6a8538bcdde5cd01cc1fd4644e30e9610954736dc328a92242011cfa92694ff7"
       },
       {
         "path": "packages/core/src/tasks/task-kernel/kernel.ts",
-        "digest": "sha256:71ec7417fb4f78bf2e11d8f32613ac0997ad05655b2588c917f48ef10c4006e9"
+        "digest": "sha256:61199adc9d9526eee1b0934a57fe0dcc7695b26a4038a09388b5f23a4ddb893c"
       },
       {
         "path": "packages/core/src/tasks/task-kernel/model.ts",
-        "digest": "sha256:24e2d2bc530e64c6aa7bf19f19c8f41df747dbf0c0e67c195db2c950d8854204"
+        "digest": "sha256:276c59976aab3a7528852b26795ec4ccc5e8e4da643b43d843ebad82153b8049"
       },
       {
         "path": "packages/core/src/tasks/task-store.ts",
@@ -269,19 +301,27 @@
         "digest": "sha256:c2baee7b89798b2646367e066ec7b447546395b9b019244cc21e950680fac523"
       },
       {
-        "path": "scripts/bench/compare-agent-efficiency-VN1FN4.mjs",
-        "digest": "sha256:3ca187359e42b88baec8c6cad1218818219cb82445fd461ee8013c9410c560a1"
+        "path": "scripts/bench/compare-agent-efficiency-vn1-fn4.mjs",
+        "digest": "sha256:fb80181d5e3febf659cd47b0cde7320f3963e41c2294dc527857ee2d423b8829"
       },
       {
         "path": "scripts/bench/measure-agent-efficiency.mjs",
         "digest": "sha256:fc25f2ba66c4cc15d9b54f06c2f83439f7315c3c596b97a929d0dd6f52c191b4"
       },
       {
+        "path": "scripts/checks/check-compatibility-contract-baseline.mjs",
+        "digest": "sha256:bc5dd5ab6d868b1db6bf624a4dd342184d664d7a5e02812f6dbf292139100f4f"
+      },
+      {
         "path": "scripts/lib/agent-efficiency-repository-snapshot.mjs",
-        "digest": "sha256:d761bbeb4bbdbef49347e90467e97ae9ca64d22b04c3911a0a8efe340511dbb4"
+        "digest": "sha256:37d97731a9b55ac7e61243e99592842763ed1cdd59915023404ea03f8b86fda7"
+      },
+      {
+        "path": "scripts/lib/github-ci-capabilities.mjs",
+        "digest": "sha256:d61eb212dd1b55d244947260356b446d20072cc8cb9e6f57beb009be4f8505f1"
       }
     ],
-    "note": "Working source digests identify the uncommitted candidate; HEAD does not identify it."
+    "note": "Source digests identify current file contents relative to the historical snapshot, including committed and uncommitted changes."
   },
   "historical_snapshot": {
     "before": {
@@ -425,7 +465,7 @@
   "correctness_limits": [
     "Generated schema parity was synchronized through the separately USER-approved Q6MEAH task and now passes schemas:check. The current working-source manifest includes those generated mirrors.",
     "Legacy bootstrap task QCBB76 has a separate malformed scope-extension contract; its lifecycle and integration are not complete.",
-    "Independent framework evaluation is required before comparison-report acceptance. Full repository CI, external provider effects, publication and integration are not claimed.",
+    "This report records the local comparison only. Full repository CI, external provider effects, publication and integration are not established by these measurements.",
     "Missing usage stays null; native receipts, stale-state/CAS checks, authority, input/output digests and crash recovery remain required costs."
   ]
 }

--- a/scripts/baselines/agent-efficiency-VN1FN4-comparison.json
+++ b/scripts/baselines/agent-efficiency-VN1FN4-comparison.json
@@ -1,0 +1,431 @@
+{
+  "schema_version": 1,
+  "task_id": "202609071501-VN1FN4",
+  "status": "implementation_measured_schema_parity_verified_pending_framework_review",
+  "source": {
+    "committed_head": "92efd467a7b045e7e784597168ac21bd41a975a1",
+    "committed_snapshot_digest": "sha256:6daf20729a4383c5e63e20b3663e81fc2060c0c7416f0c2ec5958665949834ea",
+    "repeated_snapshot_digest": "sha256:6daf20729a4383c5e63e20b3663e81fc2060c0c7416f0c2ec5958665949834ea",
+    "working_source_manifest_digest": "sha256:f73d4b087e863bb00b78d3d4e69c2fa485252d1a0bfea095718c88d55337e4cb",
+    "working_sources": [
+      {
+        "path": "packages/agentplane/src/adapters/task-backend/kernel-authority-schema.ts",
+        "digest": "sha256:7658d80c8c06380b7bd210406d03671ee4639f7327e0a690a415f4fd91e2c2e2"
+      },
+      {
+        "path": "packages/agentplane/src/cli/run-cli.core.kernel-transport.test.ts",
+        "digest": "sha256:b1692e989a5dcaabf298707d92edff6094d7fb40e454dceacc95271b650fcd00"
+      },
+      {
+        "path": "packages/agentplane/src/cli/run-cli.core.task-advance-effect-recovery.test.ts",
+        "digest": "sha256:cb96171b86a69e566652f5542340e3f2eb738dec5e35b2d131260492f2b6ca48"
+      },
+      {
+        "path": "packages/agentplane/src/cli/run-cli.core.task-advance.evidence-rework.test.ts",
+        "digest": "sha256:82a697849e7d8e8b99d2f50e51ba62d1a2058e73c2d15af72821c3ce903928ea"
+      },
+      {
+        "path": "packages/agentplane/src/cli/run-cli.critical.agent-efficiency-baseline.test.ts",
+        "digest": "sha256:ffdfa8cd7ca6de62713fad72d83e2ab332887bf62a6391bd98c31206e9d2227c"
+      },
+      {
+        "path": "packages/agentplane/src/commands/evaluator/evaluator-evidence-store.test.ts",
+        "digest": "sha256:ce60d71e9576889b622e771d01a26198bf01fd0d6503d8e3990ff9b68b4dc4c3"
+      },
+      {
+        "path": "packages/agentplane/src/commands/evaluator/evaluator-evidence-store.ts",
+        "digest": "sha256:79c3afa22aae902c8141a6eaeb9da3f926736000d9220d361b4d5691dcb2afbf"
+      },
+      {
+        "path": "packages/agentplane/src/commands/shared/quality-review-target.ts",
+        "digest": "sha256:384f50ae031d04b69b3e18822886fccd05cfe1d386a97489e4849edcddc7599b"
+      },
+      {
+        "path": "packages/agentplane/src/commands/task/advance.command.ts",
+        "digest": "sha256:93ad71066c835e58cd43391f05ff3ab9896217433e737d8882b2b34037d1a7a8"
+      },
+      {
+        "path": "packages/agentplane/src/commands/task/agent-action-packet.test.ts",
+        "digest": "sha256:e05fe638d412b2b1c94785f69efcfcf3ef02437965633d9d29299b64b4a3455d"
+      },
+      {
+        "path": "packages/agentplane/src/commands/task/agent-action-packet.ts",
+        "digest": "sha256:727d4392fa2b595524620328c353e42d9f2e877c2ab9d1a49dcf64d5b5d0c651"
+      },
+      {
+        "path": "packages/agentplane/src/commands/task/branch-task-supervisor-artifact-commit.test.ts",
+        "digest": "sha256:3f052e9b5cd2e48e167fd7ce94bc62ac1fb63ab12881ab8d90a4eb8c4f6a1f29"
+      },
+      {
+        "path": "packages/agentplane/src/commands/task/branch-task-supervisor-artifact-commit.ts",
+        "digest": "sha256:fdb87bac6e2e3ac15bc7b7d6cb837892e7f25dc15d07a7172232d3963fff5af0"
+      },
+      {
+        "path": "packages/agentplane/src/commands/task/branch-task-supervisor-episodes.ts",
+        "digest": "sha256:0f18c2b2d119111218ecf49140c1c8f9aca384c88c2c2fa7954721404cfc0164"
+      },
+      {
+        "path": "packages/agentplane/src/commands/task/external-agent-exchange.ts",
+        "digest": "sha256:bb697f351ee72a416084cf32aee17390b5686bf09cc74677fa4978369f628af0"
+      },
+      {
+        "path": "packages/agentplane/src/commands/task/external-agent-implementation-finalization.ts",
+        "digest": "sha256:7e66d3935ef3b585d628a7b107d2d2ed252bde9aab041e302f59c9ddd7e58ac4"
+      },
+      {
+        "path": "packages/agentplane/src/commands/task/external-agent-supervisor-recovery.ts",
+        "digest": "sha256:c88670ee281353c06323799e52c3fcb59f56b8820eedff2ae08b4bcaa17b927e"
+      },
+      {
+        "path": "packages/agentplane/src/commands/task/kernel-advance.ts",
+        "digest": "sha256:fe5553443958f649aee3ac0a0fb80acd7f0202ea2630189fd778df810ed1c7b8"
+      },
+      {
+        "path": "packages/agentplane/src/commands/task/kernel-exchange.ts",
+        "digest": "sha256:62ceb5a23aec3c2e3bb51d1470d5d68088947d4d6d21a5804203ab290fd0eae6"
+      },
+      {
+        "path": "packages/agentplane/src/commands/task/kernel-final-validation.ts",
+        "digest": "sha256:2ad62f2cd9da41c4edf68cda2eb0bc4ff7fdca0624bc71f79040df94b91200f8"
+      },
+      {
+        "path": "packages/agentplane/src/commands/task/kernel-inspection.ts",
+        "digest": "sha256:bd0265d4b4fde547282d8dde667342a6b4f1e18d77f3caf195b45931b2faf09a"
+      },
+      {
+        "path": "packages/agentplane/src/commands/task/kernel-run.ts",
+        "digest": "sha256:36c68efb53cd64d4466b8a1597a10f33392c36b991506d3c993146e8d4326753"
+      },
+      {
+        "path": "packages/agentplane/src/commands/task/scope-extend.ts",
+        "digest": "sha256:19769b4d8b6243ce78ca6451ce62e172b7d9c207c4a56402ad7a7089b701ca20"
+      },
+      {
+        "path": "packages/agentplane/src/commands/task/task-token-usage.test.ts",
+        "digest": "sha256:11e24c4bd314a2a6ff21fd5537e7a1772b409c526fc11e3dd3890a966b3f43c8"
+      },
+      {
+        "path": "packages/agentplane/src/commands/task/task-token-usage.ts",
+        "digest": "sha256:2723ebe11be61a86326c2dab01674ee3181fa5e88338f8449696b4d781260b65"
+      },
+      {
+        "path": "packages/agentplane/src/harness/token-accounting.test.ts",
+        "digest": "sha256:b49a79b66ddcac97642bd05bcea44600d45fe49b0f470fa7817b4f58fb50302c"
+      },
+      {
+        "path": "packages/agentplane/src/harness/token-accounting.ts",
+        "digest": "sha256:b2a19d7d8ee2e9137d1e09357cf19fb19892007d09d6c9eaf51379665942ef27"
+      },
+      {
+        "path": "packages/agentplane/src/runner/adapters/codex-result-transport.test.ts",
+        "digest": "sha256:ecc0cb6f5d4bf82c0f2f5ffd9622bcccc36b1488395f79615cdf975ed4d7f91f"
+      },
+      {
+        "path": "packages/agentplane/src/runner/adapters/codex-result-transport.ts",
+        "digest": "sha256:8b9e580c591ca5dae597e666a3f012059639ed1a46469ed047b4fde8539a18ea"
+      },
+      {
+        "path": "packages/agentplane/src/runner/adapters/codex.test.ts",
+        "digest": "sha256:80717698d835a6b8821e4b5a4c7baf5c80af080930b7ba4dc7fe273513a2846f"
+      },
+      {
+        "path": "packages/agentplane/src/runner/adapters/codex.ts",
+        "digest": "sha256:4c83318ae49e397048298fb90cd4c028ab05d69a0ea1cd6ca9901fdf173199fc"
+      },
+      {
+        "path": "packages/agentplane/src/runner/adapters/prepared-input.ts",
+        "digest": "sha256:d1cf56ddf05eadc65a1a3638fdd17540c5e4cb3036544e1550e927dd0c479ad0"
+      },
+      {
+        "path": "packages/agentplane/src/runner/artifacts.ts",
+        "digest": "sha256:32bbe65bd371182f70720fed3ad3996d4846251596762e6cf84b23866dbf1468"
+      },
+      {
+        "path": "packages/agentplane/src/runner/context/task-context.test.ts",
+        "digest": "sha256:7ba50df1953b951ab7746de24d59f21276e1d400e255a6827a086e461e2204f3"
+      },
+      {
+        "path": "packages/agentplane/src/runner/context/work-order-context.ts",
+        "digest": "sha256:64e462bc014a7531a4ed7df46a2828988322830475a18742173f1e07f90e5f33"
+      },
+      {
+        "path": "packages/agentplane/src/runner/observation/git-snapshot.test.ts",
+        "digest": "sha256:937c84b323bfd100228e778790273137497a1b148377d72e82f18ed1159339b5"
+      },
+      {
+        "path": "packages/agentplane/src/runner/observation/kernel-repository.ts",
+        "digest": "sha256:e523c859ff9029c8f6e8a2184268e0a0dfe562087f4143203bb1e54b1029192d"
+      },
+      {
+        "path": "packages/agentplane/src/runner/types/context.ts",
+        "digest": "sha256:3c16f335065025e8ebf7d043a3189a0d74bbc67b2a330e59555ebed4d65b4bf3"
+      },
+      {
+        "path": "packages/agentplane/src/runner/usecases/kernel-authority.test.ts",
+        "digest": "sha256:50d7cb99d5105160ed503272aa65548d4116345085af10142cd4d918a6bdf4d1"
+      },
+      {
+        "path": "packages/agentplane/src/runner/usecases/kernel-authority.ts",
+        "digest": "sha256:6a0e990725fdf9e6b3fd1402617eda44ea3aff44d860a9fe366277a8a14551fd"
+      },
+      {
+        "path": "packages/agentplane/src/runner/usecases/kernel-task-lifecycle.test.ts",
+        "digest": "sha256:22758a6ea167139f3b8802bf2583df3250cd2d1fdf25f349249c7e9d89f61a44"
+      },
+      {
+        "path": "packages/agentplane/src/runner/usecases/task-run-bootstrap.result-examples.test.ts",
+        "digest": "sha256:82499577dd02dc21d122f6d9eecd75aa8e0b4f6db57b51b86f5666c498606440"
+      },
+      {
+        "path": "packages/agentplane/src/runner/usecases/task-run-bootstrap.ts",
+        "digest": "sha256:55f858303c0e8692313750a1ce031e12e8cadf07afb58580f79c887363c1acc3"
+      },
+      {
+        "path": "packages/core/schemas/agent-work-order-v2.schema.json",
+        "digest": "sha256:4c7dd224b4215d1abf2dc30c05fd016b5f34b128f4ccd7627fd3ff3dcb8598d2"
+      },
+      {
+        "path": "packages/core/schemas/task-readme-frontmatter.schema.json",
+        "digest": "sha256:36910c4cfb89e64e23a471f441996818f5389ed23d37e1ca5376db852bd75f24"
+      },
+      {
+        "path": "packages/core/schemas/tasks-export.schema.json",
+        "digest": "sha256:c2baee7b89798b2646367e066ec7b447546395b9b019244cc21e950680fac523"
+      },
+      {
+        "path": "packages/core/src/runner/agent-semantic-result.test.ts",
+        "digest": "sha256:332440c768850b303fd48663ad2f9eef1c93f3b500b31040317d2c6e337bfc81"
+      },
+      {
+        "path": "packages/core/src/runner/agent-semantic-result.ts",
+        "digest": "sha256:ff6e73da887a6948125d41a3e0c09b2d48a671b52b99d9227016410cdde3d91d"
+      },
+      {
+        "path": "packages/core/src/runner/agent-work-order.ts",
+        "digest": "sha256:9a75874b9b7d7b32637f873c546e91cbc1e915de65d0967b4c98dbe2bcab0d89"
+      },
+      {
+        "path": "packages/core/src/runner/supervisor-execution-episode.test.ts",
+        "digest": "sha256:110a4a5a90f94addd815d5d28e92e96163ed2d0f6f9068d749f3fa9b54c3d5be"
+      },
+      {
+        "path": "packages/core/src/runner/supervisor-execution-episode.ts",
+        "digest": "sha256:06aeba661ff2fbe74ce748f5c9e3c93589904b4ce4096bcbb6ed5ed3cadfc84d"
+      },
+      {
+        "path": "packages/core/src/tasks/kernel-semantic.ts",
+        "digest": "sha256:139482e21080e8287638b6dafcbf38f017e9518d5fdd4c03003cc899144bbc37"
+      },
+      {
+        "path": "packages/core/src/tasks/task-artifact-schema.task.ts",
+        "digest": "sha256:fa73a96b81c5c8cf569abcff849baf29865f24e1032597869f2a623f01d84d3b"
+      },
+      {
+        "path": "packages/core/src/tasks/task-kernel/authority-lineage.ts",
+        "digest": "sha256:921525ecf69efecdb1c894e8e154dcfb209ac098d5b61111e95d6bcdefca6041"
+      },
+      {
+        "path": "packages/core/src/tasks/task-kernel/kernel.test.ts",
+        "digest": "sha256:96250577db20891a8d39df91b026229778147cbed9ba66e53aff558d9530d712"
+      },
+      {
+        "path": "packages/core/src/tasks/task-kernel/kernel.ts",
+        "digest": "sha256:71ec7417fb4f78bf2e11d8f32613ac0997ad05655b2588c917f48ef10c4006e9"
+      },
+      {
+        "path": "packages/core/src/tasks/task-kernel/model.ts",
+        "digest": "sha256:24e2d2bc530e64c6aa7bf19f19c8f41df747dbf0c0e67c195db2c950d8854204"
+      },
+      {
+        "path": "packages/core/src/tasks/task-store.ts",
+        "digest": "sha256:fd3c9cd78f09f37149243d95b9424062c8f736950c2aa6d9602d72b8980cffb3"
+      },
+      {
+        "path": "packages/spec/schemas/agent-work-order-v2.schema.json",
+        "digest": "sha256:4c7dd224b4215d1abf2dc30c05fd016b5f34b128f4ccd7627fd3ff3dcb8598d2"
+      },
+      {
+        "path": "packages/spec/schemas/task-readme-frontmatter.schema.json",
+        "digest": "sha256:36910c4cfb89e64e23a471f441996818f5389ed23d37e1ca5376db852bd75f24"
+      },
+      {
+        "path": "packages/spec/schemas/tasks-export.schema.json",
+        "digest": "sha256:c2baee7b89798b2646367e066ec7b447546395b9b019244cc21e950680fac523"
+      },
+      {
+        "path": "schemas/agent-semantic-result.schema.json",
+        "digest": "sha256:dc7c5048cb6136df64033d110d45a3f2b290c1f3a3537ccc3c6a2bdd2df3fffa"
+      },
+      {
+        "path": "schemas/agent-work-order-v2.schema.json",
+        "digest": "sha256:4c7dd224b4215d1abf2dc30c05fd016b5f34b128f4ccd7627fd3ff3dcb8598d2"
+      },
+      {
+        "path": "schemas/task-readme-frontmatter.schema.json",
+        "digest": "sha256:36910c4cfb89e64e23a471f441996818f5389ed23d37e1ca5376db852bd75f24"
+      },
+      {
+        "path": "schemas/tasks-export.schema.json",
+        "digest": "sha256:c2baee7b89798b2646367e066ec7b447546395b9b019244cc21e950680fac523"
+      },
+      {
+        "path": "scripts/bench/compare-agent-efficiency-VN1FN4.mjs",
+        "digest": "sha256:3ca187359e42b88baec8c6cad1218818219cb82445fd461ee8013c9410c560a1"
+      },
+      {
+        "path": "scripts/bench/measure-agent-efficiency.mjs",
+        "digest": "sha256:fc25f2ba66c4cc15d9b54f06c2f83439f7315c3c596b97a929d0dd6f52c191b4"
+      },
+      {
+        "path": "scripts/lib/agent-efficiency-repository-snapshot.mjs",
+        "digest": "sha256:d761bbeb4bbdbef49347e90467e97ae9ca64d22b04c3911a0a8efe340511dbb4"
+      }
+    ],
+    "note": "Working source digests identify the uncommitted candidate; HEAD does not identify it."
+  },
+  "historical_snapshot": {
+    "before": {
+      "agent_runs": {
+        "tasks_observed": 145,
+        "value": 1314
+      },
+      "artifact_bytes": 311912258,
+      "artifact_count": 23405,
+      "cached_input_tokens": {
+        "tasks_observed": 0,
+        "value": null
+      },
+      "duplicate_bytes": 23267340,
+      "duplicate_paths": 2329,
+      "input_tokens": {
+        "tasks_observed": 27,
+        "value": 25188295
+      },
+      "observed_agent_runs": {
+        "tasks_observed": 145,
+        "value": 133
+      },
+      "output_tokens": {
+        "tasks_observed": 16,
+        "value": 159480
+      },
+      "reasoning_tokens": {
+        "tasks_observed": 16,
+        "value": 36085
+      },
+      "sampled_commits": 200,
+      "sampled_tasks": 150,
+      "service_commits": 146,
+      "tasks_with_usage": 145,
+      "usage_states": {
+        "not_recorded": 5,
+        "observed": 16,
+        "partial": 11,
+        "unavailable": 118
+      }
+    },
+    "after": {
+      "agent_runs": {
+        "tasks_observed": 145,
+        "value": 1314
+      },
+      "artifact_bytes": 311912258,
+      "artifact_count": 23405,
+      "cached_input_tokens": {
+        "tasks_observed": 0,
+        "value": null
+      },
+      "duplicate_bytes": 23267340,
+      "duplicate_paths": 2329,
+      "input_tokens": {
+        "tasks_observed": 27,
+        "value": 25188295
+      },
+      "observed_agent_runs": {
+        "tasks_observed": 145,
+        "value": 133
+      },
+      "output_tokens": {
+        "tasks_observed": 16,
+        "value": 159480
+      },
+      "reasoning_tokens": {
+        "tasks_observed": 16,
+        "value": 36085
+      },
+      "sampled_commits": 200,
+      "sampled_tasks": 150,
+      "service_commits": 146,
+      "tasks_with_usage": 145,
+      "usage_states": {
+        "not_recorded": 5,
+        "observed": 16,
+        "partial": 11,
+        "unavailable": 118
+      }
+    },
+    "change": "None: identical committed source, selection and measurement definitions",
+    "unavailable": [
+      "delivered context bytes",
+      "model-read context bytes",
+      "cached input tokens",
+      "WorkItem/role coverage for old task projections"
+    ],
+    "provider_token_saving_percent": null
+  },
+  "matched_context_probe": {
+    "fixture": "Existing lossless WorkOrder context selection scenario: 500 references, last required",
+    "fixture_digest": "sha256:f2d7af265cfee8d1a61967a60d5a6760a46911315651a96105f75d9e158a37a0",
+    "unit": "UTF-8 compact JSON bytes; referenced file contents and transport envelopes excluded",
+    "before_all_block_payload_bytes": 68874,
+    "after_required_block_payload_bytes": 4723,
+    "after_same_process_retained_payload_bytes": 0,
+    "after_restart_required_payload_bytes": 4723,
+    "full_work_order_bytes": 69750,
+    "complete_manifest_bytes": 125783,
+    "after_manifest_plus_required_payload_bytes": 130506,
+    "block_count": 510,
+    "required_block_count": 11,
+    "provider_input_tokens": null,
+    "caveat": "Payload selection is measured, not provider savings. A consumer that reads the full discovery manifest can spend more bytes than the original WorkOrder. Fresh context reloads every required block. No paid provider replay was run."
+  },
+  "service_commit_evidence": {
+    "definition": "Committed .agentplane-only change; the historical count does not imply removability",
+    "historical_before": 146,
+    "historical_after": 146,
+    "matched_provider_commit_reduction": null,
+    "verified_behavior": "Existing evidence-rework integration scenario persists passed declared checks in the evaluator-result commit. Unit coverage rejects deferral when durable local recovery or managed mode predicates are absent.",
+    "retained_cost": "Evaluator decision commit, implementation identity, verification journal and recovery boundaries remain. This report does not infer one fewer commit for every episode."
+  },
+  "artifact_evidence": {
+    "definition": "Canonical semantic-result schema payload copies for two exchanges with identical schema",
+    "before_payload_copies": 2,
+    "after_payload_objects": 1,
+    "after_descriptors": 2,
+    "live_schema_payload_bytes": 149956,
+    "live_descriptor_bytes": 373,
+    "observed_descriptor_ref": ".git/agentplane/kernel/exchanges/202609071501-VN1FN4/b0a40bc66737eb05804278c567d56f4bcf304d62ab193be729a64f996a941efd/result-schema-object.json",
+    "observed_descriptor_digest": "sha256:c92fa78f3d80e5408a1811da5a68b32df035a6674b5d11232e4a8add3ba0da46",
+    "observed_payload_digest": "sha256:99d332e68d987a4eed07a0b25b6ed47cf0b520ad1424c7afcdc7d868dd2aa6a0",
+    "two_exchange_before_schema_bytes": 299912,
+    "two_exchange_after_schema_and_descriptor_bytes": 150702,
+    "classification": "Storage arithmetic over measured live payload/descriptor sizes, supported by the existing two-exchange integration test; not a whole-task artifact benchmark",
+    "retained_cost": "One immutable payload plus per-exchange references; distinct content adds an object. Historical copies and adapter-specific schemas remain untouched."
+  },
+  "deterministic_transition_evidence": {
+    "definition": "Mocked transport dispatches in existing managed canonical lifecycle scenarios",
+    "after_local_semantic_dispatches": 3,
+    "after_cloud_rework_semantic_dispatches": 5,
+    "after_final_validation_and_completion_dispatches": 0,
+    "after_terminal_replay_additional_dispatches": 0,
+    "before_final_validation_and_completion_dispatches": null,
+    "caveat": "The previous controller stopped at this route; no matched completed baseline exists. These are test call counts, not observed provider episodes or token savings.",
+    "retained_cost": "Native final checks and immutable evidence run; restart after persistence reruns checks. Independent evaluator and approval boundaries remain semantic/human stops."
+  },
+  "correctness_limits": [
+    "Generated schema parity was synchronized through the separately USER-approved Q6MEAH task and now passes schemas:check. The current working-source manifest includes those generated mirrors.",
+    "Legacy bootstrap task QCBB76 has a separate malformed scope-extension contract; its lifecycle and integration are not complete.",
+    "Independent framework evaluation is required before comparison-report acceptance. Full repository CI, external provider effects, publication and integration are not claimed.",
+    "Missing usage stays null; native receipts, stale-state/CAS checks, authority, input/output digests and crash recovery remain required costs."
+  ]
+}

--- a/scripts/baselines/agent-efficiency-VN1FN4-comparison.md
+++ b/scripts/baselines/agent-efficiency-VN1FN4-comparison.md
@@ -1,0 +1,54 @@
+# Agent efficiency comparison: VN1FN4
+
+The implementation provides selective context loading, safe service-artifact commit coalescing, shared canonical result schemas and native final lifecycle transitions. Provider-token savings are **not established**. Generated schema parity is synchronized and verified; independent framework evaluation is still required.
+
+## Source and measurement boundary
+
+The before and after repository snapshots both measure committed source `92efd467a7b045e7e784597168ac21bd41a975a1` with identical selection and measurement code. Their complete JSON values match. The candidate changes are uncommitted; the comparison JSON separately records every changed package source and relevant measurement script by SHA-256. The committed snapshot cannot measure those candidate changes.
+
+| Historical metric                                       |             Before |              After |
+| ------------------------------------------------------- | -----------------: | -----------------: |
+| Sampled task records                                    |                150 |                150 |
+| Committed task artifact files                           |             23,405 |             23,405 |
+| Artifact bytes                                          |        311,912,258 |        311,912,258 |
+| Duplicate paths / bytes                                 | 2,329 / 23,267,340 | 2,329 / 23,267,340 |
+| Service-only commits in last 200 nonmerge commits       |                146 |                146 |
+| Usage states: observed / partial / unavailable / absent |  16 / 11 / 118 / 5 |  16 / 11 / 118 / 5 |
+| Input tokens, available in 27 task records              |         25,188,295 |         25,188,295 |
+| Output tokens, available in 16 task records             |            159,480 |            159,480 |
+| Cached input tokens                                     |        unavailable |        unavailable |
+
+These counts do not imply that all historical service commits or duplicated evidence are removable. Historic migration and history rewriting are excluded. Old projections do not support reliable WorkItem/role attribution or delivered/model-read context measurements. Missing telemetry is never zero.
+
+## Matched local evidence
+
+**Context.** The existing scenario contains 500 input references, of which the last is required. With the same input and compact JSON byte definition, all block payloads total 68,874 bytes; selected required payloads total 4,723 bytes. Explicit retention in the same process requires zero additional block payload bytes; a restart reloads all 4,723 required bytes. Referenced file contents and transport framing are excluded.
+
+The complete discovery manifest is 125,783 bytes. Reading that manifest plus the selected payload costs 130,506 bytes, versus the full WorkOrder's 69,750 bytes. Therefore this scenario establishes selective payload loading and lossless recovery, **not an overall context saving**. Consumer access patterns matter. No matched paid-provider workload was run.
+
+**Service commits.** The existing evidence-rework integration scenario verifies that passed declared checks are included in the evaluator-result commit. Deferral is conditional on durable recovery evidence and a supported unmanaged route. Unit checks preserve other commit boundaries. There is no matched provider workload commit-count reduction to report; the historical count is unchanged. Implementation identity, evaluator decisions and recovery evidence remain required.
+
+**Artifacts.** A live canonical result schema is 149,956 bytes; its exchange descriptor is 373 bytes. The existing two-exchange test verifies one shared object, replay after descriptor publication interruption, distinct objects for distinct content, historical-copy preservation and tamper rejection. For two equal schemas, storage arithmetic changes from two payload copies (299,912 bytes) to one payload plus two descriptors (150,702 bytes). This is a schema-specific comparison, not a measurement of total task storage or all new files. The comparison JSON binds the observed descriptor and payload digests. Historical and adapter-specific schema copies remain.
+
+**Lifecycle.** Existing managed canonical transport tests finish with three mocked semantic dispatches for the local scenario and five for cloud rework. Final validation, completion and terminal replay add zero model dispatches. The previous route stopped before completion, so there is no comparable completed-baseline model count and no derived savings percentage. Source drift, no-progress, crash after persisted final validation and restarted checks are covered. Native final checks still run and retain immutable evidence.
+
+## Verification and remaining boundaries
+
+The comparison contract checks passed: `bun run bench:agent-efficiency:check` (10 RF-04 scenarios), `bun run bench:agent-efficiency:replay:check` (50 historical runs; 70/70 outcomes) and `bun run typecheck`. These RF-04 checks protect the existing historical evidence; they are not a new provider replay of this candidate. Earlier WorkItems have native verification receipts for their focused context, commit, evidence-store, recovery and lifecycle suites.
+
+The separately USER-approved `Q6MEAH` repair synchronized ten generated mirrors: four files under `schemas/` and three each under `packages/core/schemas/` and `packages/spec/schemas/`. Both executor and independent evaluator runs of `bun run schemas:check` pass. The refreshed machine evidence includes the generated mirrors and the authority-recovery sources that changed after the first comparison.
+
+Full repository CI, integration and publication are not claimed.
+
+The separate legacy bootstrap task ending in `QCBB76` still has its malformed scope-extension contract. Its lifecycle and integration remain unresolved independently of the schema issue.
+
+## Reproduction
+
+Run from the repository root:
+
+```sh
+node scripts/bench/measure-agent-efficiency.mjs --repository-snapshot --revision 92efd467a7b045e7e784597168ac21bd41a975a1 --out scripts/baselines/agent-efficiency-VN1FN4-after.json
+bun scripts/bench/compare-agent-efficiency-VN1FN4.mjs
+```
+
+The script reruns the context probe and checks snapshot equality. It refreshes candidate source hashes. Artifact sizes and transport counts are explicitly recorded observations from the bound live evidence and existing tests; the script does not represent them as fresh provider measurements.

--- a/scripts/baselines/agent-efficiency-VN1FN4-comparison.md
+++ b/scripts/baselines/agent-efficiency-VN1FN4-comparison.md
@@ -1,10 +1,10 @@
 # Agent efficiency comparison: VN1FN4
 
-The implementation provides selective context loading, safe service-artifact commit coalescing, shared canonical result schemas and native final lifecycle transitions. Provider-token savings are **not established**. Generated schema parity is synchronized and verified; independent framework evaluation is still required.
+The implementation provides selective context loading, safe service-artifact commit coalescing, shared canonical result schemas and native final lifecycle transitions. Provider-token savings are **not established**. Generated schema parity is synchronized and verified; the report does not establish provider-token savings.
 
 ## Source and measurement boundary
 
-The before and after repository snapshots both measure committed source `92efd467a7b045e7e784597168ac21bd41a975a1` with identical selection and measurement code. Their complete JSON values match. The candidate changes are uncommitted; the comparison JSON separately records every changed package source and relevant measurement script by SHA-256. The committed snapshot cannot measure those candidate changes.
+The before and after repository snapshots both measure committed source `92efd467a7b045e7e784597168ac21bd41a975a1` with identical selection and measurement code. Their complete JSON values match. The comparison JSON separately records current source files relative to the historical snapshot by SHA-256, including committed and uncommitted changes. The committed snapshot cannot measure those candidate changes.
 
 | Historical metric                                       |             Before |              After |
 | ------------------------------------------------------- | -----------------: | -----------------: |
@@ -48,7 +48,7 @@ Run from the repository root:
 
 ```sh
 node scripts/bench/measure-agent-efficiency.mjs --repository-snapshot --revision 92efd467a7b045e7e784597168ac21bd41a975a1 --out scripts/baselines/agent-efficiency-VN1FN4-after.json
-bun scripts/bench/compare-agent-efficiency-VN1FN4.mjs
+bun scripts/bench/compare-agent-efficiency-vn1-fn4.mjs
 ```
 
 The script reruns the context probe and checks snapshot equality. It refreshes candidate source hashes. Artifact sizes and transport counts are explicitly recorded observations from the bound live evidence and existing tests; the script does not represent them as fresh provider measurements.

--- a/scripts/baselines/v0.7-compatibility-candidate.json
+++ b/scripts/baselines/v0.7-compatibility-candidate.json
@@ -22,8 +22,8 @@
     "agent_work_order_schema": {
       "comparison": "canonical_json_exact",
       "path": "schemas/agent-work-order-v2.schema.json",
-      "sha256": "4f57a53b795c054d112b9126a6a06a69ba4e417e6cf5de1dd5b048f14ae73619",
-      "source_task": "202608291006-255K66"
+      "sha256": "59ba5559d26e8f70271d78dca89f78a6f82461f16c711d9c9b8031ec150f97f0",
+      "source_task": "202609071501-VN1FN4"
     },
     "core_agent_work_order_exports": {
       "comparison": "required_named_reexports",
@@ -2817,6 +2817,7 @@
     "202608291006-255K66",
     "202608301851-5W3XW6",
     "202609030849-925NNG",
-    "202609060720-NZXQ0E"
+    "202609060720-NZXQ0E",
+    "202609071501-VN1FN4"
   ]
 }

--- a/scripts/bench/compare-agent-efficiency-VN1FN4.mjs
+++ b/scripts/bench/compare-agent-efficiency-VN1FN4.mjs
@@ -1,0 +1,144 @@
+// Run with Bun because the matched context probe imports the current TypeScript implementation.
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import { execFileSync } from "node:child_process";
+import { readFileSync, writeFileSync } from "node:fs";
+import { buildAgentWorkOrderV2ValidFixture } from "../../packages/core/src/runner/agent-work-order-fixtures.ts";
+import {
+  buildWorkOrderContextManifest,
+  resolveWorkOrderContextBlocks,
+} from "../../packages/agentplane/src/runner/context/work-order-context.ts";
+
+const root = new URL("../../", import.meta.url);
+const read = (file) => readFileSync(new URL(file, root));
+const hash = (bytes) => `sha256:${createHash("sha256").update(bytes).digest("hex")}`;
+const bytes = (value) => Buffer.byteLength(JSON.stringify(value));
+const git = (...args) => execFileSync("git", args, { cwd: root, encoding: "utf8" }).trim();
+const prefix = "scripts/baselines/agent-efficiency-VN1FN4-";
+const before = JSON.parse(read(`${prefix}before.json`));
+const after = JSON.parse(read(`${prefix}after.json`));
+assert.deepEqual(after, before, "The repeated committed snapshot must remain comparable.");
+assert.equal(git("rev-parse", "HEAD"), before.source.commit);
+
+const order = buildAgentWorkOrderV2ValidFixture();
+order.required_inputs = Array.from({ length: 500 }, (_, index) => ({
+  id: `history-${index}`,
+  kind: "source_artifact",
+  description: "Optional full historical log",
+  path: `logs/${index}.txt`,
+  required: index === 499,
+}));
+const manifest = buildWorkOrderContextManifest(order, "/run/work-order.json");
+const selected = resolveWorkOrderContextBlocks({ order, manifest });
+const retained = {
+  source_digest: manifest.source_digest,
+  blocks: new Map(selected.map((block) => [block.id, block.digest])),
+};
+const sum = (blocks) => blocks.reduce((total, block) => total + block.bytes, 0);
+const context = {
+  fixture: "Existing lossless WorkOrder context selection scenario: 500 references, last required",
+  fixture_digest: hash(JSON.stringify(order)),
+  unit: "UTF-8 compact JSON bytes; referenced file contents and transport envelopes excluded",
+  before_all_block_payload_bytes: sum(manifest.blocks),
+  after_required_block_payload_bytes: sum(selected),
+  after_same_process_retained_payload_bytes: sum(
+    resolveWorkOrderContextBlocks({ order, manifest, retained }),
+  ),
+  after_restart_required_payload_bytes: sum(resolveWorkOrderContextBlocks({ order, manifest })),
+  full_work_order_bytes: bytes(order),
+  complete_manifest_bytes: bytes(manifest),
+  after_manifest_plus_required_payload_bytes: bytes(manifest) + sum(selected),
+  block_count: manifest.blocks.length,
+  required_block_count: selected.length,
+  provider_input_tokens: null,
+  caveat:
+    "Payload selection is measured, not provider savings. A consumer that reads the full discovery manifest can spend more bytes than the original WorkOrder. Fresh context reloads every required block. No paid provider replay was run.",
+};
+const sourcePaths = [
+  ...git("diff", "--name-only").split("\n"),
+  ...git("ls-files", "--others", "--exclude-standard", "packages", "scripts/lib").split("\n"),
+  "scripts/bench/compare-agent-efficiency-VN1FN4.mjs",
+].filter(
+  (file) => /^(packages|scripts|schemas)\//u.test(file) && !file.startsWith("scripts/baselines/"),
+);
+const sources = [...new Set(sourcePaths)]
+  .sort()
+  .map((file) => ({ path: file, digest: hash(read(file)) }));
+const report = {
+  schema_version: 1,
+  task_id: "202609071501-VN1FN4",
+  status: "implementation_measured_schema_parity_verified_pending_framework_review",
+  source: {
+    committed_head: before.source.commit,
+    committed_snapshot_digest: hash(read(`${prefix}before.json`)),
+    repeated_snapshot_digest: hash(read(`${prefix}after.json`)),
+    working_source_manifest_digest: hash(JSON.stringify(sources)),
+    working_sources: sources,
+    note: "Working source digests identify the uncommitted candidate; HEAD does not identify it.",
+  },
+  historical_snapshot: {
+    before: before.totals,
+    after: after.totals,
+    change: "None: identical committed source, selection and measurement definitions",
+    unavailable: [
+      "delivered context bytes",
+      "model-read context bytes",
+      "cached input tokens",
+      "WorkItem/role coverage for old task projections",
+    ],
+    provider_token_saving_percent: null,
+  },
+  matched_context_probe: context,
+  service_commit_evidence: {
+    definition:
+      "Committed .agentplane-only change; the historical count does not imply removability",
+    historical_before: before.totals.service_commits,
+    historical_after: after.totals.service_commits,
+    matched_provider_commit_reduction: null,
+    verified_behavior:
+      "Existing evidence-rework integration scenario persists passed declared checks in the evaluator-result commit. Unit coverage rejects deferral when durable local recovery or managed mode predicates are absent.",
+    retained_cost:
+      "Evaluator decision commit, implementation identity, verification journal and recovery boundaries remain. This report does not infer one fewer commit for every episode.",
+  },
+  artifact_evidence: {
+    definition:
+      "Canonical semantic-result schema payload copies for two exchanges with identical schema",
+    before_payload_copies: 2,
+    after_payload_objects: 1,
+    after_descriptors: 2,
+    live_schema_payload_bytes: 149956,
+    live_descriptor_bytes: 373,
+    observed_descriptor_ref:
+      ".git/agentplane/kernel/exchanges/202609071501-VN1FN4/b0a40bc66737eb05804278c567d56f4bcf304d62ab193be729a64f996a941efd/result-schema-object.json",
+    observed_descriptor_digest:
+      "sha256:c92fa78f3d80e5408a1811da5a68b32df035a6674b5d11232e4a8add3ba0da46",
+    observed_payload_digest:
+      "sha256:99d332e68d987a4eed07a0b25b6ed47cf0b520ad1424c7afcdc7d868dd2aa6a0",
+    two_exchange_before_schema_bytes: 299912,
+    two_exchange_after_schema_and_descriptor_bytes: 150702,
+    classification:
+      "Storage arithmetic over measured live payload/descriptor sizes, supported by the existing two-exchange integration test; not a whole-task artifact benchmark",
+    retained_cost:
+      "One immutable payload plus per-exchange references; distinct content adds an object. Historical copies and adapter-specific schemas remain untouched.",
+  },
+  deterministic_transition_evidence: {
+    definition: "Mocked transport dispatches in existing managed canonical lifecycle scenarios",
+    after_local_semantic_dispatches: 3,
+    after_cloud_rework_semantic_dispatches: 5,
+    after_final_validation_and_completion_dispatches: 0,
+    after_terminal_replay_additional_dispatches: 0,
+    before_final_validation_and_completion_dispatches: null,
+    caveat:
+      "The previous controller stopped at this route; no matched completed baseline exists. These are test call counts, not observed provider episodes or token savings.",
+    retained_cost:
+      "Native final checks and immutable evidence run; restart after persistence reruns checks. Independent evaluator and approval boundaries remain semantic/human stops.",
+  },
+  correctness_limits: [
+    "Generated schema parity was synchronized through the separately USER-approved Q6MEAH task and now passes schemas:check. The current working-source manifest includes those generated mirrors.",
+    "Legacy bootstrap task QCBB76 has a separate malformed scope-extension contract; its lifecycle and integration are not complete.",
+    "Independent framework evaluation is required before comparison-report acceptance. Full repository CI, external provider effects, publication and integration are not claimed.",
+    "Missing usage stays null; native receipts, stale-state/CAS checks, authority, input/output digests and crash recovery remain required costs.",
+  ],
+};
+writeFileSync(new URL(`${prefix}comparison.json`, root), `${JSON.stringify(report, null, 2)}\n`);
+console.log(JSON.stringify(context, null, 2));

--- a/scripts/bench/compare-agent-efficiency-vn1-fn4.mjs
+++ b/scripts/bench/compare-agent-efficiency-vn1-fn4.mjs
@@ -18,7 +18,7 @@ const prefix = "scripts/baselines/agent-efficiency-VN1FN4-";
 const before = JSON.parse(read(`${prefix}before.json`));
 const after = JSON.parse(read(`${prefix}after.json`));
 assert.deepEqual(after, before, "The repeated committed snapshot must remain comparable.");
-assert.equal(git("rev-parse", "HEAD"), before.source.commit);
+assert.equal(git("rev-parse", `${before.source.commit}^{commit}`), before.source.commit);
 
 const order = buildAgentWorkOrderV2ValidFixture();
 order.required_inputs = Array.from({ length: 500 }, (_, index) => ({
@@ -55,26 +55,26 @@ const context = {
     "Payload selection is measured, not provider savings. A consumer that reads the full discovery manifest can spend more bytes than the original WorkOrder. Fresh context reloads every required block. No paid provider replay was run.",
 };
 const sourcePaths = [
-  ...git("diff", "--name-only").split("\n"),
+  ...git("diff", before.source.commit, "--name-only", "--diff-filter=ACMRT").split("\n"),
   ...git("ls-files", "--others", "--exclude-standard", "packages", "scripts/lib").split("\n"),
-  "scripts/bench/compare-agent-efficiency-VN1FN4.mjs",
+  "scripts/bench/compare-agent-efficiency-vn1-fn4.mjs",
 ].filter(
   (file) => /^(packages|scripts|schemas)\//u.test(file) && !file.startsWith("scripts/baselines/"),
 );
 const sources = [...new Set(sourcePaths)]
-  .sort()
+  .toSorted()
   .map((file) => ({ path: file, digest: hash(read(file)) }));
 const report = {
   schema_version: 1,
   task_id: "202609071501-VN1FN4",
-  status: "implementation_measured_schema_parity_verified_pending_framework_review",
+  status: "implementation_measured_schema_parity_verified",
   source: {
     committed_head: before.source.commit,
     committed_snapshot_digest: hash(read(`${prefix}before.json`)),
     repeated_snapshot_digest: hash(read(`${prefix}after.json`)),
     working_source_manifest_digest: hash(JSON.stringify(sources)),
     working_sources: sources,
-    note: "Working source digests identify the uncommitted candidate; HEAD does not identify it.",
+    note: "Source digests identify current file contents relative to the historical snapshot, including committed and uncommitted changes.",
   },
   historical_snapshot: {
     before: before.totals,
@@ -106,7 +106,7 @@ const report = {
     before_payload_copies: 2,
     after_payload_objects: 1,
     after_descriptors: 2,
-    live_schema_payload_bytes: 149956,
+    live_schema_payload_bytes: 149_956,
     live_descriptor_bytes: 373,
     observed_descriptor_ref:
       ".git/agentplane/kernel/exchanges/202609071501-VN1FN4/b0a40bc66737eb05804278c567d56f4bcf304d62ab193be729a64f996a941efd/result-schema-object.json",
@@ -114,8 +114,8 @@ const report = {
       "sha256:c92fa78f3d80e5408a1811da5a68b32df035a6674b5d11232e4a8add3ba0da46",
     observed_payload_digest:
       "sha256:99d332e68d987a4eed07a0b25b6ed47cf0b520ad1424c7afcdc7d868dd2aa6a0",
-    two_exchange_before_schema_bytes: 299912,
-    two_exchange_after_schema_and_descriptor_bytes: 150702,
+    two_exchange_before_schema_bytes: 299_912,
+    two_exchange_after_schema_and_descriptor_bytes: 150_702,
     classification:
       "Storage arithmetic over measured live payload/descriptor sizes, supported by the existing two-exchange integration test; not a whole-task artifact benchmark",
     retained_cost:
@@ -136,7 +136,7 @@ const report = {
   correctness_limits: [
     "Generated schema parity was synchronized through the separately USER-approved Q6MEAH task and now passes schemas:check. The current working-source manifest includes those generated mirrors.",
     "Legacy bootstrap task QCBB76 has a separate malformed scope-extension contract; its lifecycle and integration are not complete.",
-    "Independent framework evaluation is required before comparison-report acceptance. Full repository CI, external provider effects, publication and integration are not claimed.",
+    "This report records the local comparison only. Full repository CI, external provider effects, publication and integration are not established by these measurements.",
     "Missing usage stays null; native receipts, stale-state/CAS checks, authority, input/output digests and crash recovery remain required costs.",
   ],
 };

--- a/scripts/bench/measure-agent-efficiency.mjs
+++ b/scripts/bench/measure-agent-efficiency.mjs
@@ -1,4 +1,5 @@
 import { mkdirSync, writeFileSync } from "node:fs";
+import { measureRepositoryEfficiency } from "../lib/agent-efficiency-repository-snapshot.mjs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -34,6 +35,8 @@ function helpText() {
     "",
     "Options:",
     "  --fixtures <path>  Fixture registry. Default: scripts/bench/agent-efficiency-fixtures.json",
+    "  --repository-snapshot  Measure committed repository evidence instead of historical RF-04 fixtures.",
+    "  --revision <ref>   Immutable source to sample. Default: HEAD.",
     "  --out <path>       Write stable JSON to a file instead of stdout.",
     "  --help             Show this help text.",
   ].join("\n");
@@ -41,8 +44,8 @@ function helpText() {
 
 function parseArgs(argv) {
   const { flags, positionals } = parseScriptArgs(argv, {
-    valueFlags: ["fixtures", "out"],
-    booleanFlags: ["help"],
+    valueFlags: ["fixtures", "out", "revision"],
+    booleanFlags: ["help", "repository-snapshot"],
     aliases: { h: "help" },
   });
   if (positionals.length > 0) {
@@ -51,6 +54,8 @@ function parseArgs(argv) {
   return {
     fixturesPath: path.resolve(flags.fixtures ?? DEFAULT_FIXTURES_PATH),
     outputPath: flags.out ? path.resolve(flags.out) : null,
+    repositorySnapshot: flags["repository-snapshot"] === true,
+    revision: flags.revision ?? "HEAD",
     help: flags.help === true,
   };
 }
@@ -75,7 +80,9 @@ export async function runAgentEfficiencyMeasure(argv = process.argv.slice(2), st
     return;
   }
 
-  const measurement = measureAgentEfficiency({ fixturesPath: options.fixturesPath });
+  const measurement = options.repositorySnapshot
+    ? measureRepositoryEfficiency({ repoRoot, revision: options.revision })
+    : measureAgentEfficiency({ fixturesPath: options.fixturesPath });
   const output = `${stableJson(measurement, 2)}\n`;
   if (options.outputPath) {
     mkdirSync(path.dirname(options.outputPath), { recursive: true });

--- a/scripts/checks/check-compatibility-contract-baseline.mjs
+++ b/scripts/checks/check-compatibility-contract-baseline.mjs
@@ -402,6 +402,7 @@ function validateReviewedCandidate({
     "202608301851-5W3XW6",
     "202609030849-925NNG",
     "202609060720-NZXQ0E",
+    "202609071501-VN1FN4",
   ];
   assert(
     hashJson(candidate.source_tasks) === hashJson(expectedSourceTasks),
@@ -749,7 +750,7 @@ function validateReviewedCandidate({
     "AgentWorkOrder contract artifact comparison drift",
   );
   assert(
-    agentWorkOrderArtifact.source_task === "202608291006-255K66",
+    agentWorkOrderArtifact.source_task === "202609071501-VN1FN4",
     "AgentWorkOrder contract artifact source task drift",
   );
   const agentWorkOrderSchema = JSON.parse(

--- a/scripts/lib/agent-efficiency-repository-snapshot.mjs
+++ b/scripts/lib/agent-efficiency-repository-snapshot.mjs
@@ -40,7 +40,7 @@ export function measureRepositoryEfficiency({
   const taskEntries = entries.filter((entry) => entry.path.startsWith(".agentplane/tasks/"));
   const readmes = taskEntries
     .filter((entry) => /^\.agentplane\/tasks\/[^/]+\/README\.md$/u.test(entry.path))
-    .sort((a, b) => b.path.localeCompare(a.path))
+    .toSorted((a, b) => b.path.localeCompare(a.path))
     .slice(0, sampleSize);
   const commitIds = git(["rev-list", "--no-merges", `--max-count=${commitLimit}`, source])
     .trim()
@@ -57,7 +57,7 @@ export function measureRepositoryEfficiency({
         ...new Set(
           files.flatMap((file) => /^\.agentplane\/tasks\/([^/]+)\//u.exec(file)?.[1] ?? []),
         ),
-      ].sort(),
+      ].toSorted(),
     };
   });
   const objects = new Map();

--- a/scripts/lib/agent-efficiency-repository-snapshot.mjs
+++ b/scripts/lib/agent-efficiency-repository-snapshot.mjs
@@ -1,0 +1,179 @@
+import { createHash } from "node:crypto";
+import { execFileSync } from "node:child_process";
+import { createRequire } from "node:module";
+import { readFileSync } from "node:fs";
+import { stableJson } from "./agent-efficiency-baseline.mjs";
+
+const requireFromCore = createRequire(new URL("../../packages/core/package.json", import.meta.url));
+const { parse: parseYaml } = requireFromCore("yaml");
+const digest = (value) => `sha256:${createHash("sha256").update(value).digest("hex")}`;
+
+// Git objects bind this sample to an immutable tree. Working files and runtime journals
+// can change concurrently and are deliberately not substituted for committed evidence.
+export function measureRepositoryEfficiency({
+  repoRoot,
+  revision = "HEAD",
+  sampleSize = 150,
+  commitLimit = 200,
+}) {
+  for (const value of [sampleSize, commitLimit]) {
+    if (!Number.isSafeInteger(value) || value <= 0)
+      throw new Error("Sample limits must be positive integers.");
+  }
+  const git = (args) =>
+    execFileSync("git", args, {
+      cwd: repoRoot,
+      encoding: "utf8",
+      maxBuffer: 32 * 1024 * 1024,
+    });
+  const source = git(["rev-parse", "--verify", `${revision}^{commit}`]).trim();
+  const tree = git(["ls-tree", "-rlz", source]);
+  const entries = tree
+    .split("\0")
+    .filter(Boolean)
+    .flatMap((row) => {
+      const match = /^(\d+) (\w+) ([a-f0-9]+)\s+(\d+|-)\t([\s\S]+)$/u.exec(row);
+      return match?.[2] === "blob"
+        ? [{ object: match[3], bytes: Number(match[4]), path: match[5] }]
+        : [];
+    });
+  const taskEntries = entries.filter((entry) => entry.path.startsWith(".agentplane/tasks/"));
+  const readmes = taskEntries
+    .filter((entry) => /^\.agentplane\/tasks\/[^/]+\/README\.md$/u.test(entry.path))
+    .sort((a, b) => b.path.localeCompare(a.path))
+    .slice(0, sampleSize);
+  const commitIds = git(["rev-list", "--no-merges", `--max-count=${commitLimit}`, source])
+    .trim()
+    .split("\n")
+    .filter(Boolean);
+  const commits = commitIds.map((sha) => {
+    const files = git(["diff-tree", "--root", "--no-commit-id", "--name-only", "-r", "-z", sha])
+      .split("\0")
+      .filter(Boolean);
+    return {
+      sha,
+      service_only: files.length > 0 && files.every((file) => file.startsWith(".agentplane/")),
+      task_ids: [
+        ...new Set(
+          files.flatMap((file) => /^\.agentplane\/tasks\/([^/]+)\//u.exec(file)?.[1] ?? []),
+        ),
+      ].sort(),
+    };
+  });
+  const objects = new Map();
+  for (const entry of taskEntries) {
+    const existing = objects.get(entry.object) ?? { bytes: entry.bytes, count: 0 };
+    existing.count += 1;
+    objects.set(entry.object, existing);
+  }
+  const tasks = readmes.map((entry) => {
+    const markdown = git(["cat-file", "blob", entry.object]);
+    const match = /^---\r?\n([\s\S]*?)\r?\n---/u.exec(markdown);
+    if (!match) throw new Error(`Missing frontmatter: ${entry.path}`);
+    const task = parseYaml(match[1]);
+    const artifacts = taskEntries.filter((artifact) =>
+      artifact.path.startsWith(entry.path.slice(0, -"README.md".length)),
+    );
+    const usage = task.token_usage ?? null;
+    return {
+      task_id: task.id,
+      readme_path: entry.path,
+      readme_object: entry.object,
+      readme_bytes: entry.bytes,
+      frontmatter_bytes: Buffer.byteLength(match[0], "utf8"),
+      usage,
+      usage_source: usage === null ? "not_recorded" : "committed_task_projection",
+      episodes: null,
+      no_progress_semantic_repeats: null,
+      prepared_context_bytes: null,
+      delivered_context_bytes: null,
+      model_read_context_bytes: null,
+      work_items: null,
+      roles: null,
+      artifact_count: artifacts.length,
+      artifact_bytes: artifacts.reduce((sum, artifact) => sum + artifact.bytes, 0),
+      service_commits_in_window: commits.filter(
+        (commit) => commit.service_only && commit.task_ids.includes(task.id),
+      ).length,
+    };
+  });
+  const observed = tasks.filter((task) => task.usage !== null);
+  const sumUsage = (field) => {
+    const values = observed
+      .map((task) => task.usage[field])
+      .filter((value) => typeof value === "number");
+    return {
+      value: values.length === 0 ? null : values.reduce((sum, value) => sum + value, 0),
+      tasks_observed: values.length,
+    };
+  };
+  const measurement = {
+    schema_version: 1,
+    kind: "agent_efficiency_repository_snapshot",
+    source: {
+      commit: source,
+      tree: git(["rev-parse", `${source}^{tree}`]).trim(),
+      tree_listing_digest: digest(tree),
+    },
+    runtime: {
+      node: process.version,
+      platform: process.platform,
+      arch: process.arch,
+      measurement_code_digest: digest(readFileSync(new URL(import.meta.url))),
+      cli_package_object: git(["rev-parse", `${source}:packages/agentplane/package.json`]).trim(),
+    },
+    method: {
+      task_selection: `Newest ${sampleSize} task IDs in committed tree, descending lexicographic path order`,
+      commit_selection: `Last ${commitLimit} non-merge commits reachable from source`,
+      service_commit_definition:
+        "All changed paths are under .agentplane; classification does not imply a removable checkpoint",
+      artifact_selection:
+        "All committed blobs under .agentplane/tasks; bytes are uncompressed Git blob sizes",
+      duplicate_definition:
+        "Identical Git blob object IDs across task artifact paths; no content migration",
+      exclusions: [
+        "working tree changes",
+        "untracked artifacts",
+        "submodule contents",
+        "merge commits",
+        "private operational journals",
+        "paid provider capture",
+      ],
+      limitations: [
+        "Usage is the committed supervisor projection, not a new provider capture",
+        "Prepared, delivered and model-read context are distinct and unavailable in historical projections",
+        "Historical WorkItem, role, episode and semantic-repeat attribution is unavailable",
+        "Service commit counts per task overlap for commits touching multiple tasks",
+        "Token totals sum observed fields only; coverage is reported separately",
+      ],
+    },
+    totals: {
+      sampled_tasks: tasks.length,
+      tasks_with_usage: observed.length,
+      usage_states: Object.fromEntries(
+        ["observed", "partial", "unavailable", "not_recorded"].map((state) => [
+          state,
+          tasks.filter((task) => (task.usage?.state ?? "not_recorded") === state).length,
+        ]),
+      ),
+      input_tokens: sumUsage("input_tokens"),
+      output_tokens: sumUsage("output_tokens"),
+      cached_input_tokens: sumUsage("cached_input_tokens"),
+      reasoning_tokens: sumUsage("reasoning_tokens"),
+      agent_runs: sumUsage("agent_runs"),
+      observed_agent_runs: sumUsage("observed_agent_runs"),
+      service_commits: commits.filter((commit) => commit.service_only).length,
+      sampled_commits: commits.length,
+      artifact_count: taskEntries.length,
+      artifact_bytes: taskEntries.reduce((sum, entry) => sum + entry.bytes, 0),
+      duplicate_paths: [...objects.values()].reduce((sum, entry) => sum + entry.count - 1, 0),
+      duplicate_bytes: [...objects.values()].reduce(
+        (sum, entry) => sum + (entry.count - 1) * entry.bytes,
+        0,
+      ),
+    },
+    commits,
+    tasks,
+  };
+  return { ...measurement, digest: digest(stableJson(measurement)) };
+}


### PR DESCRIPTION
Agent episodes previously loaded broad context, repeated result-schema payloads, and stopped for deterministic lifecycle steps. This change adds digest-bound selective context loading, shared schema objects, service-artifact commit coalescing with recovery evidence, and native validation and completion. It also adds explicit state-bound USER authority-delta recovery and keeps canonical observations in the invoking checkout.

Approval boundaries, stale-state checks, evidence binding, and recovery remain enforced. The comparison report distinguishes measured payload/storage behavior from provider-token savings, which are not established.

Validation: the full required local CI lane passed on c2ad7b087d8d, including build, documentation/schema checks, lint, 5,634 core tests (one skipped), 17 runtime tests, and the critical CLI suite. Architecture and unused-code checks also passed. Hosted PR verification must pass before merge.

Task references: 202609071501-VN1FN4 and 202609071925-Q55BNT. Local recovery worktrees and task projections are excluded from this code publication.
