### PR TITLE
🚧 MGB383 task: Harden the post-release evidence close-tail under branch protection for GitHub issue #4848 [202609111340-MGB383]

### DIFF
--- a/.agentplane/tasks/202609111340-MGB383/README.md
+++ b/.agentplane/tasks/202609111340-MGB383/README.md
@@ -4,7 +4,7 @@ title: "Harden the post-release evidence close-tail under branch protection for 
 status: "DOING"
 priority: "high"
 owner: "CODER"
-revision: 6
+revision: 8
 origin:
   system: "manual"
 depends_on: []
@@ -103,10 +103,17 @@ execution_contract:
       - "scripts/workflow/verify-release-evidence-pr.mjs"
   observed:
     authority_violations: []
-    changed_components: []
-    changed_paths: []
+    changed_components:
+      - "packages/agentplane"
+      - "scripts"
+    changed_paths:
+      - "packages/agentplane/src/commands/release/verify-release-evidence-pr-script.test.ts"
+      - "scripts/workflow/verify-release-evidence-pr.mjs"
     external_effects: []
-    repository_effects: []
+    repository_effects:
+      - "repository_write"
+      - "source_code"
+      - "tests"
     verification_results: []
   reason_codes:
     - "agent_preferred_branch_pr"
@@ -157,12 +164,13 @@ execution_contract:
           implementation_uncertainty: "bounded"
           requirements_uncertainty: "bounded"
           reversibility: "recovery_required"
-      digest: "sha256:898dd4ed3767290fadaa1eac967d14e23359c4dfa6135d24e3d6a10f0e5b5fe7"
+      digest: "sha256:0647a1831b3858bc8e3ee50c75796d33ba932b0aee02b1200a4b3ccc3773a96e"
       escalation_reasons:
         - "central_component:.github/workflows/publish.yml"
         - "central_component:scripts/lib/next-development-version.mjs"
         - "central_component:scripts/release/open-next-development-version.mjs"
         - "central_component:scripts/workflow/verify-release-evidence-pr.mjs"
+        - "central_path:scripts/workflow/verify-release-evidence-pr.mjs"
         - "effect_ci"
         - "effect_release_metadata"
         - "external_effect_requires_real_e2e"
@@ -173,10 +181,17 @@ execution_contract:
         - "runtime"
         - "cli"
       observed:
-        changed_components: []
-        changed_files: []
+        changed_components:
+          - "packages/agentplane"
+          - "scripts"
+        changed_files:
+          - "packages/agentplane/src/commands/release/verify-release-evidence-pr-script.test.ts"
+          - "scripts/workflow/verify-release-evidence-pr.mjs"
         external_effects: []
-        repository_effects: []
+        repository_effects:
+          - "repository_write"
+          - "source_code"
+          - "tests"
       phase: "task"
       policy_floor:
         monotonic_strengthening: true
@@ -213,8 +228,8 @@ execution_contract:
       - "repository_effect:tests"
       - "task_outcome"
 commit:
-  hash: "d47adfe6fb060256ad54bf95ff116a1a60b26b2d"
-  message: "🔒 MGB383 release: require native PR verification"
+  hash: "6f127b5ad60646d6233d08ec333b16035bc40279"
+  message: "🚧 MGB383 task: apply external agent result"
 comments:
   -
     author: "CODER"
@@ -234,8 +249,15 @@ events:
     from: "DOING"
     to: "DOING"
     commit: "d47adfe6fb060256ad54bf95ff116a1a60b26b2d"
+  -
+    type: "status"
+    at: "2026-09-11T18:51:27.640Z"
+    author: "CODER"
+    from: "DOING"
+    to: "DOING"
+    commit: "6f127b5ad60646d6233d08ec333b16035bc40279"
 doc_version: 3
-doc_updated_at: "2026-09-11T18:49:54.166Z"
+doc_updated_at: "2026-09-11T18:51:27.640Z"
 doc_updated_by: "CODER"
 description: "GitHub issue #4848 is still relevant on current main. The release follow-up stages version surfaces but does not refresh or stage scripts/baselines/v0.7-compatibility-candidate.json, and verify-release-evidence-pr still publishes a synthetic PR verification check after workflow_dispatch instead of obtaining a native pull_request status accepted by branch protection. Make the generated next-development diff Prettier-clean, refresh and stage the compatibility candidate whenever the version surface advances, add a pre-push/pre-PR contract gate, and drive the close-tail through a native pull_request verification with regression coverage for action_required or empty native rollup. Do not weaken branch protection or use admin bypass. Issue: https://github.com/basilisk-labs/agentplane/issues/4848"
 sections:
@@ -594,7 +616,7 @@ extensions:
       revision: 1
       schema_version: 1
       task_id: "202609111340-MGB383"
-    event_cursor: 4
+    event_cursor: 6
     final_validation: null
     id: "202609111340-MGB383"
     intent:
@@ -614,9 +636,9 @@ extensions:
     lifecycle: "ACTIVE"
     plan_amendments: []
     plan_history: []
-    revision: 6
+    revision: 8
     schema_version: 1
-    updated_at: "2026-09-11T18:49:54.166Z"
+    updated_at: "2026-09-11T18:51:27.640Z"
     work_items:
       work-native-pr-verification:
         attempt: 0
@@ -650,6 +672,30 @@ extensions:
     events: []
     leases: []
     mutation_receipts:
+      compatibility:sha256:0d9670b99051a55edbb7ac41ecacbe142f74f39da97aca1c64b1642e23bfd5b9:
+        aggregate_digest: "sha256:c906cea1410c0d86c4d5098be9f85653651e5832e4f972f8b53192897a5ec49b"
+        event:
+          actor_id: "agentplane"
+          at: "2026-09-11T18:51:27.640Z"
+          cause_refs:
+            - "compatibility_projection_mutation"
+          entity: "task"
+          from: "ACTIVE"
+          id: "event_1a4a8f024abcae03d5aaf251"
+          mutation_id: "compatibility:sha256:0d9670b99051a55edbb7ac41ecacbe142f74f39da97aca1c64b1642e23bfd5b9"
+          plan_digest: "sha256:561ecf6a31e5da0501ae93d26c9f884af477f46a4b17250d7c9b5d40ae1f24fa"
+          plan_revision: 1
+          repository_fingerprint: null
+          schema_version: 1
+          task_id: "202609111340-MGB383"
+          task_revision: 6
+          to: "ACTIVE"
+          work_item_id: null
+        mutation_id: "compatibility:sha256:0d9670b99051a55edbb7ac41ecacbe142f74f39da97aca1c64b1642e23bfd5b9"
+        next_revision: 7
+        previous_revision: 6
+        schema_version: 1
+        task_id: "202609111340-MGB383"
       compatibility:sha256:2ee8880913ca100651457df7cf734a1ea9d8f8ce32b1b2a291244f23ac254070:
         aggregate_digest: "sha256:d3c1f46829b97ab9c3494a730223f741349fbaa78d1a82a958196a45be714d45"
         event:
@@ -746,9 +792,35 @@ extensions:
         previous_revision: 5
         schema_version: 1
         task_id: "202609111340-MGB383"
+      compatibility:sha256:e0846c7149ff8c2d65ff0249273e12693103117bce14ad60bcfbb670102b06ba:
+        aggregate_digest: "sha256:2be570a486cd1fcba1ec097b3bef53b06d59ae1abb7f15bd167b1f708c8f7764"
+        event:
+          actor_id: "agentplane"
+          at: "2026-09-11T18:51:27.640Z"
+          cause_refs:
+            - "compatibility_projection_mutation"
+          entity: "task"
+          from: "ACTIVE"
+          id: "event_3591c58a2baee3785f755791"
+          mutation_id: "compatibility:sha256:e0846c7149ff8c2d65ff0249273e12693103117bce14ad60bcfbb670102b06ba"
+          plan_digest: "sha256:561ecf6a31e5da0501ae93d26c9f884af477f46a4b17250d7c9b5d40ae1f24fa"
+          plan_revision: 1
+          repository_fingerprint: null
+          schema_version: 1
+          task_id: "202609111340-MGB383"
+          task_revision: 7
+          to: "ACTIVE"
+          work_item_id: null
+        mutation_id: "compatibility:sha256:e0846c7149ff8c2d65ff0249273e12693103117bce14ad60bcfbb670102b06ba"
+        next_revision: 8
+        previous_revision: 7
+        schema_version: 1
+        task_id: "202609111340-MGB383"
     pending_effects: []
     retry_budgets: []
     schema_version: 1
+  implementation_commit:
+    hash: "6f127b5ad60646d6233d08ec333b16035bc40279"
   task_execution_context:
     base_ref: "main"
     base_sha: "f774282d4a6ef8ce7da5bc08c8e2fd9abb99303d"

--- a/.agentplane/tasks/202609111340-MGB383/README.md
+++ b/.agentplane/tasks/202609111340-MGB383/README.md
@@ -4,7 +4,7 @@ title: "Harden the post-release evidence close-tail under branch protection for 
 status: "DOING"
 priority: "high"
 owner: "CODER"
-revision: 5
+revision: 6
 origin:
   system: "manual"
 depends_on: []
@@ -212,7 +212,9 @@ execution_contract:
       - "repository_effect:source_code"
       - "repository_effect:tests"
       - "task_outcome"
-commit: null
+commit:
+  hash: "d47adfe6fb060256ad54bf95ff116a1a60b26b2d"
+  message: "🔒 MGB383 release: require native PR verification"
 comments:
   -
     author: "CODER"
@@ -225,8 +227,15 @@ events:
     from: "DOING"
     to: "DOING"
     note: "Start: continue branch_pr task in the dedicated task worktree."
+  -
+    type: "status"
+    at: "2026-09-11T18:49:54.166Z"
+    author: "CODER"
+    from: "DOING"
+    to: "DOING"
+    commit: "d47adfe6fb060256ad54bf95ff116a1a60b26b2d"
 doc_version: 3
-doc_updated_at: "2026-09-11T18:45:55.083Z"
+doc_updated_at: "2026-09-11T18:49:54.166Z"
 doc_updated_by: "CODER"
 description: "GitHub issue #4848 is still relevant on current main. The release follow-up stages version surfaces but does not refresh or stage scripts/baselines/v0.7-compatibility-candidate.json, and verify-release-evidence-pr still publishes a synthetic PR verification check after workflow_dispatch instead of obtaining a native pull_request status accepted by branch protection. Make the generated next-development diff Prettier-clean, refresh and stage the compatibility candidate whenever the version surface advances, add a pre-push/pre-PR contract gate, and drive the close-tail through a native pull_request verification with regression coverage for action_required or empty native rollup. Do not weaken branch protection or use admin bypass. Issue: https://github.com/basilisk-labs/agentplane/issues/4848"
 sections:
@@ -585,7 +594,7 @@ extensions:
       revision: 1
       schema_version: 1
       task_id: "202609111340-MGB383"
-    event_cursor: 3
+    event_cursor: 4
     final_validation: null
     id: "202609111340-MGB383"
     intent:
@@ -605,9 +614,9 @@ extensions:
     lifecycle: "ACTIVE"
     plan_amendments: []
     plan_history: []
-    revision: 5
+    revision: 6
     schema_version: 1
-    updated_at: "2026-09-11T18:45:55.083Z"
+    updated_at: "2026-09-11T18:49:54.166Z"
     work_items:
       work-native-pr-verification:
         attempt: 0
@@ -711,6 +720,30 @@ extensions:
         mutation_id: "compatibility:sha256:aa8960213bb9882caf65594e4072847419b2b1afdb3e9e1a37122e775b307af0"
         next_revision: 5
         previous_revision: 4
+        schema_version: 1
+        task_id: "202609111340-MGB383"
+      compatibility:sha256:c629e1cb3b0716b944b9a72dbb85e963bc5e720deccd7d029e170f204cf200b6:
+        aggregate_digest: "sha256:e9f04760f247e2e44e6275d536bf0190b958638a1980b71dd601c3b5010ebce5"
+        event:
+          actor_id: "agentplane"
+          at: "2026-09-11T18:49:54.166Z"
+          cause_refs:
+            - "compatibility_projection_mutation"
+          entity: "task"
+          from: "ACTIVE"
+          id: "event_b64340622ca55cc7524a05c9"
+          mutation_id: "compatibility:sha256:c629e1cb3b0716b944b9a72dbb85e963bc5e720deccd7d029e170f204cf200b6"
+          plan_digest: "sha256:561ecf6a31e5da0501ae93d26c9f884af477f46a4b17250d7c9b5d40ae1f24fa"
+          plan_revision: 1
+          repository_fingerprint: null
+          schema_version: 1
+          task_id: "202609111340-MGB383"
+          task_revision: 5
+          to: "ACTIVE"
+          work_item_id: null
+        mutation_id: "compatibility:sha256:c629e1cb3b0716b944b9a72dbb85e963bc5e720deccd7d029e170f204cf200b6"
+        next_revision: 6
+        previous_revision: 5
         schema_version: 1
         task_id: "202609111340-MGB383"
     pending_effects: []

--- a/.agentplane/tasks/202609111340-MGB383/README.md
+++ b/.agentplane/tasks/202609111340-MGB383/README.md
@@ -4,7 +4,7 @@ title: "Harden the post-release evidence close-tail under branch protection for 
 status: "DOING"
 priority: "high"
 owner: "CODER"
-revision: 11
+revision: 12
 origin:
   system: "manual"
 depends_on: []
@@ -232,9 +232,7 @@ execution_contract:
       - "repository_effect:source_code"
       - "repository_effect:tests"
       - "task_outcome"
-commit:
-  hash: "2ce9ad411025921a1b82b7f8b383501fd655d342"
-  message: "🚧 MGB383 task: apply external agent result"
+commit: null
 comments:
   -
     author: "CODER"
@@ -652,9 +650,9 @@ extensions:
     lifecycle: "ACTIVE"
     plan_amendments: []
     plan_history: []
-    revision: 11
+    revision: 12
     schema_version: 1
-    updated_at: "2026-09-11T18:53:27.398Z"
+    updated_at: "2026-09-11T18:53:32.566Z"
     work_items:
       work-native-pr-verification:
         attempt: 1
@@ -705,14 +703,44 @@ extensions:
         state: "PLANNED"
         validation_result: null
       work-version-surfaces:
-        attempt: 0
+        attempt: 1
         claim_id: null
         id: "work-version-surfaces"
         last_failure: null
-        output_manifests: []
-        revision: 1
-        state: "READY"
-        validation_result: null
+        output_manifests:
+          -
+            digest: "sha256:a66f81c22d2e046eac1dd705cd52388652d3e2d0aac7b401d1c09637ea80e90a"
+            id: "version-surfaces-output"
+            kind: "semantic_output"
+            producer:
+              attempt: 1
+              plan_revision: 1
+              task_id: "202609111340-MGB383"
+              work_item_id: "work-version-surfaces"
+            provenance:
+              - "sha256:2ec5376fd9b14961437c5531371012bf86e5eb1d8341600d6f1aae6b9b0df999"
+              - ".agentplane/tasks/202609111340-MGB383/supervision/declared-checks.json"
+            repository_snapshot_digest: "sha256:b549cd9a4d2460a47b45d6268f874d41b73b622949a7b86105ae1287ad9f34eb"
+            schema: "agentplane.semantic-output.v1"
+            schema_version: 1
+        revision: 2
+        state: "COMPLETED"
+        validation_result:
+          evidence:
+            -
+              artifact_refs:
+                - ".agentplane/tasks/202609111340-MGB383/supervision/declared-checks.json"
+              check_id: "check-focused-release"
+              command_identity: "bunx --no-install vitest run packages/agentplane/src/commands/release/open-next-development-version-script.test.ts packages/agentplane/src/commands/release/verify-release-evidence-pr-script.test.ts packages/agentplane/src/commands/release/publish-workflow-contract.test.ts --maxWorkers=1"
+              detail: "Observed by bunx --no-install vitest run packages/agentplane/src/commands/release/open-next-development-version-script.test.ts packages/agentplane/src/commands/release/verify-release-evidence-pr-script.test.ts packages/agentplane/src/commands/release/publish-workflow-contract.test.ts --maxWorkers=1."
+              exit_code: 0
+              observed_at: "2026-09-11T18:53:32.561Z"
+              repository_snapshot_digest: "sha256:b549cd9a4d2460a47b45d6268f874d41b73b622949a7b86105ae1287ad9f34eb"
+              status: "passed"
+          schema_version: 1
+          stale_evidence: []
+          status: "passed"
+          unsatisfied_criteria: []
   agentplane.task_centric_runtime:
     checkpoints: []
     events:
@@ -733,6 +761,23 @@ extensions:
         task_id: "202609111340-MGB383"
         task_revision: 8
         work_item_id: "work-native-pr-verification"
+      -
+        at: "2026-09-11T18:53:32.566Z"
+        from: "READY"
+        to: "COMPLETED"
+        actor_id: "agentplane"
+        cause_refs:
+          - "semantic-result:sha256:03ca1339036ae6197342903a378fa7806bb3fb2851a9108784063dc64648cd43"
+        entity: "work_item"
+        id: "event_b7491f446ece417e2db5601b"
+        mutation_id: "external-result:work-order-202609111340-MGB383-executor-af6f56de8792d5457346d125"
+        plan_digest: "sha256:561ecf6a31e5da0501ae93d26c9f884af477f46a4b17250d7c9b5d40ae1f24fa"
+        plan_revision: 1
+        repository_fingerprint: null
+        schema_version: 1
+        task_id: "202609111340-MGB383"
+        task_revision: 11
+        work_item_id: "work-version-surfaces"
     leases: []
     mutation_receipts:
       compatibility:sha256:0d9670b99051a55edbb7ac41ecacbe142f74f39da97aca1c64b1642e23bfd5b9:
@@ -949,6 +994,30 @@ extensions:
         mutation_id: "external-result:work-order-202609111340-MGB383-executor-45a8e43f6c5503dd1507e90d"
         next_revision: 9
         previous_revision: 8
+        schema_version: 1
+        task_id: "202609111340-MGB383"
+      external-result:work-order-202609111340-MGB383-executor-af6f56de8792d5457346d125:
+        aggregate_digest: "sha256:167a22022f7f0c9b015fa9bf867e9b70e2cfe7747b940a990e0bbfb2b1a7b23d"
+        event:
+          actor_id: "agentplane"
+          at: "2026-09-11T18:53:32.566Z"
+          cause_refs:
+            - "semantic-result:sha256:03ca1339036ae6197342903a378fa7806bb3fb2851a9108784063dc64648cd43"
+          entity: "work_item"
+          from: "READY"
+          id: "event_b7491f446ece417e2db5601b"
+          mutation_id: "external-result:work-order-202609111340-MGB383-executor-af6f56de8792d5457346d125"
+          plan_digest: "sha256:561ecf6a31e5da0501ae93d26c9f884af477f46a4b17250d7c9b5d40ae1f24fa"
+          plan_revision: 1
+          repository_fingerprint: null
+          schema_version: 1
+          task_id: "202609111340-MGB383"
+          task_revision: 11
+          to: "COMPLETED"
+          work_item_id: "work-version-surfaces"
+        mutation_id: "external-result:work-order-202609111340-MGB383-executor-af6f56de8792d5457346d125"
+        next_revision: 12
+        previous_revision: 11
         schema_version: 1
         task_id: "202609111340-MGB383"
     pending_effects: []

--- a/.agentplane/tasks/202609111340-MGB383/README.md
+++ b/.agentplane/tasks/202609111340-MGB383/README.md
@@ -1,0 +1,762 @@
+---
+id: "202609111340-MGB383"
+title: "Harden the post-release evidence close-tail under branch protection for GitHub issue #4848"
+status: "DOING"
+priority: "high"
+owner: "CODER"
+revision: 5
+origin:
+  system: "manual"
+depends_on: []
+tags:
+  - "ci"
+  - "github-issue"
+  - "release"
+task_kind: "release"
+mutation_scope: "release"
+risk_flags:
+  - "external_system"
+blueprint_request: "release.strict"
+verify:
+  - "bunx --no-install vitest run packages/agentplane/src/commands/release/open-next-development-version-script.test.ts packages/agentplane/src/commands/release/verify-release-evidence-pr-script.test.ts packages/agentplane/src/commands/release/publish-workflow-contract.test.ts --maxWorkers=1"
+plan_approval:
+  state: "approved"
+  updated_at: "2026-09-11T18:45:43.034Z"
+  updated_by: "HOST:codex-desktop:USER"
+  note: "host_user_decision=sha256:f98e5b47d56b1ba68efdd822b04e28d97a72d04ee6fa3a7ab585112dbcbabbea"
+verification:
+  state: "pending"
+  updated_at: null
+  updated_by: null
+  note: null
+  attempts: 0
+execution_route:
+  frozen: true
+  reason_codes:
+    - "agent_preferred_branch_pr"
+    - "effect_ci"
+    - "effect_external_write"
+    - "effect_release_metadata"
+    - "repository_branch_pr_floor"
+    - "reversibility_recovery_required"
+  repository_mode: "branch_pr"
+  requested_mode: "branch_pr"
+  schema_version: 1
+  selected_mode: "branch_pr"
+execution_contract:
+  authority:
+    allowed_external_effects: []
+    allowed_repository_effects:
+      - "ci"
+      - "release_metadata"
+      - "repository_write"
+      - "source_code"
+      - "tests"
+    forbidden_external_effects:
+      - "network_read"
+      - "external_write"
+      - "credentials"
+      - "publish"
+      - "deploy"
+      - "destructive_git"
+    forbidden_repository_effects:
+      - "documentation"
+      - "public_api"
+      - "schema"
+      - "dependencies"
+      - "security_boundary"
+    writable_roots:
+      - ".github/workflows/publish.yml"
+      - "packages/agentplane/src/commands/release/open-next-development-version-script.test.ts"
+      - "packages/agentplane/src/commands/release/publish-workflow-contract.test.ts"
+      - "packages/agentplane/src/commands/release/verify-release-evidence-pr-script.test.ts"
+      - "scripts/baselines/v0.7-compatibility-candidate.json"
+      - "scripts/lib/next-development-version.mjs"
+      - "scripts/release/open-next-development-version.mjs"
+      - "scripts/workflow/verify-release-evidence-pr.mjs"
+  declaration:
+    external_effects:
+      - "external_write"
+    implementation_uncertainty: "bounded"
+    preferred_mode: "branch_pr"
+    rationale:
+      - "A branch_pr route provides hosted validation for the changed workflow and release behavior."
+      - "The repaired workflow opens and merges a protected pull request through GitHub."
+      - "The task changes the stable publish workflow and release follow-up scripts."
+    repository_effects:
+      - "ci"
+      - "release_metadata"
+      - "repository_write"
+      - "source_code"
+      - "tests"
+    requirements_uncertainty: "bounded"
+    reversibility: "recovery_required"
+    schema_version: 2
+    scope_roots:
+      - ".github/workflows/publish.yml"
+      - "packages/agentplane/src/commands/release/open-next-development-version-script.test.ts"
+      - "packages/agentplane/src/commands/release/publish-workflow-contract.test.ts"
+      - "packages/agentplane/src/commands/release/verify-release-evidence-pr-script.test.ts"
+      - "scripts/baselines/v0.7-compatibility-candidate.json"
+      - "scripts/lib/next-development-version.mjs"
+      - "scripts/release/open-next-development-version.mjs"
+      - "scripts/workflow/verify-release-evidence-pr.mjs"
+  observed:
+    authority_violations: []
+    changed_components: []
+    changed_paths: []
+    external_effects: []
+    repository_effects: []
+    verification_results: []
+  reason_codes:
+    - "agent_preferred_branch_pr"
+    - "effect_ci"
+    - "effect_external_write"
+    - "effect_release_metadata"
+    - "repository_branch_pr_floor"
+    - "reversibility_recovery_required"
+  repository_mode: "branch_pr"
+  safety:
+    approval_effects:
+      - "external_write"
+    requires_user_approval: true
+    requires_worktree: true
+  schema_version: 1
+  selected_mode: "branch_pr"
+  source: "agent_declared"
+  verification:
+    contract:
+      declared:
+        components:
+          - ".github/workflows/publish.yml"
+          - "packages/agentplane/src/commands/release/open-next-development-version-script.test.ts"
+          - "packages/agentplane/src/commands/release/publish-workflow-contract.test.ts"
+          - "packages/agentplane/src/commands/release/verify-release-evidence-pr-script.test.ts"
+          - "scripts/baselines/v0.7-compatibility-candidate.json"
+          - "scripts/lib/next-development-version.mjs"
+          - "scripts/release/open-next-development-version.mjs"
+          - "scripts/workflow/verify-release-evidence-pr.mjs"
+        evidence_requirements:
+          - "external_effect:external_write"
+          - "hosted_integration"
+          - "repository_effect:ci"
+          - "repository_effect:release_metadata"
+          - "repository_effect:repository_write"
+          - "repository_effect:source_code"
+          - "repository_effect:tests"
+          - "task_outcome"
+        external_effects:
+          - "external_write"
+        repository_effects:
+          - "ci"
+          - "release_metadata"
+          - "repository_write"
+          - "source_code"
+          - "tests"
+        risk:
+          implementation_uncertainty: "bounded"
+          requirements_uncertainty: "bounded"
+          reversibility: "recovery_required"
+      digest: "sha256:898dd4ed3767290fadaa1eac967d14e23359c4dfa6135d24e3d6a10f0e5b5fe7"
+      escalation_reasons:
+        - "central_component:.github/workflows/publish.yml"
+        - "central_component:scripts/lib/next-development-version.mjs"
+        - "central_component:scripts/release/open-next-development-version.mjs"
+        - "central_component:scripts/workflow/verify-release-evidence-pr.mjs"
+        - "effect_ci"
+        - "effect_release_metadata"
+        - "external_effect_requires_real_e2e"
+        - "reversibility_recovery_required"
+      execution_groups:
+        - "docs-schema"
+        - "core"
+        - "runtime"
+        - "cli"
+      observed:
+        changed_components: []
+        changed_files: []
+        external_effects: []
+        repository_effects: []
+      phase: "task"
+      policy_floor:
+        monotonic_strengthening: true
+        pr_full_regression: true
+        unknown_or_central_full_regression: true
+      requires_full_regression: true
+      requires_real_e2e: true
+      schema_version: 2
+      selected_checks:
+        - "affected_unit_integration"
+        - "critical_paths"
+        - "full_regression"
+        - "hosted_integration"
+        - "real_e2e"
+        - "task_outcome"
+      selector:
+        bucket: null
+        buckets: []
+        execution_mode: "semantic"
+        kind: "semantic"
+        lint_targets: []
+        reason: "execution_declaration"
+        run_cli_docs_check: false
+        selected_test_files: []
+        vitest_pool: "forks"
+      source: "execution_contract"
+    required_evidence:
+      - "external_effect:external_write"
+      - "hosted_integration"
+      - "repository_effect:ci"
+      - "repository_effect:release_metadata"
+      - "repository_effect:repository_write"
+      - "repository_effect:source_code"
+      - "repository_effect:tests"
+      - "task_outcome"
+commit: null
+comments:
+  -
+    author: "CODER"
+    body: "Start: continue branch_pr task in the dedicated task worktree."
+events:
+  -
+    type: "status"
+    at: "2026-09-11T18:45:55.083Z"
+    author: "CODER"
+    from: "DOING"
+    to: "DOING"
+    note: "Start: continue branch_pr task in the dedicated task worktree."
+doc_version: 3
+doc_updated_at: "2026-09-11T18:45:55.083Z"
+doc_updated_by: "CODER"
+description: "GitHub issue #4848 is still relevant on current main. The release follow-up stages version surfaces but does not refresh or stage scripts/baselines/v0.7-compatibility-candidate.json, and verify-release-evidence-pr still publishes a synthetic PR verification check after workflow_dispatch instead of obtaining a native pull_request status accepted by branch protection. Make the generated next-development diff Prettier-clean, refresh and stage the compatibility candidate whenever the version surface advances, add a pre-push/pre-PR contract gate, and drive the close-tail through a native pull_request verification with regression coverage for action_required or empty native rollup. Do not weaken branch protection or use admin bypass. Issue: https://github.com/basilisk-labs/agentplane/issues/4848"
+sections:
+  Summary: |-
+    Harden the post-release evidence close-tail under branch protection for GitHub issue #4848
+
+    GitHub issue #4848 is still relevant on current main. The release follow-up stages version surfaces but does not refresh or stage scripts/baselines/v0.7-compatibility-candidate.json, and verify-release-evidence-pr still publishes a synthetic PR verification check after workflow_dispatch instead of obtaining a native pull_request status accepted by branch protection. Make the generated next-development diff Prettier-clean, refresh and stage the compatibility candidate whenever the version surface advances, add a pre-push/pre-PR contract gate, and drive the close-tail through a native pull_request verification with regression coverage for action_required or empty native rollup. Do not weaken branch protection or use admin bypass. Issue: https://github.com/basilisk-labs/agentplane/issues/4848
+  Scope: |-
+    - In scope: GitHub issue #4848 is still relevant on current main. The release follow-up stages version surfaces but does not refresh or stage scripts/baselines/v0.7-compatibility-candidate.json, and verify-release-evidence-pr still publishes a synthetic PR verification check after workflow_dispatch instead of obtaining a native pull_request status accepted by branch protection. Make the generated next-development diff Prettier-clean, refresh and stage the compatibility candidate whenever the version surface advances, add a pre-push/pre-PR contract gate, and drive the close-tail through a native pull_request verification with regression coverage for action_required or empty native rollup. Do not weaken branch protection or use admin bypass. Issue: https://github.com/basilisk-labs/agentplane/issues/4848.
+    - Out of scope: unrelated refactors not required for "Harden the post-release evidence close-tail under branch protection for GitHub issue #4848".
+  Plan: "Prepared a bounded branch_pr plan for the release close-tail repair."
+  Verify Steps: |-
+    1. Run `bunx --no-install vitest run packages/agentplane/src/commands/release/open-next-development-version-script.test.ts packages/agentplane/src/commands/release/verify-release-evidence-pr-script.test.ts packages/agentplane/src/commands/release/publish-workflow-contract.test.ts --maxWorkers=1`. Expected: the next-development diff is Prettier-clean, the compatibility candidate refresh is covered, the publish workflow stages and gates all generated files, and native pull_request verification succeeds while action_required and empty rollups fail closed.
+    2. Inspect the release-evidence close-tail diff. Expected: it does not create a synthetic success check, use admin bypass, or modify files outside the approved scope.
+    3. Complete hosted integration for the exact task commit. Expected: required branch-protection checks pass and the pull request merges without bypass.
+    4. Record final task-outcome evidence and `git status --short --untracked-files=all`. Expected: all required evidence is present and no unintended tracked changes or task-local artifacts remain.
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: ""
+extensions:
+  agentplane.execution_grant:
+    actor: "HOST:codex-desktop:USER"
+    approval_evidence_digest: "sha256:f98e5b47d56b1ba68efdd822b04e28d97a72d04ee6fa3a7ab585112dbcbabbea"
+    approval_kind: "host_user_decision"
+    capabilities:
+      - "provider.merge"
+      - "provider.pr"
+      - "repository.integrate"
+      - "repository.write"
+      - "task.lifecycle"
+      - "task.scope.extend"
+    completion_contract_digest: "sha256:a1a6fcfb99704e8194c515dbe16cc42ec814d9042010dd9cfa9a94adcd121fd2"
+    digest: "sha256:89a153528e21e002da4c1cf46b1bbc4f5c3016ed1c6c0a6a34911ee8e6fdbab2"
+    grant_id: "0a2d500e-30ed-470a-a446-e9f84c00b2d3"
+    issued_at: "2026-09-11T18:45:43.034Z"
+    kind: "agentplane.execution_grant"
+    plan_digest: "sha256:ff0948c7df5380615f382821bcc32ac3aba7a0c127f21f69fd2a786fd93ba2b3"
+    plan_revision: 3
+    repository_identity: "sha256:da6b1bd36fbd8902ecef3732738a9db0fd8478b8fcbe61ce4ba5a648cdccfd3b"
+    schema_version: 1
+    scope_digest: "sha256:924fa491dbf622137be02ff38eccbc44fb902a6d91543353255cd15cedfc5d4c"
+    status: "active"
+    task_id: "202609111340-MGB383"
+  agentplane.task_centric:
+    current_plan:
+      approval:
+        approved_at: "2026-09-11T18:45:43.034Z"
+        approved_by: "HOST:codex-desktop:USER"
+        approved_digest: "sha256:561ecf6a31e5da0501ae93d26c9f884af477f46a4b17250d7c9b5d40ae1f24fa"
+        policy_facts:
+          - "host_user_decision"
+        state: "approved"
+      created_at: "2026-09-11T18:44:37.585Z"
+      digest: "sha256:561ecf6a31e5da0501ae93d26c9f884af477f46a4b17250d7c9b5d40ae1f24fa"
+      proposal:
+        assumptions:
+          - "The existing compatibility candidate capture script remains the canonical generator."
+          - "The existing release evidence pull request remains the only branch-protected close-tail path."
+        planning_baseline:
+          captured_at: "2026-09-11T18:41:19.270Z"
+          config_digest: null
+          context_digest: "sha256:890b5e5c75bdf159d4314db2bb015c07f8837e3eddfa3dd65a6b41186d162086"
+          digest: "sha256:e5d76a939ee0b62444fb44ed1c7fc038b24ea5865367d03fc6338b9d1f605659"
+          dirty_paths:
+            - ".agentplane/tasks/202609111340-MGB383/README.md"
+            - ".agentplane/tasks/202609111341-FK9C2T/README.md"
+            - ".agentplane/tasks/202609111341-SED9K5/README.md"
+            - ".agentplane/tasks/202609111502-4XSWZQ/README.md"
+          git:
+            kind: "commit"
+            ref: null
+            sha: "50b1810dda648be0c0762b47e885c6ad0b2d42af"
+          policy_digest: null
+          schema_version: 1
+          task_history_cursor: "task-revision:1"
+        schema_version: 1
+        task_id: "202609111340-MGB383"
+        top_level_validation:
+          checks:
+            -
+              capability: "task.verify"
+              command: "bunx --no-install vitest run packages/agentplane/src/commands/release/open-next-development-version-script.test.ts packages/agentplane/src/commands/release/verify-release-evidence-pr-script.test.ts packages/agentplane/src/commands/release/publish-workflow-contract.test.ts --maxWorkers=1"
+              id: "check-focused-release"
+              kind: "deterministic"
+              required: true
+              timeout_ms: 900000
+          criteria:
+            -
+              check_ids:
+                - "check-focused-release"
+              description: "Opening the next development version produces a Prettier-clean diff and refreshes scripts/baselines/v0.7-compatibility-candidate.json when version surfaces advance."
+              id: "criterion-generated-diff"
+              required: true
+            -
+              check_ids:
+                - "check-focused-release"
+              description: "The publish close-tail stages every generated version and compatibility path and fails before push or PR creation when the generated contract is incomplete or dirty."
+              id: "criterion-contract-gate"
+              required: true
+            -
+              check_ids:
+                - "check-focused-release"
+              description: "The close-tail waits for the native pull_request Core CI rollup for the exact closure SHA and fails closed for action_required or an empty native rollup without creating a synthetic success check."
+              id: "criterion-native-pr-check"
+              required: true
+            -
+              check_ids:
+                - "check-focused-release"
+              description: "The workflow merges only through normal branch protection and does not use an admin bypass."
+              id: "criterion-protection"
+              required: true
+            -
+              check_ids:
+                - "check-focused-release"
+              description: "The final diff stays within the declared release close-tail scope and records residual findings explicitly."
+              id: "criterion-scope"
+              required: true
+          evidence_fingerprint: "sha256:e5d76a939ee0b62444fb44ed1c7fc038b24ea5865367d03fc6338b9d1f605659"
+          schema_version: 1
+        unresolved_questions: []
+        work_items:
+          schema_version: 1
+          work_items:
+            -
+              acceptance_criteria:
+                -
+                  check_ids:
+                    - "check-focused-release"
+                  description: "Opening the next development version produces a Prettier-clean diff and refreshes scripts/baselines/v0.7-compatibility-candidate.json when version surfaces advance."
+                  id: "criterion-generated-diff"
+                  required: true
+              capabilities:
+                - "task.verify"
+              context:
+                max_bytes: 120000
+                optional_sources: []
+                required_sources:
+                  - "scripts/lib/next-development-version.mjs"
+                  - "scripts/bench/capture-compatibility-candidate.mjs"
+                  - "packages/agentplane/src/commands/release/open-next-development-version-script.test.ts"
+                symbol_hints:
+                  - "applyNextDevelopmentVersion"
+                  - "changedPaths"
+              depends_on: []
+              expected_outputs:
+                - "version-surfaces-output"
+              id: "work-version-surfaces"
+              objective: "Make the next-development mutation format generated files and refresh the compatibility candidate when version surfaces advance."
+              optional: false
+              priority: 1
+              required_inputs: []
+              resource_claims:
+                -
+                  kind: "path"
+                  mode: "write"
+                  resource: "scripts/lib/next-development-version.mjs"
+                -
+                  kind: "path"
+                  mode: "write"
+                  resource: "scripts/baselines/v0.7-compatibility-candidate.json"
+                -
+                  kind: "path"
+                  mode: "write"
+                  resource: "packages/agentplane/src/commands/release/open-next-development-version-script.test.ts"
+              risk: "medium"
+              scope_roots:
+                - "scripts/lib/next-development-version.mjs"
+                - "scripts/release/open-next-development-version.mjs"
+                - "scripts/baselines/v0.7-compatibility-candidate.json"
+                - "packages/agentplane/src/commands/release/open-next-development-version-script.test.ts"
+              validation:
+                checks:
+                  -
+                    capability: "task.verify"
+                    command: "bunx --no-install vitest run packages/agentplane/src/commands/release/open-next-development-version-script.test.ts packages/agentplane/src/commands/release/verify-release-evidence-pr-script.test.ts packages/agentplane/src/commands/release/publish-workflow-contract.test.ts --maxWorkers=1"
+                    id: "check-focused-release"
+                    kind: "deterministic"
+                    required: true
+                    timeout_ms: 900000
+                criteria:
+                  -
+                    check_ids:
+                      - "check-focused-release"
+                    description: "Opening the next development version produces a Prettier-clean diff and refreshes scripts/baselines/v0.7-compatibility-candidate.json when version surfaces advance."
+                    id: "criterion-generated-diff"
+                    required: true
+                evidence_fingerprint: "sha256:e5d76a939ee0b62444fb44ed1c7fc038b24ea5865367d03fc6338b9d1f605659"
+                schema_version: 1
+            -
+              acceptance_criteria:
+                -
+                  check_ids:
+                    - "check-focused-release"
+                  description: "The close-tail waits for the native pull_request Core CI rollup for the exact closure SHA and fails closed for action_required or an empty native rollup without creating a synthetic success check."
+                  id: "criterion-native-pr-check"
+                  required: true
+                -
+                  check_ids:
+                    - "check-focused-release"
+                  description: "The workflow merges only through normal branch protection and does not use an admin bypass."
+                  id: "criterion-protection"
+                  required: true
+              capabilities:
+                - "task.verify"
+              context:
+                max_bytes: 120000
+                optional_sources:
+                  - "scripts/workflow/wait-remote-pr-checks.mjs"
+                required_sources:
+                  - "scripts/workflow/verify-release-evidence-pr.mjs"
+                  - "packages/agentplane/src/commands/release/verify-release-evidence-pr-script.test.ts"
+                symbol_hints:
+                  - "runListArgs"
+                  - "discoverDispatchedRun"
+                  - "publishRequiredCheck"
+                  - "mergePullRequest"
+              depends_on: []
+              expected_outputs:
+                - "native-pr-verification-output"
+              id: "work-native-pr-verification"
+              objective: "Replace synthetic workflow_dispatch evidence with the exact closure SHA native pull_request check rollup and fail closed for missing or action_required results."
+              optional: false
+              priority: 1
+              required_inputs: []
+              resource_claims:
+                -
+                  kind: "path"
+                  mode: "write"
+                  resource: "scripts/workflow/verify-release-evidence-pr.mjs"
+                -
+                  kind: "path"
+                  mode: "write"
+                  resource: "packages/agentplane/src/commands/release/verify-release-evidence-pr-script.test.ts"
+              risk: "high"
+              scope_roots:
+                - "scripts/workflow/verify-release-evidence-pr.mjs"
+                - "packages/agentplane/src/commands/release/verify-release-evidence-pr-script.test.ts"
+              validation:
+                checks:
+                  -
+                    capability: "task.verify"
+                    command: "bunx --no-install vitest run packages/agentplane/src/commands/release/open-next-development-version-script.test.ts packages/agentplane/src/commands/release/verify-release-evidence-pr-script.test.ts packages/agentplane/src/commands/release/publish-workflow-contract.test.ts --maxWorkers=1"
+                    id: "check-focused-release"
+                    kind: "deterministic"
+                    required: true
+                    timeout_ms: 900000
+                criteria:
+                  -
+                    check_ids:
+                      - "check-focused-release"
+                    description: "The close-tail waits for the native pull_request Core CI rollup for the exact closure SHA and fails closed for action_required or an empty native rollup without creating a synthetic success check."
+                    id: "criterion-native-pr-check"
+                    required: true
+                  -
+                    check_ids:
+                      - "check-focused-release"
+                    description: "The workflow merges only through normal branch protection and does not use an admin bypass."
+                    id: "criterion-protection"
+                    required: true
+                evidence_fingerprint: "sha256:e5d76a939ee0b62444fb44ed1c7fc038b24ea5865367d03fc6338b9d1f605659"
+                schema_version: 1
+            -
+              acceptance_criteria:
+                -
+                  check_ids:
+                    - "check-focused-release"
+                  description: "The publish close-tail stages every generated version and compatibility path and fails before push or PR creation when the generated contract is incomplete or dirty."
+                  id: "criterion-contract-gate"
+                  required: true
+                -
+                  check_ids:
+                    - "check-focused-release"
+                  description: "The workflow merges only through normal branch protection and does not use an admin bypass."
+                  id: "criterion-protection"
+                  required: true
+                -
+                  check_ids:
+                    - "check-focused-release"
+                  description: "The final diff stays within the declared release close-tail scope and records residual findings explicitly."
+                  id: "criterion-scope"
+                  required: true
+              capabilities:
+                - "task.verify"
+              context:
+                max_bytes: 160000
+                optional_sources:
+                  - "package.json"
+                  - "scripts/checks/check-compatibility-contract-baseline.mjs"
+                required_sources:
+                  - ".github/workflows/publish.yml"
+                  - "packages/agentplane/src/commands/release/publish-workflow-contract.test.ts"
+                symbol_hints:
+                  - "Apply release task evidence on a follow-up branch"
+                  - "Push release evidence branch"
+                  - "Open or recover release evidence PR"
+                  - "Verify and merge exact release evidence SHA"
+              depends_on:
+                - "work-version-surfaces"
+                - "work-native-pr-verification"
+              expected_outputs:
+                - "publish-contract-output"
+              id: "work-publish-contract"
+              objective: "Stage the refreshed generated surfaces and add a fail-closed contract gate before the release evidence branch is pushed or its pull request is opened."
+              optional: false
+              priority: 2
+              required_inputs:
+                - "version-surfaces-output"
+                - "native-pr-verification-output"
+              resource_claims:
+                -
+                  kind: "path"
+                  mode: "write"
+                  resource: ".github/workflows/publish.yml"
+                -
+                  kind: "path"
+                  mode: "write"
+                  resource: "packages/agentplane/src/commands/release/publish-workflow-contract.test.ts"
+              risk: "high"
+              scope_roots:
+                - ".github/workflows/publish.yml"
+                - "packages/agentplane/src/commands/release/publish-workflow-contract.test.ts"
+              validation:
+                checks:
+                  -
+                    capability: "task.verify"
+                    command: "bunx --no-install vitest run packages/agentplane/src/commands/release/open-next-development-version-script.test.ts packages/agentplane/src/commands/release/verify-release-evidence-pr-script.test.ts packages/agentplane/src/commands/release/publish-workflow-contract.test.ts --maxWorkers=1"
+                    id: "check-focused-release"
+                    kind: "deterministic"
+                    required: true
+                    timeout_ms: 900000
+                criteria:
+                  -
+                    check_ids:
+                      - "check-focused-release"
+                    description: "The publish close-tail stages every generated version and compatibility path and fails before push or PR creation when the generated contract is incomplete or dirty."
+                    id: "criterion-contract-gate"
+                    required: true
+                  -
+                    check_ids:
+                      - "check-focused-release"
+                    description: "The workflow merges only through normal branch protection and does not use an admin bypass."
+                    id: "criterion-protection"
+                    required: true
+                  -
+                    check_ids:
+                      - "check-focused-release"
+                    description: "The final diff stays within the declared release close-tail scope and records residual findings explicitly."
+                    id: "criterion-scope"
+                    required: true
+                evidence_fingerprint: "sha256:e5d76a939ee0b62444fb44ed1c7fc038b24ea5865367d03fc6338b9d1f605659"
+                schema_version: 1
+      revision: 1
+      schema_version: 1
+      task_id: "202609111340-MGB383"
+    event_cursor: 3
+    final_validation: null
+    id: "202609111340-MGB383"
+    intent:
+      acceptance_criteria:
+        -
+          check_ids: []
+          description: "bunx --no-install vitest run packages/agentplane/src/commands/release/open-next-development-version-script.test.ts packages/agentplane/src/commands/release/verify-release-evidence-pr-script.test.ts packages/agentplane/src/commands/release/publish-workflow-contract.test.ts --maxWorkers=1"
+          id: "legacy-1"
+          required: true
+      captured_at: "2026-09-11T13:40:47.769Z"
+      constraints: []
+      request: |-
+        Harden the post-release evidence close-tail under branch protection for GitHub issue #4848
+
+        GitHub issue #4848 is still relevant on current main. The release follow-up stages version surfaces but does not refresh or stage scripts/baselines/v0.7-compatibility-candidate.json, and verify-release-evidence-pr still publishes a synthetic PR verification check after workflow_dispatch instead of obtaining a native pull_request status accepted by branch protection. Make the generated next-development diff Prettier-clean, refresh and stage the compatibility candidate whenever the version surface advances, add a pre-push/pre-PR contract gate, and drive the close-tail through a native pull_request verification with regression coverage for action_required or empty native rollup. Do not weaken branch protection or use admin bypass. Issue: https://github.com/basilisk-labs/agentplane/issues/4848
+      task_id: "202609111340-MGB383"
+    lifecycle: "ACTIVE"
+    plan_amendments: []
+    plan_history: []
+    revision: 5
+    schema_version: 1
+    updated_at: "2026-09-11T18:45:55.083Z"
+    work_items:
+      work-native-pr-verification:
+        attempt: 0
+        claim_id: null
+        id: "work-native-pr-verification"
+        last_failure: null
+        output_manifests: []
+        revision: 1
+        state: "READY"
+        validation_result: null
+      work-publish-contract:
+        attempt: 0
+        claim_id: null
+        id: "work-publish-contract"
+        last_failure: null
+        output_manifests: []
+        revision: 1
+        state: "PLANNED"
+        validation_result: null
+      work-version-surfaces:
+        attempt: 0
+        claim_id: null
+        id: "work-version-surfaces"
+        last_failure: null
+        output_manifests: []
+        revision: 1
+        state: "READY"
+        validation_result: null
+  agentplane.task_centric_runtime:
+    checkpoints: []
+    events: []
+    leases: []
+    mutation_receipts:
+      compatibility:sha256:2ee8880913ca100651457df7cf734a1ea9d8f8ce32b1b2a291244f23ac254070:
+        aggregate_digest: "sha256:d3c1f46829b97ab9c3494a730223f741349fbaa78d1a82a958196a45be714d45"
+        event:
+          actor_id: "agentplane"
+          at: "2026-09-11T18:45:31.180Z"
+          cause_refs:
+            - "compatibility_projection_mutation"
+          entity: "task"
+          from: "AWAITING_PLAN_APPROVAL"
+          id: "event_452054b76228fc9ee1ba3575"
+          mutation_id: "compatibility:sha256:2ee8880913ca100651457df7cf734a1ea9d8f8ce32b1b2a291244f23ac254070"
+          plan_digest: "sha256:561ecf6a31e5da0501ae93d26c9f884af477f46a4b17250d7c9b5d40ae1f24fa"
+          plan_revision: 1
+          repository_fingerprint: null
+          schema_version: 1
+          task_id: "202609111340-MGB383"
+          task_revision: 2
+          to: "AWAITING_PLAN_APPROVAL"
+          work_item_id: null
+        mutation_id: "compatibility:sha256:2ee8880913ca100651457df7cf734a1ea9d8f8ce32b1b2a291244f23ac254070"
+        next_revision: 3
+        previous_revision: 2
+        schema_version: 1
+        task_id: "202609111340-MGB383"
+      compatibility:sha256:338a8cc2e871ba92a096792e869ee3d10ea6a003443de215f1ef63599afd3d75:
+        aggregate_digest: "sha256:756c6d03b43b59298280c9ab44155a8673b5f2d02383b5e8551c055323d3f500"
+        event:
+          actor_id: "agentplane"
+          at: "2026-09-11T18:45:31.181Z"
+          cause_refs:
+            - "compatibility_projection_mutation"
+          entity: "task"
+          from: "AWAITING_PLAN_APPROVAL"
+          id: "event_e4f1a1b80f1d4a1cf4e43e03"
+          mutation_id: "compatibility:sha256:338a8cc2e871ba92a096792e869ee3d10ea6a003443de215f1ef63599afd3d75"
+          plan_digest: "sha256:561ecf6a31e5da0501ae93d26c9f884af477f46a4b17250d7c9b5d40ae1f24fa"
+          plan_revision: 1
+          repository_fingerprint: null
+          schema_version: 1
+          task_id: "202609111340-MGB383"
+          task_revision: 3
+          to: "ACTIVE"
+          work_item_id: null
+        mutation_id: "compatibility:sha256:338a8cc2e871ba92a096792e869ee3d10ea6a003443de215f1ef63599afd3d75"
+        next_revision: 4
+        previous_revision: 3
+        schema_version: 1
+        task_id: "202609111340-MGB383"
+      compatibility:sha256:aa8960213bb9882caf65594e4072847419b2b1afdb3e9e1a37122e775b307af0:
+        aggregate_digest: "sha256:91d2efe8c5305283b14ee4b32d22802ae9727e5f953e8a12b10b54752abafd51"
+        event:
+          actor_id: "agentplane"
+          at: "2026-09-11T18:45:55.083Z"
+          cause_refs:
+            - "compatibility_projection_mutation"
+          entity: "task"
+          from: "ACTIVE"
+          id: "event_c23fa6066db5afa5121ece36"
+          mutation_id: "compatibility:sha256:aa8960213bb9882caf65594e4072847419b2b1afdb3e9e1a37122e775b307af0"
+          plan_digest: "sha256:561ecf6a31e5da0501ae93d26c9f884af477f46a4b17250d7c9b5d40ae1f24fa"
+          plan_revision: 1
+          repository_fingerprint: null
+          schema_version: 1
+          task_id: "202609111340-MGB383"
+          task_revision: 4
+          to: "ACTIVE"
+          work_item_id: null
+        mutation_id: "compatibility:sha256:aa8960213bb9882caf65594e4072847419b2b1afdb3e9e1a37122e775b307af0"
+        next_revision: 5
+        previous_revision: 4
+        schema_version: 1
+        task_id: "202609111340-MGB383"
+    pending_effects: []
+    retry_budgets: []
+    schema_version: 1
+  task_execution_context:
+    base_ref: "main"
+    base_sha: "f774282d4a6ef8ce7da5bc08c8e2fd9abb99303d"
+    repository_identity: "sha256:da6b1bd36fbd8902ecef3732738a9db0fd8478b8fcbe61ce4ba5a648cdccfd3b"
+    schema_version: 1
+    source: "creation_checkout"
+  workflow_route_baseline:
+    start_head_sha: "f774282d4a6ef8ce7da5bc08c8e2fd9abb99303d"
+    version: 1
+id_source: "generated"
+---
+## Summary
+
+Harden the post-release evidence close-tail under branch protection for GitHub issue #4848
+
+GitHub issue #4848 is still relevant on current main. The release follow-up stages version surfaces but does not refresh or stage scripts/baselines/v0.7-compatibility-candidate.json, and verify-release-evidence-pr still publishes a synthetic PR verification check after workflow_dispatch instead of obtaining a native pull_request status accepted by branch protection. Make the generated next-development diff Prettier-clean, refresh and stage the compatibility candidate whenever the version surface advances, add a pre-push/pre-PR contract gate, and drive the close-tail through a native pull_request verification with regression coverage for action_required or empty native rollup. Do not weaken branch protection or use admin bypass. Issue: https://github.com/basilisk-labs/agentplane/issues/4848
+
+## Scope
+
+- In scope: GitHub issue #4848 is still relevant on current main. The release follow-up stages version surfaces but does not refresh or stage scripts/baselines/v0.7-compatibility-candidate.json, and verify-release-evidence-pr still publishes a synthetic PR verification check after workflow_dispatch instead of obtaining a native pull_request status accepted by branch protection. Make the generated next-development diff Prettier-clean, refresh and stage the compatibility candidate whenever the version surface advances, add a pre-push/pre-PR contract gate, and drive the close-tail through a native pull_request verification with regression coverage for action_required or empty native rollup. Do not weaken branch protection or use admin bypass. Issue: https://github.com/basilisk-labs/agentplane/issues/4848.
+- Out of scope: unrelated refactors not required for "Harden the post-release evidence close-tail under branch protection for GitHub issue #4848".
+
+## Plan
+
+Prepared a bounded branch_pr plan for the release close-tail repair.
+
+## Verify Steps
+
+1. Run `bunx --no-install vitest run packages/agentplane/src/commands/release/open-next-development-version-script.test.ts packages/agentplane/src/commands/release/verify-release-evidence-pr-script.test.ts packages/agentplane/src/commands/release/publish-workflow-contract.test.ts --maxWorkers=1`. Expected: the next-development diff is Prettier-clean, the compatibility candidate refresh is covered, the publish workflow stages and gates all generated files, and native pull_request verification succeeds while action_required and empty rollups fail closed.
+2. Inspect the release-evidence close-tail diff. Expected: it does not create a synthetic success check, use admin bypass, or modify files outside the approved scope.
+3. Complete hosted integration for the exact task commit. Expected: required branch-protection checks pass and the pull request merges without bypass.
+4. Record final task-outcome evidence and `git status --short --untracked-files=all`. Expected: all required evidence is present and no unintended tracked changes or task-local artifacts remain.
+
+## Verification
+
+<!-- BEGIN VERIFICATION RESULTS -->
+<!-- END VERIFICATION RESULTS -->
+
+## Rollback Plan
+
+- Revert task-related commit(s).
+- Re-run required checks to confirm rollback safety.
+
+## Findings

--- a/.agentplane/tasks/202609111340-MGB383/README.md
+++ b/.agentplane/tasks/202609111340-MGB383/README.md
@@ -4,7 +4,7 @@ title: "Harden the post-release evidence close-tail under branch protection for 
 status: "DOING"
 priority: "high"
 owner: "CODER"
-revision: 8
+revision: 9
 origin:
   system: "manual"
 depends_on: []
@@ -227,9 +227,7 @@ execution_contract:
       - "repository_effect:source_code"
       - "repository_effect:tests"
       - "task_outcome"
-commit:
-  hash: "6f127b5ad60646d6233d08ec333b16035bc40279"
-  message: "🚧 MGB383 task: apply external agent result"
+commit: null
 comments:
   -
     author: "CODER"
@@ -636,19 +634,49 @@ extensions:
     lifecycle: "ACTIVE"
     plan_amendments: []
     plan_history: []
-    revision: 8
+    revision: 9
     schema_version: 1
-    updated_at: "2026-09-11T18:51:27.640Z"
+    updated_at: "2026-09-11T18:51:38.731Z"
     work_items:
       work-native-pr-verification:
-        attempt: 0
+        attempt: 1
         claim_id: null
         id: "work-native-pr-verification"
         last_failure: null
-        output_manifests: []
-        revision: 1
-        state: "READY"
-        validation_result: null
+        output_manifests:
+          -
+            digest: "sha256:8c6d57566af22d68984aea8eedb518ab23169168da9224a6087a0ec7eeb290f0"
+            id: "native-pr-verification-output"
+            kind: "semantic_output"
+            producer:
+              attempt: 1
+              plan_revision: 1
+              task_id: "202609111340-MGB383"
+              work_item_id: "work-native-pr-verification"
+            provenance:
+              - "sha256:e0d723d1fc657bead9df88304b8e4fc63bb42c2466449f6e054fbc5704089f22"
+              - ".agentplane/tasks/202609111340-MGB383/supervision/declared-checks.json"
+            repository_snapshot_digest: "sha256:3adb6c36806026873593f94dde3d572023e8c16551ee70858062285ba94fa53f"
+            schema: "agentplane.semantic-output.v1"
+            schema_version: 1
+        revision: 2
+        state: "COMPLETED"
+        validation_result:
+          evidence:
+            -
+              artifact_refs:
+                - ".agentplane/tasks/202609111340-MGB383/supervision/declared-checks.json"
+              check_id: "check-focused-release"
+              command_identity: "bunx --no-install vitest run packages/agentplane/src/commands/release/open-next-development-version-script.test.ts packages/agentplane/src/commands/release/verify-release-evidence-pr-script.test.ts packages/agentplane/src/commands/release/publish-workflow-contract.test.ts --maxWorkers=1"
+              detail: "Observed by bunx --no-install vitest run packages/agentplane/src/commands/release/open-next-development-version-script.test.ts packages/agentplane/src/commands/release/verify-release-evidence-pr-script.test.ts packages/agentplane/src/commands/release/publish-workflow-contract.test.ts --maxWorkers=1."
+              exit_code: 0
+              observed_at: "2026-09-11T18:51:38.727Z"
+              repository_snapshot_digest: "sha256:3adb6c36806026873593f94dde3d572023e8c16551ee70858062285ba94fa53f"
+              status: "passed"
+          schema_version: 1
+          stale_evidence: []
+          status: "passed"
+          unsatisfied_criteria: []
       work-publish-contract:
         attempt: 0
         claim_id: null
@@ -669,7 +697,24 @@ extensions:
         validation_result: null
   agentplane.task_centric_runtime:
     checkpoints: []
-    events: []
+    events:
+      -
+        at: "2026-09-11T18:51:38.731Z"
+        from: "READY"
+        to: "COMPLETED"
+        actor_id: "agentplane"
+        cause_refs:
+          - "semantic-result:sha256:1efaf19c4c309374d1bb4e5facd4ed64cda3ec8b4f9954a6f31e9f30fdf1e159"
+        entity: "work_item"
+        id: "event_c8890d5be130b65a42079c0a"
+        mutation_id: "external-result:work-order-202609111340-MGB383-executor-45a8e43f6c5503dd1507e90d"
+        plan_digest: "sha256:561ecf6a31e5da0501ae93d26c9f884af477f46a4b17250d7c9b5d40ae1f24fa"
+        plan_revision: 1
+        repository_fingerprint: null
+        schema_version: 1
+        task_id: "202609111340-MGB383"
+        task_revision: 8
+        work_item_id: "work-native-pr-verification"
     leases: []
     mutation_receipts:
       compatibility:sha256:0d9670b99051a55edbb7ac41ecacbe142f74f39da97aca1c64b1642e23bfd5b9:
@@ -814,6 +859,30 @@ extensions:
         mutation_id: "compatibility:sha256:e0846c7149ff8c2d65ff0249273e12693103117bce14ad60bcfbb670102b06ba"
         next_revision: 8
         previous_revision: 7
+        schema_version: 1
+        task_id: "202609111340-MGB383"
+      external-result:work-order-202609111340-MGB383-executor-45a8e43f6c5503dd1507e90d:
+        aggregate_digest: "sha256:1dcf022444eaee223e044cbceb43c79a414774d089c945b22b7a8426e8ce41c6"
+        event:
+          actor_id: "agentplane"
+          at: "2026-09-11T18:51:38.731Z"
+          cause_refs:
+            - "semantic-result:sha256:1efaf19c4c309374d1bb4e5facd4ed64cda3ec8b4f9954a6f31e9f30fdf1e159"
+          entity: "work_item"
+          from: "READY"
+          id: "event_c8890d5be130b65a42079c0a"
+          mutation_id: "external-result:work-order-202609111340-MGB383-executor-45a8e43f6c5503dd1507e90d"
+          plan_digest: "sha256:561ecf6a31e5da0501ae93d26c9f884af477f46a4b17250d7c9b5d40ae1f24fa"
+          plan_revision: 1
+          repository_fingerprint: null
+          schema_version: 1
+          task_id: "202609111340-MGB383"
+          task_revision: 8
+          to: "COMPLETED"
+          work_item_id: "work-native-pr-verification"
+        mutation_id: "external-result:work-order-202609111340-MGB383-executor-45a8e43f6c5503dd1507e90d"
+        next_revision: 9
+        previous_revision: 8
         schema_version: 1
         task_id: "202609111340-MGB383"
     pending_effects: []

--- a/.agentplane/tasks/202609111340-MGB383/README.md
+++ b/.agentplane/tasks/202609111340-MGB383/README.md
@@ -4,7 +4,7 @@ title: "Harden the post-release evidence close-tail under branch protection for 
 status: "DOING"
 priority: "high"
 owner: "CODER"
-revision: 9
+revision: 11
 origin:
   system: "manual"
 depends_on: []
@@ -107,7 +107,9 @@ execution_contract:
       - "packages/agentplane"
       - "scripts"
     changed_paths:
+      - "packages/agentplane/src/commands/release/open-next-development-version-script.test.ts"
       - "packages/agentplane/src/commands/release/verify-release-evidence-pr-script.test.ts"
+      - "scripts/lib/next-development-version.mjs"
       - "scripts/workflow/verify-release-evidence-pr.mjs"
     external_effects: []
     repository_effects:
@@ -164,12 +166,13 @@ execution_contract:
           implementation_uncertainty: "bounded"
           requirements_uncertainty: "bounded"
           reversibility: "recovery_required"
-      digest: "sha256:0647a1831b3858bc8e3ee50c75796d33ba932b0aee02b1200a4b3ccc3773a96e"
+      digest: "sha256:bda7ce45d3e95a62a0d511d902535e5279c23272e1c58fdaa29fe2ebdc9c4276"
       escalation_reasons:
         - "central_component:.github/workflows/publish.yml"
         - "central_component:scripts/lib/next-development-version.mjs"
         - "central_component:scripts/release/open-next-development-version.mjs"
         - "central_component:scripts/workflow/verify-release-evidence-pr.mjs"
+        - "central_path:scripts/lib/next-development-version.mjs"
         - "central_path:scripts/workflow/verify-release-evidence-pr.mjs"
         - "effect_ci"
         - "effect_release_metadata"
@@ -185,7 +188,9 @@ execution_contract:
           - "packages/agentplane"
           - "scripts"
         changed_files:
+          - "packages/agentplane/src/commands/release/open-next-development-version-script.test.ts"
           - "packages/agentplane/src/commands/release/verify-release-evidence-pr-script.test.ts"
+          - "scripts/lib/next-development-version.mjs"
           - "scripts/workflow/verify-release-evidence-pr.mjs"
         external_effects: []
         repository_effects:
@@ -227,11 +232,16 @@ execution_contract:
       - "repository_effect:source_code"
       - "repository_effect:tests"
       - "task_outcome"
-commit: null
+commit:
+  hash: "2ce9ad411025921a1b82b7f8b383501fd655d342"
+  message: "🚧 MGB383 task: apply external agent result"
 comments:
   -
     author: "CODER"
     body: "Start: continue branch_pr task in the dedicated task worktree."
+  -
+    author: "SUPERVISOR"
+    body: "Implementation committed: 2ce9ad411025. CLI accepted one state-bound external-agent semantic result."
 events:
   -
     type: "status"
@@ -254,9 +264,17 @@ events:
     from: "DOING"
     to: "DOING"
     commit: "6f127b5ad60646d6233d08ec333b16035bc40279"
+  -
+    type: "status"
+    at: "2026-09-11T18:53:27.398Z"
+    author: "SUPERVISOR"
+    from: "DOING"
+    to: "DOING"
+    note: "Implementation committed: 2ce9ad411025. CLI accepted one state-bound external-agent semantic result."
+    commit: "2ce9ad411025921a1b82b7f8b383501fd655d342"
 doc_version: 3
-doc_updated_at: "2026-09-11T18:51:27.640Z"
-doc_updated_by: "CODER"
+doc_updated_at: "2026-09-11T18:53:27.398Z"
+doc_updated_by: "SUPERVISOR"
 description: "GitHub issue #4848 is still relevant on current main. The release follow-up stages version surfaces but does not refresh or stage scripts/baselines/v0.7-compatibility-candidate.json, and verify-release-evidence-pr still publishes a synthetic PR verification check after workflow_dispatch instead of obtaining a native pull_request status accepted by branch protection. Make the generated next-development diff Prettier-clean, refresh and stage the compatibility candidate whenever the version surface advances, add a pre-push/pre-PR contract gate, and drive the close-tail through a native pull_request verification with regression coverage for action_required or empty native rollup. Do not weaken branch protection or use admin bypass. Issue: https://github.com/basilisk-labs/agentplane/issues/4848"
 sections:
   Summary: |-
@@ -614,7 +632,7 @@ extensions:
       revision: 1
       schema_version: 1
       task_id: "202609111340-MGB383"
-    event_cursor: 6
+    event_cursor: 8
     final_validation: null
     id: "202609111340-MGB383"
     intent:
@@ -634,9 +652,9 @@ extensions:
     lifecycle: "ACTIVE"
     plan_amendments: []
     plan_history: []
-    revision: 9
+    revision: 11
     schema_version: 1
-    updated_at: "2026-09-11T18:51:38.731Z"
+    updated_at: "2026-09-11T18:53:27.398Z"
     work_items:
       work-native-pr-verification:
         attempt: 1
@@ -789,6 +807,30 @@ extensions:
         previous_revision: 3
         schema_version: 1
         task_id: "202609111340-MGB383"
+      compatibility:sha256:44e73b17559a911182830f469995e7c2b4f7ddfa14a274ec0bddbeda00b4bba6:
+        aggregate_digest: "sha256:e31ebe03695eb0b6d40a94cbdf7acd2574eaea9197b7dc2846dd7af737bbe0b7"
+        event:
+          actor_id: "agentplane"
+          at: "2026-09-11T18:53:27.398Z"
+          cause_refs:
+            - "compatibility_projection_mutation"
+          entity: "task"
+          from: "ACTIVE"
+          id: "event_0790bf8c2406c825b082efc3"
+          mutation_id: "compatibility:sha256:44e73b17559a911182830f469995e7c2b4f7ddfa14a274ec0bddbeda00b4bba6"
+          plan_digest: "sha256:561ecf6a31e5da0501ae93d26c9f884af477f46a4b17250d7c9b5d40ae1f24fa"
+          plan_revision: 1
+          repository_fingerprint: null
+          schema_version: 1
+          task_id: "202609111340-MGB383"
+          task_revision: 10
+          to: "ACTIVE"
+          work_item_id: null
+        mutation_id: "compatibility:sha256:44e73b17559a911182830f469995e7c2b4f7ddfa14a274ec0bddbeda00b4bba6"
+        next_revision: 11
+        previous_revision: 10
+        schema_version: 1
+        task_id: "202609111340-MGB383"
       compatibility:sha256:aa8960213bb9882caf65594e4072847419b2b1afdb3e9e1a37122e775b307af0:
         aggregate_digest: "sha256:91d2efe8c5305283b14ee4b32d22802ae9727e5f953e8a12b10b54752abafd51"
         event:
@@ -861,6 +903,30 @@ extensions:
         previous_revision: 7
         schema_version: 1
         task_id: "202609111340-MGB383"
+      compatibility:sha256:f99fa24a918250c2b18f1b78c15bc156205db81c62c3d943da47ace4b0b45559:
+        aggregate_digest: "sha256:245f4b0e3498a8e207e753962386896bdd2d3be0d53a257e81d3ec6f33b78a48"
+        event:
+          actor_id: "agentplane"
+          at: "2026-09-11T18:53:27.398Z"
+          cause_refs:
+            - "compatibility_projection_mutation"
+          entity: "task"
+          from: "ACTIVE"
+          id: "event_6b7231298fd505a6dc694255"
+          mutation_id: "compatibility:sha256:f99fa24a918250c2b18f1b78c15bc156205db81c62c3d943da47ace4b0b45559"
+          plan_digest: "sha256:561ecf6a31e5da0501ae93d26c9f884af477f46a4b17250d7c9b5d40ae1f24fa"
+          plan_revision: 1
+          repository_fingerprint: null
+          schema_version: 1
+          task_id: "202609111340-MGB383"
+          task_revision: 9
+          to: "ACTIVE"
+          work_item_id: null
+        mutation_id: "compatibility:sha256:f99fa24a918250c2b18f1b78c15bc156205db81c62c3d943da47ace4b0b45559"
+        next_revision: 10
+        previous_revision: 9
+        schema_version: 1
+        task_id: "202609111340-MGB383"
       external-result:work-order-202609111340-MGB383-executor-45a8e43f6c5503dd1507e90d:
         aggregate_digest: "sha256:1dcf022444eaee223e044cbceb43c79a414774d089c945b22b7a8426e8ce41c6"
         event:
@@ -889,7 +955,7 @@ extensions:
     retry_budgets: []
     schema_version: 1
   implementation_commit:
-    hash: "6f127b5ad60646d6233d08ec333b16035bc40279"
+    hash: "2ce9ad411025921a1b82b7f8b383501fd655d342"
   task_execution_context:
     base_ref: "main"
     base_sha: "f774282d4a6ef8ce7da5bc08c8e2fd9abb99303d"

--- a/.agentplane/tasks/202609111340-MGB383/README.md
+++ b/.agentplane/tasks/202609111340-MGB383/README.md
@@ -4,7 +4,7 @@ title: "Harden the post-release evidence close-tail under branch protection for 
 status: "DOING"
 priority: "high"
 owner: "CODER"
-revision: 14
+revision: 15
 origin:
   system: "manual"
 depends_on: []
@@ -672,9 +672,9 @@ extensions:
     lifecycle: "ACTIVE"
     plan_amendments: []
     plan_history: []
-    revision: 14
+    revision: 15
     schema_version: 1
-    updated_at: "2026-09-11T18:54:58.671Z"
+    updated_at: "2026-09-11T18:55:04.446Z"
     work_items:
       work-native-pr-verification:
         attempt: 1
@@ -716,14 +716,44 @@ extensions:
           status: "passed"
           unsatisfied_criteria: []
       work-publish-contract:
-        attempt: 0
+        attempt: 1
         claim_id: null
         id: "work-publish-contract"
         last_failure: null
-        output_manifests: []
-        revision: 1
-        state: "PLANNED"
-        validation_result: null
+        output_manifests:
+          -
+            digest: "sha256:a90f021a389e4024216e23263fe2e30f407d870e9144910c3e64bbc2190143df"
+            id: "publish-contract-output"
+            kind: "semantic_output"
+            producer:
+              attempt: 1
+              plan_revision: 1
+              task_id: "202609111340-MGB383"
+              work_item_id: "work-publish-contract"
+            provenance:
+              - "sha256:ee74b738cc1121205598dbd5d90749598f4c8cc9e3f7cb4ff63846a4d00be064"
+              - ".agentplane/tasks/202609111340-MGB383/supervision/declared-checks.json"
+            repository_snapshot_digest: "sha256:852bfa000dc552f63672c984f8f572697df4ce8fe3641a572f30231a13a12dfe"
+            schema: "agentplane.semantic-output.v1"
+            schema_version: 1
+        revision: 2
+        state: "COMPLETED"
+        validation_result:
+          evidence:
+            -
+              artifact_refs:
+                - ".agentplane/tasks/202609111340-MGB383/supervision/declared-checks.json"
+              check_id: "check-focused-release"
+              command_identity: "bunx --no-install vitest run packages/agentplane/src/commands/release/open-next-development-version-script.test.ts packages/agentplane/src/commands/release/verify-release-evidence-pr-script.test.ts packages/agentplane/src/commands/release/publish-workflow-contract.test.ts --maxWorkers=1"
+              detail: "Observed by bunx --no-install vitest run packages/agentplane/src/commands/release/open-next-development-version-script.test.ts packages/agentplane/src/commands/release/verify-release-evidence-pr-script.test.ts packages/agentplane/src/commands/release/publish-workflow-contract.test.ts --maxWorkers=1."
+              exit_code: 0
+              observed_at: "2026-09-11T18:55:04.439Z"
+              repository_snapshot_digest: "sha256:852bfa000dc552f63672c984f8f572697df4ce8fe3641a572f30231a13a12dfe"
+              status: "passed"
+          schema_version: 1
+          stale_evidence: []
+          status: "passed"
+          unsatisfied_criteria: []
       work-version-surfaces:
         attempt: 1
         claim_id: null
@@ -800,6 +830,23 @@ extensions:
         task_id: "202609111340-MGB383"
         task_revision: 11
         work_item_id: "work-version-surfaces"
+      -
+        at: "2026-09-11T18:55:04.446Z"
+        from: "PLANNED"
+        to: "COMPLETED"
+        actor_id: "agentplane"
+        cause_refs:
+          - "semantic-result:sha256:5d85e04cce331d01fbf99fb0a7442ce777a4d883418fae5da461d9bbd4499757"
+        entity: "work_item"
+        id: "event_3cfedcf4d967e0f1648e3e36"
+        mutation_id: "external-result:work-order-202609111340-MGB383-executor-13b33b57c185d8ff07a3ebe9"
+        plan_digest: "sha256:561ecf6a31e5da0501ae93d26c9f884af477f46a4b17250d7c9b5d40ae1f24fa"
+        plan_revision: 1
+        repository_fingerprint: null
+        schema_version: 1
+        task_id: "202609111340-MGB383"
+        task_revision: 14
+        work_item_id: "work-publish-contract"
     leases: []
     mutation_receipts:
       compatibility:sha256:0d9670b99051a55edbb7ac41ecacbe142f74f39da97aca1c64b1642e23bfd5b9:
@@ -1040,6 +1087,30 @@ extensions:
         mutation_id: "compatibility:sha256:f99fa24a918250c2b18f1b78c15bc156205db81c62c3d943da47ace4b0b45559"
         next_revision: 10
         previous_revision: 9
+        schema_version: 1
+        task_id: "202609111340-MGB383"
+      external-result:work-order-202609111340-MGB383-executor-13b33b57c185d8ff07a3ebe9:
+        aggregate_digest: "sha256:0a9482877b26c7863aac9407878ef86967995486b7a0d4ed3e13d71a5ffd6610"
+        event:
+          actor_id: "agentplane"
+          at: "2026-09-11T18:55:04.446Z"
+          cause_refs:
+            - "semantic-result:sha256:5d85e04cce331d01fbf99fb0a7442ce777a4d883418fae5da461d9bbd4499757"
+          entity: "work_item"
+          from: "PLANNED"
+          id: "event_3cfedcf4d967e0f1648e3e36"
+          mutation_id: "external-result:work-order-202609111340-MGB383-executor-13b33b57c185d8ff07a3ebe9"
+          plan_digest: "sha256:561ecf6a31e5da0501ae93d26c9f884af477f46a4b17250d7c9b5d40ae1f24fa"
+          plan_revision: 1
+          repository_fingerprint: null
+          schema_version: 1
+          task_id: "202609111340-MGB383"
+          task_revision: 14
+          to: "COMPLETED"
+          work_item_id: "work-publish-contract"
+        mutation_id: "external-result:work-order-202609111340-MGB383-executor-13b33b57c185d8ff07a3ebe9"
+        next_revision: 15
+        previous_revision: 14
         schema_version: 1
         task_id: "202609111340-MGB383"
       external-result:work-order-202609111340-MGB383-executor-45a8e43f6c5503dd1507e90d:

--- a/.agentplane/tasks/202609111340-MGB383/README.md
+++ b/.agentplane/tasks/202609111340-MGB383/README.md
@@ -4,7 +4,7 @@ title: "Harden the post-release evidence close-tail under branch protection for 
 status: "DOING"
 priority: "high"
 owner: "CODER"
-revision: 12
+revision: 14
 origin:
   system: "manual"
 depends_on: []
@@ -104,15 +104,19 @@ execution_contract:
   observed:
     authority_violations: []
     changed_components:
+      - ".github"
       - "packages/agentplane"
       - "scripts"
     changed_paths:
+      - ".github/workflows/publish.yml"
       - "packages/agentplane/src/commands/release/open-next-development-version-script.test.ts"
+      - "packages/agentplane/src/commands/release/publish-workflow-contract.test.ts"
       - "packages/agentplane/src/commands/release/verify-release-evidence-pr-script.test.ts"
       - "scripts/lib/next-development-version.mjs"
       - "scripts/workflow/verify-release-evidence-pr.mjs"
     external_effects: []
     repository_effects:
+      - "ci"
       - "repository_write"
       - "source_code"
       - "tests"
@@ -166,12 +170,13 @@ execution_contract:
           implementation_uncertainty: "bounded"
           requirements_uncertainty: "bounded"
           reversibility: "recovery_required"
-      digest: "sha256:bda7ce45d3e95a62a0d511d902535e5279c23272e1c58fdaa29fe2ebdc9c4276"
+      digest: "sha256:1282777c20ff2cb54f9109b35a46a40fac81f76b01401e72444fd71c617b883e"
       escalation_reasons:
         - "central_component:.github/workflows/publish.yml"
         - "central_component:scripts/lib/next-development-version.mjs"
         - "central_component:scripts/release/open-next-development-version.mjs"
         - "central_component:scripts/workflow/verify-release-evidence-pr.mjs"
+        - "central_path:.github/workflows/publish.yml"
         - "central_path:scripts/lib/next-development-version.mjs"
         - "central_path:scripts/workflow/verify-release-evidence-pr.mjs"
         - "effect_ci"
@@ -185,15 +190,19 @@ execution_contract:
         - "cli"
       observed:
         changed_components:
+          - ".github"
           - "packages/agentplane"
           - "scripts"
         changed_files:
+          - ".github/workflows/publish.yml"
           - "packages/agentplane/src/commands/release/open-next-development-version-script.test.ts"
+          - "packages/agentplane/src/commands/release/publish-workflow-contract.test.ts"
           - "packages/agentplane/src/commands/release/verify-release-evidence-pr-script.test.ts"
           - "scripts/lib/next-development-version.mjs"
           - "scripts/workflow/verify-release-evidence-pr.mjs"
         external_effects: []
         repository_effects:
+          - "ci"
           - "repository_write"
           - "source_code"
           - "tests"
@@ -232,7 +241,9 @@ execution_contract:
       - "repository_effect:source_code"
       - "repository_effect:tests"
       - "task_outcome"
-commit: null
+commit:
+  hash: "ab800d228f1a8ad14f0fe44654dbcddcf1266cfa"
+  message: "🚧 MGB383 task: apply external agent result"
 comments:
   -
     author: "CODER"
@@ -240,6 +251,9 @@ comments:
   -
     author: "SUPERVISOR"
     body: "Implementation committed: 2ce9ad411025. CLI accepted one state-bound external-agent semantic result."
+  -
+    author: "SUPERVISOR"
+    body: "Implementation committed: ab800d228f1a. CLI accepted one state-bound external-agent semantic result."
 events:
   -
     type: "status"
@@ -270,8 +284,16 @@ events:
     to: "DOING"
     note: "Implementation committed: 2ce9ad411025. CLI accepted one state-bound external-agent semantic result."
     commit: "2ce9ad411025921a1b82b7f8b383501fd655d342"
+  -
+    type: "status"
+    at: "2026-09-11T18:54:58.671Z"
+    author: "SUPERVISOR"
+    from: "DOING"
+    to: "DOING"
+    note: "Implementation committed: ab800d228f1a. CLI accepted one state-bound external-agent semantic result."
+    commit: "ab800d228f1a8ad14f0fe44654dbcddcf1266cfa"
 doc_version: 3
-doc_updated_at: "2026-09-11T18:53:27.398Z"
+doc_updated_at: "2026-09-11T18:54:58.671Z"
 doc_updated_by: "SUPERVISOR"
 description: "GitHub issue #4848 is still relevant on current main. The release follow-up stages version surfaces but does not refresh or stage scripts/baselines/v0.7-compatibility-candidate.json, and verify-release-evidence-pr still publishes a synthetic PR verification check after workflow_dispatch instead of obtaining a native pull_request status accepted by branch protection. Make the generated next-development diff Prettier-clean, refresh and stage the compatibility candidate whenever the version surface advances, add a pre-push/pre-PR contract gate, and drive the close-tail through a native pull_request verification with regression coverage for action_required or empty native rollup. Do not weaken branch protection or use admin bypass. Issue: https://github.com/basilisk-labs/agentplane/issues/4848"
 sections:
@@ -630,7 +652,7 @@ extensions:
       revision: 1
       schema_version: 1
       task_id: "202609111340-MGB383"
-    event_cursor: 8
+    event_cursor: 10
     final_validation: null
     id: "202609111340-MGB383"
     intent:
@@ -650,9 +672,9 @@ extensions:
     lifecycle: "ACTIVE"
     plan_amendments: []
     plan_history: []
-    revision: 12
+    revision: 14
     schema_version: 1
-    updated_at: "2026-09-11T18:53:32.566Z"
+    updated_at: "2026-09-11T18:54:58.671Z"
     work_items:
       work-native-pr-verification:
         attempt: 1
@@ -804,6 +826,30 @@ extensions:
         previous_revision: 6
         schema_version: 1
         task_id: "202609111340-MGB383"
+      compatibility:sha256:1df0d37ff3203565f192f7428ea1fe128c2cfbd9088cd984ff5e0db955c85ac4:
+        aggregate_digest: "sha256:b9eb158f9d7653bf7ea2c4cd06cf19efbf12e01ce060d849edd21cc6e8a6eb4c"
+        event:
+          actor_id: "agentplane"
+          at: "2026-09-11T18:54:58.671Z"
+          cause_refs:
+            - "compatibility_projection_mutation"
+          entity: "task"
+          from: "ACTIVE"
+          id: "event_cd6526c38b151e2c92789151"
+          mutation_id: "compatibility:sha256:1df0d37ff3203565f192f7428ea1fe128c2cfbd9088cd984ff5e0db955c85ac4"
+          plan_digest: "sha256:561ecf6a31e5da0501ae93d26c9f884af477f46a4b17250d7c9b5d40ae1f24fa"
+          plan_revision: 1
+          repository_fingerprint: null
+          schema_version: 1
+          task_id: "202609111340-MGB383"
+          task_revision: 13
+          to: "ACTIVE"
+          work_item_id: null
+        mutation_id: "compatibility:sha256:1df0d37ff3203565f192f7428ea1fe128c2cfbd9088cd984ff5e0db955c85ac4"
+        next_revision: 14
+        previous_revision: 13
+        schema_version: 1
+        task_id: "202609111340-MGB383"
       compatibility:sha256:2ee8880913ca100651457df7cf734a1ea9d8f8ce32b1b2a291244f23ac254070:
         aggregate_digest: "sha256:d3c1f46829b97ab9c3494a730223f741349fbaa78d1a82a958196a45be714d45"
         event:
@@ -898,6 +944,30 @@ extensions:
         mutation_id: "compatibility:sha256:aa8960213bb9882caf65594e4072847419b2b1afdb3e9e1a37122e775b307af0"
         next_revision: 5
         previous_revision: 4
+        schema_version: 1
+        task_id: "202609111340-MGB383"
+      compatibility:sha256:c0b7229f1eace6d585734c47cf51aaa51f1f9caa6c7d16cf0a347ffe6d08043b:
+        aggregate_digest: "sha256:bd5cb0f8541e801c3577e77aa0eae33c6265d0907daafcf44343c57bcc560c85"
+        event:
+          actor_id: "agentplane"
+          at: "2026-09-11T18:54:58.671Z"
+          cause_refs:
+            - "compatibility_projection_mutation"
+          entity: "task"
+          from: "ACTIVE"
+          id: "event_afc8b66f9e6f23867b537246"
+          mutation_id: "compatibility:sha256:c0b7229f1eace6d585734c47cf51aaa51f1f9caa6c7d16cf0a347ffe6d08043b"
+          plan_digest: "sha256:561ecf6a31e5da0501ae93d26c9f884af477f46a4b17250d7c9b5d40ae1f24fa"
+          plan_revision: 1
+          repository_fingerprint: null
+          schema_version: 1
+          task_id: "202609111340-MGB383"
+          task_revision: 12
+          to: "ACTIVE"
+          work_item_id: null
+        mutation_id: "compatibility:sha256:c0b7229f1eace6d585734c47cf51aaa51f1f9caa6c7d16cf0a347ffe6d08043b"
+        next_revision: 13
+        previous_revision: 12
         schema_version: 1
         task_id: "202609111340-MGB383"
       compatibility:sha256:c629e1cb3b0716b944b9a72dbb85e963bc5e720deccd7d029e170f204cf200b6:
@@ -1024,7 +1094,7 @@ extensions:
     retry_budgets: []
     schema_version: 1
   implementation_commit:
-    hash: "2ce9ad411025921a1b82b7f8b383501fd655d342"
+    hash: "ab800d228f1a8ad14f0fe44654dbcddcf1266cfa"
   task_execution_context:
     base_ref: "main"
     base_sha: "f774282d4a6ef8ce7da5bc08c8e2fd9abb99303d"

--- a/.agentplane/tasks/202609111340-MGB383/blueprint/resolved-snapshot.json
+++ b/.agentplane/tasks/202609111340-MGB383/blueprint/resolved-snapshot.json
@@ -1,0 +1,467 @@
+{
+  "schemaVersion": 1,
+  "artifactKind": "agentplane.blueprint.resolved_snapshot",
+  "resolverInput": {
+    "taskId": "202609111340-MGB383",
+    "title": "Harden the post-release evidence close-tail under branch protection for GitHub issue #4848",
+    "description": "GitHub issue #4848 is still relevant on current main. The release follow-up stages version surfaces but does not refresh or stage scripts/baselines/v0.7-compatibility-candidate.json, and verify-release-evidence-pr still publishes a synthetic PR verification check after workflow_dispatch instead of obtaining a native pull_request status accepted by branch protection. Make the generated next-development diff Prettier-clean, refresh and stage the compatibility candidate whenever the version surface advances, add a pre-push/pre-PR contract gate, and drive the close-tail through a native pull_request verification with regression coverage for action_required or empty native rollup. Do not weaken branch protection or use admin bypass. Issue: https://github.com/basilisk-labs/agentplane/issues/4848",
+    "tags": [
+      "ci",
+      "github-issue",
+      "release"
+    ],
+    "owner": "CODER",
+    "taskKind": "release",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "mutation": "release",
+    "mutationScope": "release",
+    "touchedPaths": [],
+    "recipeHints": [],
+    "riskFlags": [
+      "external_system"
+    ],
+    "blueprintRequest": "release.strict"
+  },
+  "selectedBlueprint": {
+    "id": "release.strict",
+    "version": 1,
+    "title": "Strict release",
+    "taskKinds": [
+      "release"
+    ],
+    "workflowModes": [
+      "direct",
+      "branch_pr"
+    ]
+  },
+  "plan": {
+    "schemaVersion": 1,
+    "blueprintId": "release.strict",
+    "blueprintVersion": 1,
+    "title": "Strict release",
+    "taskId": "202609111340-MGB383",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "taskIntent": {
+      "taskKind": "release",
+      "mutationScope": "release",
+      "riskFlags": [
+        "external_system"
+      ],
+      "blueprintRequest": "release.strict"
+    },
+    "whySelected": [
+      "explicit blueprint requested: release.strict",
+      "task intent kind: release",
+      "workflow mode: branch_pr",
+      "task intent mutation scope: release"
+    ],
+    "states": [
+      {
+        "id": "intake",
+        "kind": "intake",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": []
+      },
+      {
+        "id": "scope",
+        "kind": "scope",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "assumptions"
+        ]
+      },
+      {
+        "id": "approval_gate",
+        "kind": "approval_gate",
+        "mode": "approval",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "approval"
+        ]
+      },
+      {
+        "id": "context_resolve",
+        "kind": "context_resolve",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [
+          ".agentplane/policy/security.must.md",
+          ".agentplane/policy/dod.core.md",
+          ".agentplane/policy/dod.code.md",
+          ".agentplane/policy/workflow.release.md"
+        ],
+        "evidenceKinds": [
+          "context_manifest"
+        ]
+      },
+      {
+        "id": "work_unit",
+        "kind": "work_unit",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "artifact"
+        ]
+      },
+      {
+        "id": "deterministic_check",
+        "kind": "deterministic_check",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "publish_or_integrate",
+        "kind": "publish_or_integrate",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit",
+          "external_link"
+        ]
+      },
+      {
+        "id": "verify_record",
+        "kind": "verify_record",
+        "mode": "record",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "quality_gate",
+        "kind": "quality_gate",
+        "mode": "agentic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "quality_report"
+        ]
+      },
+      {
+        "id": "finish",
+        "kind": "finish",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit"
+        ]
+      }
+    ],
+    "requiredEvidence": [
+      {
+        "id": "release.approval",
+        "kind": "approval",
+        "producedBy": "approval_gate",
+        "required": true,
+        "description": "Release approval."
+      },
+      {
+        "id": "release.plan",
+        "kind": "artifact",
+        "producedBy": "work_unit",
+        "required": true,
+        "description": "Release plan or candidate artifact."
+      },
+      {
+        "id": "release.check",
+        "kind": "check_result",
+        "producedBy": "deterministic_check",
+        "required": true,
+        "description": "Release gates."
+      },
+      {
+        "id": "release.publish",
+        "kind": "external_link",
+        "producedBy": "publish_or_integrate",
+        "required": true,
+        "description": "Publish evidence."
+      },
+      {
+        "id": "release.commit",
+        "kind": "commit",
+        "producedBy": "publish_or_integrate",
+        "required": true,
+        "description": "Release commit."
+      },
+      {
+        "id": "release.quality",
+        "kind": "quality_report",
+        "producedBy": "quality_gate",
+        "required": true,
+        "description": "EVALUATOR quality verdict."
+      }
+    ],
+    "policyModules": [
+      ".agentplane/policy/dod.code.md",
+      ".agentplane/policy/dod.core.md",
+      ".agentplane/policy/security.must.md",
+      ".agentplane/policy/workflow.release.md"
+    ],
+    "allowedCommands": [
+      "agentplane task verify-show <task-id>",
+      "agentplane verify <task-id> --ok|--rework",
+      "publish commands after approval",
+      "release gates"
+    ],
+    "contextBudget": {
+      "maxPolicyModules": 4,
+      "maxPromptBlocks": 16,
+      "rationale": "Release work needs strict release policy, approval evidence, and rollback context."
+    },
+    "contextManifest": [],
+    "acceptedRecipeExtensions": [],
+    "rejectedRecipeExtensions": [],
+    "stopReasons": []
+  },
+  "nodes": [
+    {
+      "id": "intake",
+      "kind": "intake",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": []
+    },
+    {
+      "id": "scope",
+      "kind": "scope",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "assumptions"
+      ]
+    },
+    {
+      "id": "approval_gate",
+      "kind": "approval_gate",
+      "mode": "approval",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "approval"
+      ]
+    },
+    {
+      "id": "context_resolve",
+      "kind": "context_resolve",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [
+        ".agentplane/policy/security.must.md",
+        ".agentplane/policy/dod.core.md",
+        ".agentplane/policy/dod.code.md",
+        ".agentplane/policy/workflow.release.md"
+      ],
+      "evidenceKinds": [
+        "context_manifest"
+      ]
+    },
+    {
+      "id": "work_unit",
+      "kind": "work_unit",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "artifact"
+      ]
+    },
+    {
+      "id": "deterministic_check",
+      "kind": "deterministic_check",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "publish_or_integrate",
+      "kind": "publish_or_integrate",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit",
+        "external_link"
+      ]
+    },
+    {
+      "id": "verify_record",
+      "kind": "verify_record",
+      "mode": "record",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "quality_gate",
+      "kind": "quality_gate",
+      "mode": "agentic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "quality_report"
+      ]
+    },
+    {
+      "id": "finish",
+      "kind": "finish",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit"
+      ]
+    }
+  ],
+  "requiredEvidence": [
+    {
+      "id": "release.approval",
+      "kind": "approval",
+      "producedBy": "approval_gate",
+      "required": true,
+      "description": "Release approval."
+    },
+    {
+      "id": "release.plan",
+      "kind": "artifact",
+      "producedBy": "work_unit",
+      "required": true,
+      "description": "Release plan or candidate artifact."
+    },
+    {
+      "id": "release.check",
+      "kind": "check_result",
+      "producedBy": "deterministic_check",
+      "required": true,
+      "description": "Release gates."
+    },
+    {
+      "id": "release.publish",
+      "kind": "external_link",
+      "producedBy": "publish_or_integrate",
+      "required": true,
+      "description": "Publish evidence."
+    },
+    {
+      "id": "release.commit",
+      "kind": "commit",
+      "producedBy": "publish_or_integrate",
+      "required": true,
+      "description": "Release commit."
+    },
+    {
+      "id": "release.quality",
+      "kind": "quality_report",
+      "producedBy": "quality_gate",
+      "required": true,
+      "description": "EVALUATOR quality verdict."
+    }
+  ],
+  "policyModules": [
+    ".agentplane/policy/dod.code.md",
+    ".agentplane/policy/dod.core.md",
+    ".agentplane/policy/security.must.md",
+    ".agentplane/policy/workflow.release.md"
+  ],
+  "allowedCommands": [
+    "agentplane task verify-show <task-id>",
+    "agentplane verify <task-id> --ok|--rework",
+    "publish commands after approval",
+    "release gates"
+  ],
+  "contextBudget": {
+    "maxPolicyModules": 4,
+    "maxPromptBlocks": 16,
+    "rationale": "Release work needs strict release policy, approval evidence, and rollback context."
+  },
+  "contextManifest": [],
+  "acceptedRecipeExtensions": [],
+  "rejectedRecipeExtensions": [],
+  "stopReasons": [],
+  "selectionReasons": [
+    "explicit blueprint requested: release.strict",
+    "task intent kind: release",
+    "workflow mode: branch_pr",
+    "task intent mutation scope: release"
+  ],
+  "digest": {
+    "algorithm": "sha256",
+    "value": "5e117f855511db9899a92a6c6d2d159ca447590d353c55ff774a02f3875378af"
+  }
+}

--- a/.agentplane/tasks/202609111340-MGB383/pr/diffstat.txt
+++ b/.agentplane/tasks/202609111340-MGB383/pr/diffstat.txt
@@ -1,3 +1,5 @@
+ .../open-next-development-version-script.test.ts   |  22 +++-
  .../verify-release-evidence-pr-script.test.ts      |  68 +++++++------
+ scripts/lib/next-development-version.mjs           |  31 +++++-
  scripts/workflow/verify-release-evidence-pr.mjs    | 111 +++++++++++----------
- 2 files changed, 99 insertions(+), 80 deletions(-)
+ 4 files changed, 150 insertions(+), 82 deletions(-)

--- a/.agentplane/tasks/202609111340-MGB383/pr/diffstat.txt
+++ b/.agentplane/tasks/202609111340-MGB383/pr/diffstat.txt
@@ -1,0 +1,3 @@
+ .../verify-release-evidence-pr-script.test.ts      |  68 +++++++------
+ scripts/workflow/verify-release-evidence-pr.mjs    | 111 +++++++++++----------
+ 2 files changed, 99 insertions(+), 80 deletions(-)

--- a/.agentplane/tasks/202609111340-MGB383/pr/diffstat.txt
+++ b/.agentplane/tasks/202609111340-MGB383/pr/diffstat.txt
@@ -1,5 +1,7 @@
+ .github/workflows/publish.yml                      |  15 ++-
  .../open-next-development-version-script.test.ts   |  22 +++-
+ .../release/publish-workflow-contract.test.ts      |  17 +++-
  .../verify-release-evidence-pr-script.test.ts      |  68 +++++++------
  scripts/lib/next-development-version.mjs           |  31 +++++-
  scripts/workflow/verify-release-evidence-pr.mjs    | 111 +++++++++++----------
- 4 files changed, 150 insertions(+), 82 deletions(-)
+ 6 files changed, 180 insertions(+), 84 deletions(-)

--- a/.agentplane/tasks/202609111340-MGB383/pr/github-body.md
+++ b/.agentplane/tasks/202609111340-MGB383/pr/github-body.md
@@ -1,0 +1,35 @@
+Task: `202609111340-MGB383`
+Title: Harden the post-release evidence close-tail under branch protection for GitHub issue #4848
+Canonical task record: `.agentplane/tasks/202609111340-MGB383/README.md`
+
+## Summary
+
+Harden the post-release evidence close-tail under branch protection for GitHub issue #4848
+
+GitHub issue #4848 is still relevant on current main. The release follow-up stages version surfaces but does not refresh or stage scripts/baselines/v0.7-compatibility-candidate.json, and verify-release-evidence-pr still publishes a synthetic PR verification check after workflow_dispatch instead of obtaining a native pull_request status accepted by branch protection. Make the generated next-development diff Prettier-clean, refresh and stage the compatibility candidate whenever the version surface advances, add a pre-push/pre-PR contract gate, and drive the close-tail through a native pull_request verification with regression coverage for action_required or empty native rollup. Do not weaken branch protection or use admin bypass. Issue: https://github.com/basilisk-labs/agentplane/issues/4848
+
+## Scope
+
+- In scope: GitHub issue #4848 is still relevant on current main. The release follow-up stages version surfaces but does not refresh or stage scripts/baselines/v0.7-compatibility-candidate.json, and verify-release-evidence-pr still publishes a synthetic PR verification check after workflow_dispatch instead of obtaining a native pull_request status accepted by branch protection. Make the generated next-development diff Prettier-clean, refresh and stage the compatibility candidate whenever the version surface advances, add a pre-push/pre-PR contract gate, and drive the close-tail through a native pull_request verification with regression coverage for action_required or empty native rollup. Do not weaken branch protection or use admin bypass. Issue: https://github.com/basilisk-labs/agentplane/issues/4848.
+- Out of scope: unrelated refactors not required for "Harden the post-release evidence close-tail under branch protection for GitHub issue #4848".
+
+## Verification
+
+- State: pending
+- Note: Not recorded yet.
+- Canonical workflow state lives in the task README.
+
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-09-11T18:45:55.843Z
+- Branch: task/202609111340-MGB383/harden-the-post-release-evidence-close-tail-unde
+- Head: computed live by `agentplane pr check` / `agentplane integrate`
+
+```text
+ .../verify-release-evidence-pr-script.test.ts      |  68 +++++++------
+ scripts/workflow/verify-release-evidence-pr.mjs    | 111 +++++++++++----------
+ 2 files changed, 99 insertions(+), 80 deletions(-)
+```
+
+</details>

--- a/.agentplane/tasks/202609111340-MGB383/pr/github-body.md
+++ b/.agentplane/tasks/202609111340-MGB383/pr/github-body.md
@@ -27,11 +27,13 @@ GitHub issue #4848 is still relevant on current main. The release follow-up stag
 - Head: computed live by `agentplane pr check` / `agentplane integrate`
 
 ```text
+ .github/workflows/publish.yml                      |  15 ++-
  .../open-next-development-version-script.test.ts   |  22 +++-
+ .../release/publish-workflow-contract.test.ts      |  17 +++-
  .../verify-release-evidence-pr-script.test.ts      |  68 +++++++------
  scripts/lib/next-development-version.mjs           |  31 +++++-
  scripts/workflow/verify-release-evidence-pr.mjs    | 111 +++++++++++----------
- 4 files changed, 150 insertions(+), 82 deletions(-)
+ 6 files changed, 180 insertions(+), 84 deletions(-)
 ```
 
 </details>

--- a/.agentplane/tasks/202609111340-MGB383/pr/github-body.md
+++ b/.agentplane/tasks/202609111340-MGB383/pr/github-body.md
@@ -27,9 +27,11 @@ GitHub issue #4848 is still relevant on current main. The release follow-up stag
 - Head: computed live by `agentplane pr check` / `agentplane integrate`
 
 ```text
+ .../open-next-development-version-script.test.ts   |  22 +++-
  .../verify-release-evidence-pr-script.test.ts      |  68 +++++++------
+ scripts/lib/next-development-version.mjs           |  31 +++++-
  scripts/workflow/verify-release-evidence-pr.mjs    | 111 +++++++++++----------
- 2 files changed, 99 insertions(+), 80 deletions(-)
+ 4 files changed, 150 insertions(+), 82 deletions(-)
 ```
 
 </details>

--- a/.agentplane/tasks/202609111340-MGB383/pr/github-title.txt
+++ b/.agentplane/tasks/202609111340-MGB383/pr/github-title.txt
@@ -1,0 +1,1 @@
+🚧 MGB383 task: Harden the post-release evidence close-tail under branch protection for GitHub issue #4848 [202609111340-MGB383]

--- a/.agentplane/tasks/202609111340-MGB383/pr/meta.json
+++ b/.agentplane/tasks/202609111340-MGB383/pr/meta.json
@@ -2,7 +2,7 @@
   "base": "main",
   "branch": "task/202609111340-MGB383/harden-the-post-release-evidence-close-tail-unde",
   "created_at": "2026-09-11T18:45:55.843Z",
-  "diffstat_sha256": "sha256:abca54a6a2ab14e2a6c7ed6337ced9c84c8b07301d5fcda1ab12185692938907",
+  "diffstat_sha256": "sha256:2bb16c25f782885477a0d6ce50c013c326290e2fa891362c0968cd8cfc2201c8",
   "last_verified_at": null,
   "provider": {
     "hostname": "github.com",

--- a/.agentplane/tasks/202609111340-MGB383/pr/meta.json
+++ b/.agentplane/tasks/202609111340-MGB383/pr/meta.json
@@ -2,7 +2,7 @@
   "base": "main",
   "branch": "task/202609111340-MGB383/harden-the-post-release-evidence-close-tail-unde",
   "created_at": "2026-09-11T18:45:55.843Z",
-  "diffstat_sha256": "sha256:678b1bac3e312a57e71de7f43d0ffa313e0a487d3a5c3a1329a2b18fc929a85e",
+  "diffstat_sha256": "sha256:abca54a6a2ab14e2a6c7ed6337ced9c84c8b07301d5fcda1ab12185692938907",
   "last_verified_at": null,
   "provider": {
     "hostname": "github.com",

--- a/.agentplane/tasks/202609111340-MGB383/pr/meta.json
+++ b/.agentplane/tasks/202609111340-MGB383/pr/meta.json
@@ -1,0 +1,21 @@
+{
+  "base": "main",
+  "branch": "task/202609111340-MGB383/harden-the-post-release-evidence-close-tail-unde",
+  "created_at": "2026-09-11T18:45:55.843Z",
+  "diffstat_sha256": "sha256:678b1bac3e312a57e71de7f43d0ffa313e0a487d3a5c3a1329a2b18fc929a85e",
+  "last_verified_at": null,
+  "provider": {
+    "hostname": "github.com",
+    "kind": "github",
+    "remote": "origin",
+    "schema_version": 1,
+    "source_project": "basilisk-labs/agentplane",
+    "target_project": "basilisk-labs/agentplane"
+  },
+  "schema_version": 1,
+  "task_id": "202609111340-MGB383",
+  "updated_at": "2026-09-11T18:45:55.843Z",
+  "verify": {
+    "status": "skipped"
+  }
+}

--- a/.agentplane/tasks/202609111340-MGB383/pr/review.md
+++ b/.agentplane/tasks/202609111340-MGB383/pr/review.md
@@ -1,0 +1,38 @@
+# PR Review
+
+Created: 2026-09-11T18:45:55.843Z
+
+## Task
+
+- Task: `202609111340-MGB383`
+- Title: Harden the post-release evidence close-tail under branch protection for GitHub issue #4848
+- Status: DOING
+- Branch: `task/202609111340-MGB383/harden-the-post-release-evidence-close-tail-unde`
+- Canonical task record: `.agentplane/tasks/202609111340-MGB383/README.md`
+
+## Verification
+
+- State: pending
+- Note: Not recorded yet.
+- Canonical workflow state lives in the task README.
+
+## Handoff Notes
+
+- No handoff notes recorded yet. Use `agentplane pr note ...` to append one.
+
+<!-- BEGIN AUTO SUMMARY -->
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-09-11T18:45:55.843Z
+- Branch: task/202609111340-MGB383/harden-the-post-release-evidence-close-tail-unde
+- Head: computed live by `agentplane pr check` / `agentplane integrate`
+
+```text
+ .../verify-release-evidence-pr-script.test.ts      |  68 +++++++------
+ scripts/workflow/verify-release-evidence-pr.mjs    | 111 +++++++++++----------
+ 2 files changed, 99 insertions(+), 80 deletions(-)
+```
+
+</details>
+<!-- END AUTO SUMMARY -->

--- a/.agentplane/tasks/202609111340-MGB383/pr/review.md
+++ b/.agentplane/tasks/202609111340-MGB383/pr/review.md
@@ -29,11 +29,13 @@ Created: 2026-09-11T18:45:55.843Z
 - Head: computed live by `agentplane pr check` / `agentplane integrate`
 
 ```text
+ .github/workflows/publish.yml                      |  15 ++-
  .../open-next-development-version-script.test.ts   |  22 +++-
+ .../release/publish-workflow-contract.test.ts      |  17 +++-
  .../verify-release-evidence-pr-script.test.ts      |  68 +++++++------
  scripts/lib/next-development-version.mjs           |  31 +++++-
  scripts/workflow/verify-release-evidence-pr.mjs    | 111 +++++++++++----------
- 4 files changed, 150 insertions(+), 82 deletions(-)
+ 6 files changed, 180 insertions(+), 84 deletions(-)
 ```
 
 </details>

--- a/.agentplane/tasks/202609111340-MGB383/pr/review.md
+++ b/.agentplane/tasks/202609111340-MGB383/pr/review.md
@@ -29,9 +29,11 @@ Created: 2026-09-11T18:45:55.843Z
 - Head: computed live by `agentplane pr check` / `agentplane integrate`
 
 ```text
+ .../open-next-development-version-script.test.ts   |  22 +++-
  .../verify-release-evidence-pr-script.test.ts      |  68 +++++++------
+ scripts/lib/next-development-version.mjs           |  31 +++++-
  scripts/workflow/verify-release-evidence-pr.mjs    | 111 +++++++++++----------
- 2 files changed, 99 insertions(+), 80 deletions(-)
+ 4 files changed, 150 insertions(+), 82 deletions(-)
 ```
 
 </details>

--- a/.agentplane/tasks/202609111340-MGB383/supervision/declared-checks.json
+++ b/.agentplane/tasks/202609111340-MGB383/supervision/declared-checks.json
@@ -5,7 +5,7 @@
         "check-focused-release"
       ],
       "command": "bunx --no-install vitest run packages/agentplane/src/commands/release/open-next-development-version-script.test.ts packages/agentplane/src/commands/release/verify-release-evidence-pr-script.test.ts packages/agentplane/src/commands/release/publish-workflow-contract.test.ts --maxWorkers=1",
-      "duration_ms": 4815,
+      "duration_ms": 3467,
       "exit_code": 0,
       "runtime": {
         "environment_digest": "sha256:3308005fac9d32f69b94b3df9ca32d660556868e17bec2215bbf27726c7cc603",
@@ -16,7 +16,7 @@
       },
       "script": null,
       "stderr_tail": "",
-      "stdout_tail": "\n RUN  v4.1.9 /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202609111340-MGB383-harden-the-post-release-evidence-close-tail-unde\n\n\n Test Files  3 passed (3)\n      Tests  42 passed (42)\n   Start at  21:51:35\n   Duration  3.32s (transform 60ms, setup 0ms, import 127ms, tests 3.00s, environment 0ms)\n\n"
+      "stdout_tail": "\n RUN  v4.1.9 /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202609111340-MGB383-harden-the-post-release-evidence-close-tail-unde\n\n\n Test Files  3 passed (3)\n      Tests  42 passed (42)\n   Start at  21:53:29\n   Duration  3.17s (transform 63ms, setup 0ms, import 145ms, tests 2.82s, environment 0ms)\n\n"
     }
   ],
   "kind": "direct_task_declared_checks",

--- a/.agentplane/tasks/202609111340-MGB383/supervision/declared-checks.json
+++ b/.agentplane/tasks/202609111340-MGB383/supervision/declared-checks.json
@@ -5,7 +5,7 @@
         "check-focused-release"
       ],
       "command": "bunx --no-install vitest run packages/agentplane/src/commands/release/open-next-development-version-script.test.ts packages/agentplane/src/commands/release/verify-release-evidence-pr-script.test.ts packages/agentplane/src/commands/release/publish-workflow-contract.test.ts --maxWorkers=1",
-      "duration_ms": 3467,
+      "duration_ms": 4028,
       "exit_code": 0,
       "runtime": {
         "environment_digest": "sha256:3308005fac9d32f69b94b3df9ca32d660556868e17bec2215bbf27726c7cc603",
@@ -16,7 +16,7 @@
       },
       "script": null,
       "stderr_tail": "",
-      "stdout_tail": "\n RUN  v4.1.9 /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202609111340-MGB383-harden-the-post-release-evidence-close-tail-unde\n\n\n Test Files  3 passed (3)\n      Tests  42 passed (42)\n   Start at  21:53:29\n   Duration  3.17s (transform 63ms, setup 0ms, import 145ms, tests 2.82s, environment 0ms)\n\n"
+      "stdout_tail": "\n RUN  v4.1.9 /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202609111340-MGB383-harden-the-post-release-evidence-close-tail-unde\n\n\n Test Files  3 passed (3)\n      Tests  42 passed (42)\n   Start at  21:55:00\n   Duration  3.79s (transform 74ms, setup 0ms, import 160ms, tests 3.41s, environment 0ms)\n\n"
     }
   ],
   "kind": "direct_task_declared_checks",

--- a/.agentplane/tasks/202609111340-MGB383/supervision/declared-checks.json
+++ b/.agentplane/tasks/202609111340-MGB383/supervision/declared-checks.json
@@ -1,0 +1,27 @@
+{
+  "checks": [
+    {
+      "check_ids": [
+        "check-focused-release"
+      ],
+      "command": "bunx --no-install vitest run packages/agentplane/src/commands/release/open-next-development-version-script.test.ts packages/agentplane/src/commands/release/verify-release-evidence-pr-script.test.ts packages/agentplane/src/commands/release/publish-workflow-contract.test.ts --maxWorkers=1",
+      "duration_ms": 4815,
+      "exit_code": 0,
+      "runtime": {
+        "environment_digest": "sha256:3308005fac9d32f69b94b3df9ca32d660556868e17bec2215bbf27726c7cc603",
+        "executable_digest": "sha256:afb43ad4efc9c7ddf503ff2dd8cd80d6e2485e336d388eb2b64d74e95d69a55c",
+        "kind": "local_runtime_resolution",
+        "status": "resolved",
+        "toolchain_digest": "sha256:291167c34a65f8d48ba977f0882cab96919f80af508e8938fde983cb899a9729"
+      },
+      "script": null,
+      "stderr_tail": "",
+      "stdout_tail": "\n RUN  v4.1.9 /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202609111340-MGB383-harden-the-post-release-evidence-close-tail-unde\n\n\n Test Files  3 passed (3)\n      Tests  42 passed (42)\n   Start at  21:51:35\n   Duration  3.32s (transform 60ms, setup 0ms, import 127ms, tests 3.00s, environment 0ms)\n\n"
+    }
+  ],
+  "kind": "direct_task_declared_checks",
+  "reason": null,
+  "schema_version": 1,
+  "status": "passed",
+  "task_id": "202609111340-MGB383"
+}

--- a/.agentplane/tasks/202609111340-MGB383/supervision/implementation-evidence.json
+++ b/.agentplane/tasks/202609111340-MGB383/supervision/implementation-evidence.json
@@ -1,7 +1,7 @@
 {
   "checks": [
     {
-      "command": "git diff --check 521cdc0310be7401234907b0b64e718973474dde..2ce9ad411025921a1b82b7f8b383501fd655d342",
+      "command": "git diff --check 2fa4c538aa40fcdf2b5b467ae07126a19cb13562..ab800d228f1a8ad14f0fe44654dbcddcf1266cfa",
       "id": "committed-diff-check",
       "result": "pass",
       "stdout": []
@@ -13,7 +13,7 @@
       "stdout": []
     },
     {
-      "command": "git diff --name-status --diff-filter=ACDMRTUXB 521cdc0310be7401234907b0b64e718973474dde..2ce9ad411025921a1b82b7f8b383501fd655d342",
+      "command": "git diff --name-status --diff-filter=ACDMRTUXB 2fa4c538aa40fcdf2b5b467ae07126a19cb13562..ab800d228f1a8ad14f0fe44654dbcddcf1266cfa",
       "id": "commit-paths",
       "result": "pass",
       "stdout": [
@@ -21,8 +21,8 @@
         "M\t.agentplane/tasks/202609111340-MGB383/pr/github-body.md",
         "M\t.agentplane/tasks/202609111340-MGB383/pr/meta.json",
         "M\t.agentplane/tasks/202609111340-MGB383/pr/review.md",
-        "M\tpackages/agentplane/src/commands/release/open-next-development-version-script.test.ts",
-        "M\tscripts/lib/next-development-version.mjs"
+        "M\t.github/workflows/publish.yml",
+        "M\tpackages/agentplane/src/commands/release/publish-workflow-contract.test.ts"
       ]
     },
     {
@@ -32,8 +32,8 @@
       "stdout": []
     }
   ],
-  "execution_base_commit": "521cdc0310be7401234907b0b64e718973474dde",
-  "implementation_commit": "2ce9ad411025921a1b82b7f8b383501fd655d342",
+  "execution_base_commit": "2fa4c538aa40fcdf2b5b467ae07126a19cb13562",
+  "implementation_commit": "ab800d228f1a8ad14f0fe44654dbcddcf1266cfa",
   "kind": "direct_task_implementation_evidence",
   "repository_status": {
     "baseline": [],

--- a/.agentplane/tasks/202609111340-MGB383/supervision/implementation-evidence.json
+++ b/.agentplane/tasks/202609111340-MGB383/supervision/implementation-evidence.json
@@ -1,7 +1,7 @@
 {
   "checks": [
     {
-      "command": "git diff --check f774282d4a6ef8ce7da5bc08c8e2fd9abb99303d..6f127b5ad60646d6233d08ec333b16035bc40279",
+      "command": "git diff --check 521cdc0310be7401234907b0b64e718973474dde..2ce9ad411025921a1b82b7f8b383501fd655d342",
       "id": "committed-diff-check",
       "result": "pass",
       "stdout": []
@@ -13,92 +13,34 @@
       "stdout": []
     },
     {
-      "command": "git diff --name-status --diff-filter=ACDMRTUXB f774282d4a6ef8ce7da5bc08c8e2fd9abb99303d..6f127b5ad60646d6233d08ec333b16035bc40279",
+      "command": "git diff --name-status --diff-filter=ACDMRTUXB 521cdc0310be7401234907b0b64e718973474dde..2ce9ad411025921a1b82b7f8b383501fd655d342",
       "id": "commit-paths",
       "result": "pass",
       "stdout": [
-        "A\t.agentplane/tasks/202609111340-MGB383/README.md",
-        "A\t.agentplane/tasks/202609111340-MGB383/blueprint/resolved-snapshot.json",
-        "A\t.agentplane/tasks/202609111340-MGB383/pr/diffstat.txt",
-        "A\t.agentplane/tasks/202609111340-MGB383/pr/github-body.md",
-        "A\t.agentplane/tasks/202609111340-MGB383/pr/github-title.txt",
-        "A\t.agentplane/tasks/202609111340-MGB383/pr/meta.json",
-        "A\t.agentplane/tasks/202609111340-MGB383/pr/review.md",
-        "M\tpackages/agentplane/src/commands/release/verify-release-evidence-pr-script.test.ts",
-        "M\tscripts/workflow/verify-release-evidence-pr.mjs"
+        "M\t.agentplane/tasks/202609111340-MGB383/pr/diffstat.txt",
+        "M\t.agentplane/tasks/202609111340-MGB383/pr/github-body.md",
+        "M\t.agentplane/tasks/202609111340-MGB383/pr/meta.json",
+        "M\t.agentplane/tasks/202609111340-MGB383/pr/review.md",
+        "M\tpackages/agentplane/src/commands/release/open-next-development-version-script.test.ts",
+        "M\tscripts/lib/next-development-version.mjs"
       ]
     },
     {
       "command": "git status --short --untracked-files=all",
       "id": "final-repository-status",
       "result": "pass",
-      "stdout": [
-        " M .agentplane/tasks/202609111340-MGB383/README.md"
-      ]
+      "stdout": []
     }
   ],
-  "execution_base_commit": "f774282d4a6ef8ce7da5bc08c8e2fd9abb99303d",
-  "implementation_commit": "6f127b5ad60646d6233d08ec333b16035bc40279",
+  "execution_base_commit": "521cdc0310be7401234907b0b64e718973474dde",
+  "implementation_commit": "2ce9ad411025921a1b82b7f8b383501fd655d342",
   "kind": "direct_task_implementation_evidence",
   "repository_status": {
-    "baseline": [
-      "?? .agentplane/tasks/202609111340-MGB383/README.md",
-      "?? .agentplane/tasks/202609111340-MGB383/blueprint/resolved-snapshot.json",
-      "?? .agentplane/tasks/202609111340-MGB383/pr/diffstat.txt",
-      "?? .agentplane/tasks/202609111340-MGB383/pr/github-body.md",
-      "?? .agentplane/tasks/202609111340-MGB383/pr/github-title.txt",
-      "?? .agentplane/tasks/202609111340-MGB383/pr/meta.json",
-      "?? .agentplane/tasks/202609111340-MGB383/pr/review.md"
-    ],
-    "classification": [
-      {
-        "classification": "introduced_during_execution",
-        "line": " M .agentplane/tasks/202609111340-MGB383/README.md"
-      },
-      {
-        "classification": "removed_during_execution",
-        "line": "?? .agentplane/tasks/202609111340-MGB383/README.md"
-      },
-      {
-        "classification": "removed_during_execution",
-        "line": "?? .agentplane/tasks/202609111340-MGB383/blueprint/resolved-snapshot.json"
-      },
-      {
-        "classification": "removed_during_execution",
-        "line": "?? .agentplane/tasks/202609111340-MGB383/pr/diffstat.txt"
-      },
-      {
-        "classification": "removed_during_execution",
-        "line": "?? .agentplane/tasks/202609111340-MGB383/pr/github-body.md"
-      },
-      {
-        "classification": "removed_during_execution",
-        "line": "?? .agentplane/tasks/202609111340-MGB383/pr/github-title.txt"
-      },
-      {
-        "classification": "removed_during_execution",
-        "line": "?? .agentplane/tasks/202609111340-MGB383/pr/meta.json"
-      },
-      {
-        "classification": "removed_during_execution",
-        "line": "?? .agentplane/tasks/202609111340-MGB383/pr/review.md"
-      }
-    ],
-    "final": [
-      " M .agentplane/tasks/202609111340-MGB383/README.md"
-    ],
-    "introduced_after_execution_baseline": [
-      " M .agentplane/tasks/202609111340-MGB383/README.md"
-    ],
-    "removed_after_execution_baseline": [
-      "?? .agentplane/tasks/202609111340-MGB383/README.md",
-      "?? .agentplane/tasks/202609111340-MGB383/blueprint/resolved-snapshot.json",
-      "?? .agentplane/tasks/202609111340-MGB383/pr/diffstat.txt",
-      "?? .agentplane/tasks/202609111340-MGB383/pr/github-body.md",
-      "?? .agentplane/tasks/202609111340-MGB383/pr/github-title.txt",
-      "?? .agentplane/tasks/202609111340-MGB383/pr/meta.json",
-      "?? .agentplane/tasks/202609111340-MGB383/pr/review.md"
-    ],
+    "baseline": [],
+    "classification": [],
+    "final": [],
+    "introduced_after_execution_baseline": [],
+    "removed_after_execution_baseline": [],
     "unchanged_from_execution_baseline": []
   },
   "schema_version": 1,

--- a/.agentplane/tasks/202609111340-MGB383/supervision/implementation-evidence.json
+++ b/.agentplane/tasks/202609111340-MGB383/supervision/implementation-evidence.json
@@ -1,0 +1,106 @@
+{
+  "checks": [
+    {
+      "command": "git diff --check f774282d4a6ef8ce7da5bc08c8e2fd9abb99303d..6f127b5ad60646d6233d08ec333b16035bc40279",
+      "id": "committed-diff-check",
+      "result": "pass",
+      "stdout": []
+    },
+    {
+      "command": "git diff --cached --check",
+      "id": "staged-diff-check",
+      "result": "pass",
+      "stdout": []
+    },
+    {
+      "command": "git diff --name-status --diff-filter=ACDMRTUXB f774282d4a6ef8ce7da5bc08c8e2fd9abb99303d..6f127b5ad60646d6233d08ec333b16035bc40279",
+      "id": "commit-paths",
+      "result": "pass",
+      "stdout": [
+        "A\t.agentplane/tasks/202609111340-MGB383/README.md",
+        "A\t.agentplane/tasks/202609111340-MGB383/blueprint/resolved-snapshot.json",
+        "A\t.agentplane/tasks/202609111340-MGB383/pr/diffstat.txt",
+        "A\t.agentplane/tasks/202609111340-MGB383/pr/github-body.md",
+        "A\t.agentplane/tasks/202609111340-MGB383/pr/github-title.txt",
+        "A\t.agentplane/tasks/202609111340-MGB383/pr/meta.json",
+        "A\t.agentplane/tasks/202609111340-MGB383/pr/review.md",
+        "M\tpackages/agentplane/src/commands/release/verify-release-evidence-pr-script.test.ts",
+        "M\tscripts/workflow/verify-release-evidence-pr.mjs"
+      ]
+    },
+    {
+      "command": "git status --short --untracked-files=all",
+      "id": "final-repository-status",
+      "result": "pass",
+      "stdout": [
+        " M .agentplane/tasks/202609111340-MGB383/README.md"
+      ]
+    }
+  ],
+  "execution_base_commit": "f774282d4a6ef8ce7da5bc08c8e2fd9abb99303d",
+  "implementation_commit": "6f127b5ad60646d6233d08ec333b16035bc40279",
+  "kind": "direct_task_implementation_evidence",
+  "repository_status": {
+    "baseline": [
+      "?? .agentplane/tasks/202609111340-MGB383/README.md",
+      "?? .agentplane/tasks/202609111340-MGB383/blueprint/resolved-snapshot.json",
+      "?? .agentplane/tasks/202609111340-MGB383/pr/diffstat.txt",
+      "?? .agentplane/tasks/202609111340-MGB383/pr/github-body.md",
+      "?? .agentplane/tasks/202609111340-MGB383/pr/github-title.txt",
+      "?? .agentplane/tasks/202609111340-MGB383/pr/meta.json",
+      "?? .agentplane/tasks/202609111340-MGB383/pr/review.md"
+    ],
+    "classification": [
+      {
+        "classification": "introduced_during_execution",
+        "line": " M .agentplane/tasks/202609111340-MGB383/README.md"
+      },
+      {
+        "classification": "removed_during_execution",
+        "line": "?? .agentplane/tasks/202609111340-MGB383/README.md"
+      },
+      {
+        "classification": "removed_during_execution",
+        "line": "?? .agentplane/tasks/202609111340-MGB383/blueprint/resolved-snapshot.json"
+      },
+      {
+        "classification": "removed_during_execution",
+        "line": "?? .agentplane/tasks/202609111340-MGB383/pr/diffstat.txt"
+      },
+      {
+        "classification": "removed_during_execution",
+        "line": "?? .agentplane/tasks/202609111340-MGB383/pr/github-body.md"
+      },
+      {
+        "classification": "removed_during_execution",
+        "line": "?? .agentplane/tasks/202609111340-MGB383/pr/github-title.txt"
+      },
+      {
+        "classification": "removed_during_execution",
+        "line": "?? .agentplane/tasks/202609111340-MGB383/pr/meta.json"
+      },
+      {
+        "classification": "removed_during_execution",
+        "line": "?? .agentplane/tasks/202609111340-MGB383/pr/review.md"
+      }
+    ],
+    "final": [
+      " M .agentplane/tasks/202609111340-MGB383/README.md"
+    ],
+    "introduced_after_execution_baseline": [
+      " M .agentplane/tasks/202609111340-MGB383/README.md"
+    ],
+    "removed_after_execution_baseline": [
+      "?? .agentplane/tasks/202609111340-MGB383/README.md",
+      "?? .agentplane/tasks/202609111340-MGB383/blueprint/resolved-snapshot.json",
+      "?? .agentplane/tasks/202609111340-MGB383/pr/diffstat.txt",
+      "?? .agentplane/tasks/202609111340-MGB383/pr/github-body.md",
+      "?? .agentplane/tasks/202609111340-MGB383/pr/github-title.txt",
+      "?? .agentplane/tasks/202609111340-MGB383/pr/meta.json",
+      "?? .agentplane/tasks/202609111340-MGB383/pr/review.md"
+    ],
+    "unchanged_from_execution_baseline": []
+  },
+  "schema_version": 1,
+  "task_id": "202609111340-MGB383"
+}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -910,6 +910,7 @@ jobs:
           git add \
             "${{ steps.release_evidence.outputs.readme_path }}" \
             .agentplane/WORKFLOW.md \
+            .agentplane/config.json \
             bun.lock \
             docs/reference/generated-reference.mdx \
             packages/agentplane/package.json \
@@ -917,7 +918,8 @@ jobs:
             packages/recipes/package.json \
             packages/recipes/src/index.ts \
             packages/spec/examples/acr.json \
-            packages/testkit/package.json
+            packages/testkit/package.json \
+            scripts/baselines/v0.7-compatibility-candidate.json
           unstaged="$(git diff --name-only)"
           if [ -n "${unstaged}" ]; then
             echo "next development version mutation left unstaged tracked files" >&2
@@ -932,6 +934,17 @@ jobs:
           git commit --no-verify -m "${commit_subject}"
           echo "created_commit=true" >> "$GITHUB_OUTPUT"
           echo "closure_sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+      - name: Validate release evidence branch contract
+        if: steps.apply_release_evidence.outputs.created_commit == 'true'
+        run: |
+          set -euo pipefail
+          bun run format:check
+          bun run bench:compatibility:candidate:check
+          if [ -n "$(git status --short --untracked-files=no)" ]; then
+            echo "release evidence branch contract checks mutated tracked files" >&2
+            git status --short --untracked-files=no >&2
+            exit 1
+          fi
       - name: Push release evidence branch
         if: steps.apply_release_evidence.outputs.created_commit == 'true'
         run: |

--- a/packages/agentplane/src/commands/release/open-next-development-version-script.test.ts
+++ b/packages/agentplane/src/commands/release/open-next-development-version-script.test.ts
@@ -1,5 +1,5 @@
 import { execFile } from "node:child_process";
-import { readFile, rm } from "node:fs/promises";
+import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { promisify } from "node:util";
 
@@ -42,6 +42,19 @@ afterEach(async () => {
 describe("open next development version", () => {
   it("atomically opens the next patch beta and is idempotent", async () => {
     const root = await workspace("0.2.6");
+    const capturePath = path.join(root, "scripts", "bench", "capture-compatibility-candidate.mjs");
+    await mkdir(path.dirname(capturePath), { recursive: true });
+    await mkdir(path.join(root, "scripts", "baselines"), { recursive: true });
+    await writeFile(
+      capturePath,
+      "import { writeFileSync } from 'node:fs'; writeFileSync('scripts/baselines/v0.7-compatibility-candidate.json', JSON.stringify({ version: '0.2.7-beta.1' }));\n",
+      "utf8",
+    );
+    await writeFile(
+      path.join(root, "scripts", "baselines", "v0.7-compatibility-candidate.json"),
+      '{"version":"0.2.6"}\n',
+      "utf8",
+    );
 
     const first = await execFileAsync(
       "node",
@@ -62,6 +75,7 @@ describe("open next development version", () => {
         "packages/core/package.json",
         "packages/recipes/package.json",
         "packages/recipes/src/index.ts",
+        "scripts/baselines/v0.7-compatibility-candidate.json",
       ]),
     );
     const agentplaneManifest = await readJson(root, "packages/agentplane/package.json");
@@ -73,6 +87,12 @@ describe("open next development version", () => {
     await expect(
       readFile(path.join(root, "packages", "recipes", "src", "index.ts"), "utf8"),
     ).resolves.toContain('RECIPES_VERSION = "0.2.7-beta.1"');
+    await expect(
+      readFile(
+        path.join(root, "scripts", "baselines", "v0.7-compatibility-candidate.json"),
+        "utf8",
+      ),
+    ).resolves.toBe('{ "version": "0.2.7-beta.1" }\n');
 
     const repeated = await execFileAsync(
       "node",

--- a/packages/agentplane/src/commands/release/publish-workflow-contract.test.ts
+++ b/packages/agentplane/src/commands/release/publish-workflow-contract.test.ts
@@ -463,9 +463,15 @@ describe("publish workflow contract", () => {
     expect(workflow).toContain("node scripts/release/open-next-development-version.mjs");
     expect(workflow).toContain('--published-version "${PUBLISHED_VERSION}"');
     expect(workflow).toContain("next-development-version.json");
+    expect(workflow).toContain(".agentplane/config.json");
+    expect(workflow).toContain("scripts/baselines/v0.7-compatibility-candidate.json");
     expect(workflow).toContain("release evidence follow-up branch is dirty before mutation");
     expect(workflow).toContain("next development version mutation left unstaged tracked files");
     expect(workflow).toContain("record publish evidence and open");
+    expect(workflow).toContain("Validate release evidence branch contract");
+    expect(workflow).toContain("bun run format:check");
+    expect(workflow).toContain("bun run bench:compatibility:candidate:check");
+    expect(workflow).toContain("release evidence branch contract checks mutated tracked files");
     expect(workflow).toContain("Open or recover release evidence PR");
     expect(workflow).toContain("Verify and merge exact release evidence SHA");
     expect(workflow).toContain("node scripts/workflow/verify-release-evidence-pr.mjs");
@@ -478,6 +484,7 @@ describe("publish workflow contract", () => {
     for (const stepName of [
       "Check for existing release evidence PR",
       "Apply release task evidence on a follow-up branch",
+      "Validate release evidence branch contract",
       "Push release evidence branch",
       "Open or recover release evidence PR",
       "Verify and merge exact release evidence SHA",
@@ -500,6 +507,12 @@ describe("publish workflow contract", () => {
         expect(stepBlock).toContain("GH_TOKEN: ${{ github.token }}");
       }
     }
+    expect(workflow.indexOf("Validate release evidence branch contract")).toBeLessThan(
+      workflow.indexOf("Push release evidence branch"),
+    );
+    expect(workflow.indexOf("Validate release evidence branch contract")).toBeLessThan(
+      workflow.indexOf("Open or recover release evidence PR"),
+    );
   });
 
   it("checks out base revision and initializes required submodules for publish", async () => {
@@ -601,7 +614,7 @@ describe("publish workflow contract", () => {
     expect(workflow).toContain('echo "stable release detection skipped for prerelease $VERSION"');
   });
 
-  it("validates the exact evidence SHA and publishes the required PR check before merge", async () => {
+  it("validates the exact evidence SHA through native pull_request checks before merge", async () => {
     const workflow = await readFile(PUBLISH_WORKFLOW_PATH, "utf8");
 
     expect(workflow).toContain("source.err");
@@ -613,6 +626,8 @@ describe("publish workflow contract", () => {
     expect(workflow).toContain('--pr-url "$pr_url"');
     expect(workflow).toContain('--repo "$REPO"');
     expect(workflow).toContain("release-evidence-closeout.json");
+    expect(workflow).not.toContain("name=PR verification");
+    expect(workflow).not.toContain("admin");
     expect(workflow.indexOf("Open or recover release evidence PR")).toBeLessThan(
       workflow.indexOf("Verify and merge exact release evidence SHA"),
     );

--- a/packages/agentplane/src/commands/release/verify-release-evidence-pr-script.test.ts
+++ b/packages/agentplane/src/commands/release/verify-release-evidence-pr-script.test.ts
@@ -42,23 +42,20 @@ async function makeFakeGh() {
       "const save = () => fs.writeFileSync(statePath, `${JSON.stringify(state, null, 2)}\\n`);",
       `const sha = ${JSON.stringify(SHA)};`,
       `const ref = ${JSON.stringify(REF)};`,
-      "const oldExact = { databaseId: 101, createdAt: '2026-08-05T19:00:00Z', event: 'workflow_dispatch', headBranch: ref, headSha: sha, status: 'completed', url: 'https://github.com/basilisk-labs/agentplane/actions/runs/101' };",
+      "const syntheticExact = { conclusion: 'success', databaseId: 101, createdAt: '2026-08-05T19:00:00Z', event: 'workflow_dispatch', headBranch: ref, headSha: sha, status: 'completed', url: 'https://github.com/basilisk-labs/agentplane/actions/runs/101' };",
       "if (args[0] === 'run' && args[1] === 'list') {",
       "  state.runListCalls += 1;",
-      "  let runs = [oldExact];",
-      "  if (process.env.FAKE_GH_MODE !== 'stale' && state.runListCalls >= 3) {",
+      "  let runs = [syntheticExact];",
+      "  if (process.env.FAKE_GH_MODE !== 'empty-run' && state.runListCalls >= 3) {",
       "    runs = [",
-      "      oldExact,",
-      "      { databaseId: 200, createdAt: '2026-08-05T20:00:00Z', event: 'workflow_dispatch', headBranch: ref, headSha: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa', status: 'queued', url: 'https://github.com/basilisk-labs/agentplane/actions/runs/200' },",
-      "      { databaseId: 202, createdAt: '2026-08-05T20:00:02Z', event: 'workflow_dispatch', headBranch: ref, headSha: sha, status: 'queued', url: 'https://github.com/basilisk-labs/agentplane/actions/runs/202' },",
-      "      { databaseId: 201, createdAt: '2026-08-05T20:00:01Z', event: 'workflow_dispatch', headBranch: ref, headSha: sha, status: 'queued', url: 'https://github.com/basilisk-labs/agentplane/actions/runs/201' },",
+      "      syntheticExact,",
+      "      { conclusion: '', databaseId: 200, createdAt: '2026-08-05T20:00:00Z', event: 'pull_request', headBranch: ref, headSha: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa', status: 'queued', url: 'https://github.com/basilisk-labs/agentplane/actions/runs/200' },",
+      "      { conclusion: 'success', databaseId: 201, createdAt: '2026-08-05T20:00:01Z', event: 'pull_request', headBranch: ref, headSha: sha, status: 'completed', url: 'https://github.com/basilisk-labs/agentplane/actions/runs/201' },",
       "    ];",
       "  }",
       "  save(); console.log(JSON.stringify(runs)); process.exit(0);",
       "}",
-      "if (args[0] === 'workflow' && args[1] === 'run') { save(); process.exit(0); }",
       "if (args[0] === 'run' && args[1] === 'watch') { save(); process.exit(0); }",
-      "if (args[0] === 'api') { save(); console.log(JSON.stringify({ id: 301 })); process.exit(0); }",
       "if (args[0] === 'pr' && args[1] === 'checks') { save(); process.exit(0); }",
       "if (args[0] === 'pr' && args[1] === 'merge') {",
       "  save();",
@@ -66,6 +63,11 @@ async function makeFakeGh() {
       "  process.stderr.write('merge queue required\\n'); process.exit(1);",
       "}",
       "if (args[0] === 'pr' && args[1] === 'view') {",
+      "  if (args.includes('headRefOid,statusCheckRollup')) {",
+      "    save();",
+      "    const statusCheckRollup = process.env.FAKE_GH_MODE === 'empty-rollup' ? [] : [{ name: 'Core CI', conclusion: process.env.FAKE_GH_MODE === 'action-required' ? 'ACTION_REQUIRED' : 'SUCCESS' }];",
+      "    console.log(JSON.stringify({ headRefOid: sha, statusCheckRollup })); process.exit(0);",
+      "  }",
       "  state.prViewCalls += 1; save();",
       "  if (state.prViewCalls === 1) { console.log(JSON.stringify({ state: 'OPEN', mergedAt: null, mergeCommit: null })); process.exit(0); }",
       "  console.log(JSON.stringify({ state: 'MERGED', mergedAt: '2026-08-05T20:02:00Z', mergeCommit: { oid: 'feedface' } })); process.exit(0);",
@@ -132,7 +134,7 @@ afterEach(async () => {
 });
 
 describe("verify release-evidence PR script", () => {
-  it("correlates a new exact-SHA run, publishes its check, and completes auto-merge", async () => {
+  it("waits for the native exact-SHA pull_request run and completes auto-merge", async () => {
     const fake = await makeFakeGh();
     const result = await runScript(fake);
 
@@ -162,45 +164,53 @@ describe("verify release-evidence PR script", () => {
       expect(args).toContain(REF);
       expect(args).toContain("--commit");
       expect(args).toContain(SHA);
-      expect(args).toContain("workflow_dispatch");
+      expect(args).toContain("pull_request");
     }
 
-    const workflowIndex = state.calls.findIndex(
-      (args) => args[0] === "workflow" && args[1] === "run",
-    );
     const watchIndex = state.calls.findIndex((args) => args[0] === "run" && args[1] === "watch");
-    const checkIndex = state.calls.findIndex((args) => args[0] === "api");
     const prChecksIndex = state.calls.findIndex((args) => args[0] === "pr" && args[1] === "checks");
+    const rollupIndex = state.calls.findIndex(
+      (args) =>
+        args[0] === "pr" && args[1] === "view" && args.includes("headRefOid,statusCheckRollup"),
+    );
     const mergeIndexes = state.calls
       .map((args, index) => ({ args, index }))
       .filter(({ args }) => args[0] === "pr" && args[1] === "merge");
-    expect(workflowIndex).toBeGreaterThanOrEqual(0);
-    expect(watchIndex).toBeGreaterThan(workflowIndex);
-    expect(checkIndex).toBeGreaterThan(watchIndex);
-    expect(prChecksIndex).toBeGreaterThan(checkIndex);
+    expect(watchIndex).toBeGreaterThanOrEqual(0);
+    expect(prChecksIndex).toBeGreaterThan(watchIndex);
+    expect(rollupIndex).toBeGreaterThan(prChecksIndex);
     expect(mergeIndexes).toHaveLength(2);
-    expect(mergeIndexes[0]?.index).toBeGreaterThan(prChecksIndex);
+    expect(mergeIndexes[0]?.index).toBeGreaterThan(rollupIndex);
     expect(mergeIndexes[1]?.args).toContain("--auto");
+    expect(state.calls.some((args) => args[0] === "workflow" && args[1] === "run")).toBe(false);
+    expect(state.calls.some((args) => args[0] === "api")).toBe(false);
 
     const watchCall = state.calls[watchIndex] ?? [];
     expect(watchCall).toContain("201");
     expect(watchCall).not.toContain("101");
-    const checkCall = state.calls[checkIndex] ?? [];
-    expect(checkCall).toContain(`head_sha=${SHA}`);
-    expect(checkCall).toContain(
-      "details_url=https://github.com/basilisk-labs/agentplane/actions/runs/201",
-    );
   });
 
-  it("fails instead of reusing a pre-existing run for the same SHA", async () => {
+  it("fails instead of accepting a synthetic workflow_dispatch run for the same SHA", async () => {
     const fake = await makeFakeGh();
-    const result = await runScript(fake, { FAKE_GH_MODE: "stale" });
+    const result = await runScript(fake, { FAKE_GH_MODE: "empty-run" });
 
     expect(result.exitCode).toBe(1);
-    expect(result.stderr).toContain("No new ci.yml workflow_dispatch run appeared");
+    expect(result.stderr).toContain("No native ci.yml pull_request run appeared");
     const state = JSON.parse(await readFile(fake.statePath, "utf8")) as { calls: string[][] };
     expect(state.calls).not.toContainEqual(expect.arrayContaining(["watch", "101"]));
-    expect(state.calls.some((args) => args[0] === "api")).toBe(false);
+    expect(state.calls.some((args) => args[0] === "pr" && args[1] === "merge")).toBe(false);
+  });
+
+  it.each([
+    ["action_required", "action-required", "Core CI=ACTION_REQUIRED"],
+    ["empty", "empty-rollup", "empty native check rollup"],
+  ])("fails closed for an %s native pull request rollup", async (_label, mode, message) => {
+    const fake = await makeFakeGh();
+    const result = await runScript(fake, { FAKE_GH_MODE: mode });
+
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain(message);
+    const state = JSON.parse(await readFile(fake.statePath, "utf8")) as { calls: string[][] };
     expect(state.calls.some((args) => args[0] === "pr" && args[1] === "merge")).toBe(false);
   });
 });

--- a/scripts/lib/next-development-version.mjs
+++ b/scripts/lib/next-development-version.mjs
@@ -95,6 +95,8 @@ export function applyNextDevelopmentVersion(rootDir, publishedVersion, opts = {}
 
   const referencePath = "docs/reference/generated-reference.mdx";
   const referenceBefore = readOptional(rootDir, referencePath);
+  const compatibilityCandidatePath = "scripts/baselines/v0.7-compatibility-candidate.json";
+  const compatibilityCandidateBefore = readOptional(rootDir, compatibilityCandidatePath);
   const changedPaths = applyReleaseVersionSurfaces(rootDir, plan.nextVersion);
 
   if (opts.skipInstall !== true && existsSync(path.join(rootDir, "bun.lock"))) {
@@ -108,12 +110,39 @@ export function applyNextDevelopmentVersion(rootDir, publishedVersion, opts = {}
   if (referenceBefore !== referenceAfter && referenceAfter !== null)
     changedPaths.push(referencePath);
 
+  const compatibilityCapturePath = path.join(
+    rootDir,
+    "scripts",
+    "bench",
+    "capture-compatibility-candidate.mjs",
+  );
+  if (existsSync(compatibilityCapturePath)) {
+    run("node", [compatibilityCapturePath, "--write"], rootDir, opts.quiet === true);
+  }
+  const compatibilityCandidateAfter = readOptional(rootDir, compatibilityCandidatePath);
+  if (
+    compatibilityCandidateBefore !== compatibilityCandidateAfter &&
+    compatibilityCandidateAfter !== null
+  ) {
+    changedPaths.push(compatibilityCandidatePath);
+  }
+
+  const formattedPaths = [...new Set(changedPaths)].toSorted();
+  if (formattedPaths.length > 0) {
+    run(
+      "bunx",
+      ["--no-install", "prettier", "--write", ...formattedPaths],
+      rootDir,
+      opts.quiet === true,
+    );
+  }
+
   const parityPath = path.join(rootDir, "scripts", "release", "check-release-parity.mjs");
   if (existsSync(parityPath)) run("node", [parityPath], rootDir, opts.quiet === true);
 
   return {
     ...plan,
     dryRun: false,
-    changedPaths: [...new Set(changedPaths)].toSorted(),
+    changedPaths: formattedPaths,
   };
 }

--- a/scripts/workflow/verify-release-evidence-pr.mjs
+++ b/scripts/workflow/verify-release-evidence-pr.mjs
@@ -6,15 +6,15 @@ const execFileAsync = promisify(execFile);
 const DEFAULT_DISCOVERY_ATTEMPTS = 40;
 const DEFAULT_MERGE_ATTEMPTS = 40;
 const DEFAULT_POLL_INTERVAL_MS = 15_000;
-const RUN_JSON_FIELDS = "databaseId,createdAt,event,headBranch,headSha,status,url";
+const RUN_JSON_FIELDS = "conclusion,databaseId,createdAt,event,headBranch,headSha,status,url";
 
 function usage() {
   process.stdout.write(
     [
       "Usage: node scripts/workflow/verify-release-evidence-pr.mjs --workflow <file> --ref <branch> --sha <sha> --pr-url <url> --repo <owner/name>",
       "",
-      "Dispatch exact-SHA Core CI, publish the required PR check, and merge the release-evidence PR.",
-      "The dispatched run is discovered from a baseline delta instead of relying on optional gh output.",
+      "Wait for exact-SHA native pull_request Core CI and merge the release-evidence PR.",
+      "The PR must expose a non-empty native check rollup accepted by branch protection.",
       "",
       "Options:",
       "  --discovery-attempts <count>  New-run discovery poll budget. Default: 40.",
@@ -164,7 +164,7 @@ function runListArgs(options) {
     "--commit",
     options.sha,
     "--event",
-    "workflow_dispatch",
+    "pull_request",
     "--limit",
     "100",
     "--json",
@@ -178,6 +178,7 @@ function normalizeRuns(payload) {
     .map((entry) => ({
       databaseId: Number(entry?.databaseId),
       createdAt: typeof entry?.createdAt === "string" ? entry.createdAt : "",
+      conclusion: typeof entry?.conclusion === "string" ? entry.conclusion : "",
       event: typeof entry?.event === "string" ? entry.event : "",
       headBranch: typeof entry?.headBranch === "string" ? entry.headBranch : "",
       headSha: typeof entry?.headSha === "string" ? entry.headSha : "",
@@ -187,19 +188,18 @@ function normalizeRuns(payload) {
     .filter((entry) => Number.isInteger(entry.databaseId) && entry.databaseId > 0);
 }
 
-function selectNewExactRun(runs, baselineIds, options) {
+function selectExactPullRequestRun(runs, options) {
   return runs
     .filter(
       (run) =>
-        !baselineIds.has(run.databaseId) &&
-        run.event === "workflow_dispatch" &&
+        run.event === "pull_request" &&
         run.headBranch === options.ref &&
         run.headSha.toLowerCase() === options.sha.toLowerCase() &&
         /\/actions\/runs\/[0-9]+$/u.test(run.url),
     )
     .toSorted((left, right) => {
-      const byCreatedAt = left.createdAt.localeCompare(right.createdAt);
-      return byCreatedAt || left.databaseId - right.databaseId;
+      const byCreatedAt = right.createdAt.localeCompare(left.createdAt);
+      return byCreatedAt || right.databaseId - left.databaseId;
     })[0];
 }
 
@@ -208,42 +208,62 @@ async function sleep(ms) {
   await new Promise((resolve) => setTimeout(resolve, ms));
 }
 
-async function discoverDispatchedRun(options, baselineIds) {
+async function discoverNativePullRequestRun(options) {
   for (let attempt = 1; attempt <= options.discoveryAttempts; attempt += 1) {
     const runs = normalizeRuns(await runGhJson(runListArgs(options)));
-    const selected = selectNewExactRun(runs, baselineIds, options);
+    const selected = selectExactPullRequestRun(runs, options);
     if (selected) return selected;
     process.stderr.write(
-      `Waiting for exact-SHA Core CI dispatch (${attempt}/${options.discoveryAttempts})\n`,
+      `Waiting for exact-SHA pull_request Core CI (${attempt}/${options.discoveryAttempts})\n`,
     );
     if (attempt < options.discoveryAttempts) await sleep(options.pollIntervalMs);
   }
   throw new Error(
-    `No new ${options.workflow} workflow_dispatch run appeared for ${options.ref}@${options.sha}`,
+    `No native ${options.workflow} pull_request run appeared for ${options.ref}@${options.sha}`,
   );
 }
 
-async function publishRequiredCheck(options, run) {
-  await runGh([
-    "api",
-    `repos/${options.repo}/check-runs`,
-    "--method",
-    "POST",
-    "-f",
-    "name=PR verification",
-    "-f",
-    `head_sha=${options.sha}`,
-    "-f",
-    "status=completed",
-    "-f",
-    "conclusion=success",
-    "-f",
-    `details_url=${run.url}`,
-    "-f",
-    "output[title]=Release evidence verification passed",
-    "-f",
-    "output[summary]=The exact release-evidence closure SHA passed Core CI.",
+function normalizedRollupConclusion(entry) {
+  const conclusion = typeof entry?.conclusion === "string" ? entry.conclusion.trim() : "";
+  if (conclusion) return conclusion.toUpperCase();
+  const state = typeof entry?.state === "string" ? entry.state.trim() : "";
+  return state.toUpperCase();
+}
+
+async function assertNativePullRequestRollup(options) {
+  const payload = await runGhJson([
+    "pr",
+    "view",
+    options.prUrl,
+    "--repo",
+    options.repo,
+    "--json",
+    "headRefOid,statusCheckRollup",
   ]);
+  const headSha = typeof payload?.headRefOid === "string" ? payload.headRefOid.trim() : "";
+  if (headSha.toLowerCase() !== options.sha.toLowerCase()) {
+    throw new Error(
+      `Release-evidence PR head SHA does not match ${options.sha}: ${headSha || "missing"}`,
+    );
+  }
+  const rollup = Array.isArray(payload?.statusCheckRollup) ? payload.statusCheckRollup : [];
+  if (rollup.length === 0) {
+    throw new Error(`Release-evidence PR has an empty native check rollup for ${options.sha}`);
+  }
+  const failures = rollup
+    .map((entry) => ({
+      name: typeof entry?.name === "string" ? entry.name : "unnamed check",
+      conclusion: normalizedRollupConclusion(entry),
+    }))
+    .filter(({ conclusion }) => !["SUCCESS", "NEUTRAL", "SKIPPED"].includes(conclusion));
+  if (failures.length > 0) {
+    throw new Error(
+      `Release-evidence PR native check rollup is not successful: ${failures
+        .map(({ name, conclusion }) => `${name}=${conclusion || "PENDING"}`)
+        .join(", ")}`,
+    );
+  }
+  return rollup.length;
 }
 
 async function mergePullRequest(options) {
@@ -257,6 +277,7 @@ async function mergePullRequest(options) {
     "--interval",
     "15",
   ]);
+  const nativeCheckCount = await assertNativePullRequestRollup(options);
 
   const immediate = await runGh(
     ["pr", "merge", options.prUrl, "--repo", options.repo, "--merge", "--delete-branch"],
@@ -287,7 +308,7 @@ async function mergePullRequest(options) {
       "state,mergedAt,mergeCommit",
     ]);
     const state = typeof payload?.state === "string" ? payload.state.toUpperCase() : "";
-    if (state === "MERGED") return payload;
+    if (state === "MERGED") return { ...payload, nativeCheckCount };
     if (state === "CLOSED") {
       throw new Error(`Release-evidence PR closed without merge: ${options.prUrl}`);
     }
@@ -307,22 +328,10 @@ async function main() {
   }
   requireInputs(options);
 
-  const baselineRuns = normalizeRuns(await runGhJson(runListArgs(options)));
-  const baselineIds = new Set(baselineRuns.map((run) => run.databaseId));
-
-  await runGh([
-    "workflow",
-    "run",
-    options.workflow,
-    "--repo",
-    options.repo,
-    "--ref",
-    options.ref,
-    "-f",
-    `sha=${options.sha}`,
-  ]);
-
-  const run = await discoverDispatchedRun(options, baselineIds);
+  const run = await discoverNativePullRequestRun(options);
+  if (run.status === "completed" && run.conclusion.toLowerCase() === "action_required") {
+    throw new Error(`Native pull_request Core CI requires action for ${options.sha}`);
+  }
   await runGh([
     "run",
     "watch",
@@ -333,7 +342,6 @@ async function main() {
     "--interval",
     "15",
   ]);
-  await publishRequiredCheck(options, run);
   const merge = await mergePullRequest(options);
 
   const result = {
@@ -344,6 +352,7 @@ async function main() {
     closure_sha: options.sha,
     ci_run_id: run.databaseId,
     ci_run_url: run.url,
+    native_check_count: merge?.nativeCheckCount ?? 0,
     merge_commit: merge?.mergeCommit ?? null,
     merged_at: merge?.mergedAt ?? null,
   };


### PR DESCRIPTION
Task: `202609111340-MGB383`
Title: Harden the post-release evidence close-tail under branch protection for GitHub issue #4848
Canonical task record: `.agentplane/tasks/202609111340-MGB383/README.md`

## Summary

Harden the post-release evidence close-tail under branch protection for GitHub issue #4848

GitHub issue #4848 is still relevant on current main. The release follow-up stages version surfaces but does not refresh or stage scripts/baselines/v0.7-compatibility-candidate.json, and verify-release-evidence-pr still publishes a synthetic PR verification check after workflow_dispatch instead of obtaining a native pull_request status accepted by branch protection. Make the generated next-development diff Prettier-clean, refresh and stage the compatibility candidate whenever the version surface advances, add a pre-push/pre-PR contract gate, and drive the close-tail through a native pull_request verification with regression coverage for action_required or empty native rollup. Do not weaken branch protection or use admin bypass. Issue: https://github.com/basilisk-labs/agentplane/issues/4848

## Scope

- In scope: GitHub issue #4848 is still relevant on current main. The release follow-up stages version surfaces but does not refresh or stage scripts/baselines/v0.7-compatibility-candidate.json, and verify-release-evidence-pr still publishes a synthetic PR verification check after workflow_dispatch instead of obtaining a native pull_request status accepted by branch protection. Make the generated next-development diff Prettier-clean, refresh and stage the compatibility candidate whenever the version surface advances, add a pre-push/pre-PR contract gate, and drive the close-tail through a native pull_request verification with regression coverage for action_required or empty native rollup. Do not weaken branch protection or use admin bypass. Issue: https://github.com/basilisk-labs/agentplane/issues/4848.
- Out of scope: unrelated refactors not required for "Harden the post-release evidence close-tail under branch protection for GitHub issue #4848".

## Verification

- State: needs_rework
- Note: Rework: Declared check failed: bun run ci:local:full
- Canonical workflow state lives in the task README.

<details>
<summary>Raw evidence</summary>

- Updated: 2026-09-11T18:55:14.650Z
- Branch: task/202609111340-MGB383/harden-the-post-release-evidence-close-tail-unde
- Head: computed live by `agentplane pr check` / `agentplane integrate`

```text
 .github/workflows/publish.yml                      |  15 ++-
 .../open-next-development-version-script.test.ts   |  22 +++-
 .../release/publish-workflow-contract.test.ts      |  17 +++-
 .../verify-release-evidence-pr-script.test.ts      |  68 +++++++------
 scripts/lib/next-development-version.mjs           |  31 +++++-
 scripts/workflow/verify-release-evidence-pr.mjs    | 111 +++++++++++----------
 6 files changed, 180 insertions(+), 84 deletions(-)
```

</details>
