### PR TITLE
🚧 P11QPS task: Create the AgentPlane 0.7.9 and 0.7.10 architecture improvement roadmap [202609120943-P11QPS]

### DIFF
--- a/.agentplane/tasks/202609120943-P11QPS/README.md
+++ b/.agentplane/tasks/202609120943-P11QPS/README.md
@@ -4,7 +4,7 @@ title: "Create the AgentPlane 0.7.9 and 0.7.10 architecture improvement roadmap"
 status: "DOING"
 priority: "med"
 owner: "CODER"
-revision: 5
+revision: 7
 origin:
   system: "manual"
 depends_on: []
@@ -75,10 +75,14 @@ execution_contract:
       - "docs/internal/v0.7.9-v0.7.10-architecture-roadmap.md"
   observed:
     authority_violations: []
-    changed_components: []
-    changed_paths: []
+    changed_components:
+      - "docs"
+    changed_paths:
+      - "docs/internal/v0.7.9-v0.7.10-architecture-roadmap.md"
     external_effects: []
-    repository_effects: []
+    repository_effects:
+      - "documentation"
+      - "repository_write"
     verification_results: []
   reason_codes:
     - "agent_preferred_branch_pr"
@@ -109,16 +113,20 @@ execution_contract:
           implementation_uncertainty: "bounded"
           requirements_uncertainty: "bounded"
           reversibility: "reversible"
-      digest: "sha256:9f42706bc3a5024c87f4915710d8423520b16e159ffb9c3fa3611fd29226d488"
+      digest: "sha256:f32ac2081a48d9707c4d23f9e2c374325aedecbd7b8fd0e591ddfa125b65691b"
       escalation_reasons: []
       execution_groups:
         - "docs-schema"
         - "core"
       observed:
-        changed_components: []
-        changed_files: []
+        changed_components:
+          - "docs"
+        changed_files:
+          - "docs/internal/v0.7.9-v0.7.10-architecture-roadmap.md"
         external_effects: []
-        repository_effects: []
+        repository_effects:
+          - "documentation"
+          - "repository_write"
       phase: "task"
       policy_floor:
         monotonic_strengthening: true
@@ -147,11 +155,16 @@ execution_contract:
       - "repository_effect:documentation"
       - "repository_effect:repository_write"
       - "task_outcome"
-commit: null
+commit:
+  hash: "9801378b67064bbcf70222607e32d7ba7d773bd8"
+  message: "🚧 P11QPS task: apply external agent result"
 comments:
   -
     author: "CODER"
     body: "Start: continue branch_pr task in the dedicated task worktree."
+  -
+    author: "SUPERVISOR"
+    body: "Implementation committed: 9801378b6706. CLI accepted one state-bound external-agent semantic result."
 events:
   -
     type: "status"
@@ -160,9 +173,17 @@ events:
     from: "DOING"
     to: "DOING"
     note: "Start: continue branch_pr task in the dedicated task worktree."
+  -
+    type: "status"
+    at: "2026-09-12T10:10:12.453Z"
+    author: "SUPERVISOR"
+    from: "DOING"
+    to: "DOING"
+    note: "Implementation committed: 9801378b6706. CLI accepted one state-bound external-agent semantic result."
+    commit: "9801378b67064bbcf70222607e32d7ba7d773bd8"
 doc_version: 3
-doc_updated_at: "2026-09-12T10:00:36.409Z"
-doc_updated_by: "CODER"
+doc_updated_at: "2026-09-12T10:10:12.453Z"
+doc_updated_by: "SUPERVISOR"
 description: "Recheck the three supplied architecture proposals against current main and write a standalone English roadmap document. Split implementation into atomic GitHub PR groups and assign each group to AgentPlane 0.7.9 or 0.7.10."
 sections:
   Summary: |-
@@ -402,7 +423,7 @@ extensions:
       revision: 1
       schema_version: 1
       task_id: "202609120943-P11QPS"
-    event_cursor: 3
+    event_cursor: 5
     final_validation: null
     id: "202609120943-P11QPS"
     intent:
@@ -422,9 +443,9 @@ extensions:
     lifecycle: "ACTIVE"
     plan_amendments: []
     plan_history: []
-    revision: 5
+    revision: 7
     schema_version: 1
-    updated_at: "2026-09-12T10:00:36.409Z"
+    updated_at: "2026-09-12T10:10:12.453Z"
     work_items:
       write-versioned-architecture-roadmap:
         attempt: 0
@@ -440,6 +461,30 @@ extensions:
     events: []
     leases: []
     mutation_receipts:
+      compatibility:sha256:4d26893f3cb2c6f90090af471ef0b9072bbd79a354bcf6a8141d109b5994ec60:
+        aggregate_digest: "sha256:feece7bc0ecc2a4cf4b733eddff8feecfb0d8e46852b96f8407bac113f7a104a"
+        event:
+          actor_id: "agentplane"
+          at: "2026-09-12T10:10:12.453Z"
+          cause_refs:
+            - "compatibility_projection_mutation"
+          entity: "task"
+          from: "ACTIVE"
+          id: "event_a4d319f55737b27adcd1e677"
+          mutation_id: "compatibility:sha256:4d26893f3cb2c6f90090af471ef0b9072bbd79a354bcf6a8141d109b5994ec60"
+          plan_digest: "sha256:c04a3fd013c722ee840ae8588d230787fb244c40e180a5c82dd9b01c6f699ed5"
+          plan_revision: 1
+          repository_fingerprint: null
+          schema_version: 1
+          task_id: "202609120943-P11QPS"
+          task_revision: 5
+          to: "ACTIVE"
+          work_item_id: null
+        mutation_id: "compatibility:sha256:4d26893f3cb2c6f90090af471ef0b9072bbd79a354bcf6a8141d109b5994ec60"
+        next_revision: 6
+        previous_revision: 5
+        schema_version: 1
+        task_id: "202609120943-P11QPS"
       compatibility:sha256:5cf4a113e37185dc1c1dc1f10c538425a9e2108eff7114d36bc497ba3b96d444:
         aggregate_digest: "sha256:bd5993941dee6cb6479db2afda719ffa46c46f7bb3394423660871c7c70fca44"
         event:
@@ -512,9 +557,35 @@ extensions:
         previous_revision: 4
         schema_version: 1
         task_id: "202609120943-P11QPS"
+      compatibility:sha256:e7a2d51c6ba106f8c23479d4dae67f3fdb541a1e6f67a85f7f3546ecf03a4a67:
+        aggregate_digest: "sha256:9bd6db3037c40f7946ab5b9910637e137209cab4f1ca7d8017d1df107976d976"
+        event:
+          actor_id: "agentplane"
+          at: "2026-09-12T10:10:12.453Z"
+          cause_refs:
+            - "compatibility_projection_mutation"
+          entity: "task"
+          from: "ACTIVE"
+          id: "event_4c40bdeb07f41e7dfaee35e4"
+          mutation_id: "compatibility:sha256:e7a2d51c6ba106f8c23479d4dae67f3fdb541a1e6f67a85f7f3546ecf03a4a67"
+          plan_digest: "sha256:c04a3fd013c722ee840ae8588d230787fb244c40e180a5c82dd9b01c6f699ed5"
+          plan_revision: 1
+          repository_fingerprint: null
+          schema_version: 1
+          task_id: "202609120943-P11QPS"
+          task_revision: 6
+          to: "ACTIVE"
+          work_item_id: null
+        mutation_id: "compatibility:sha256:e7a2d51c6ba106f8c23479d4dae67f3fdb541a1e6f67a85f7f3546ecf03a4a67"
+        next_revision: 7
+        previous_revision: 6
+        schema_version: 1
+        task_id: "202609120943-P11QPS"
     pending_effects: []
     retry_budgets: []
     schema_version: 1
+  implementation_commit:
+    hash: "9801378b67064bbcf70222607e32d7ba7d773bd8"
   task_execution_context:
     base_ref: "main"
     base_sha: "50b1810dda648be0c0762b47e885c6ad0b2d42af"

--- a/.agentplane/tasks/202609120943-P11QPS/README.md
+++ b/.agentplane/tasks/202609120943-P11QPS/README.md
@@ -1,0 +1,559 @@
+---
+id: "202609120943-P11QPS"
+title: "Create the AgentPlane 0.7.9 and 0.7.10 architecture improvement roadmap"
+status: "DOING"
+priority: "med"
+owner: "CODER"
+revision: 5
+origin:
+  system: "manual"
+depends_on: []
+tags:
+  - "docs"
+task_kind: "docs"
+mutation_scope: "docs"
+verify:
+  - "node .agentplane/policy/check-routing.mjs"
+plan_approval:
+  state: "approved"
+  updated_at: "2026-09-12T09:58:49.406Z"
+  updated_by: "HOST:codex-desktop:USER"
+  note: "host_user_decision=sha256:2fdbdb599aaf3822cc490aa79da481aaa08c285a6e820f5600923a52186afeb5"
+verification:
+  state: "pending"
+  updated_at: null
+  updated_by: null
+  note: null
+  attempts: 0
+execution_route:
+  frozen: true
+  reason_codes:
+    - "agent_preferred_branch_pr"
+    - "repository_branch_pr_floor"
+  repository_mode: "branch_pr"
+  requested_mode: "branch_pr"
+  schema_version: 1
+  selected_mode: "branch_pr"
+execution_contract:
+  authority:
+    allowed_external_effects: []
+    allowed_repository_effects:
+      - "documentation"
+      - "repository_write"
+    forbidden_external_effects:
+      - "network_read"
+      - "external_write"
+      - "credentials"
+      - "publish"
+      - "deploy"
+      - "destructive_git"
+    forbidden_repository_effects:
+      - "source_code"
+      - "tests"
+      - "public_api"
+      - "schema"
+      - "dependencies"
+      - "ci"
+      - "release_metadata"
+      - "security_boundary"
+    writable_roots:
+      - "docs/internal/v0.7.9-v0.7.10-architecture-roadmap.md"
+  declaration:
+    external_effects: []
+    implementation_uncertainty: "bounded"
+    preferred_mode: "branch_pr"
+    rationale:
+      - "A pull request keeps the roadmap reviewable without changing runtime behavior."
+      - "The requested artifact is one new internal architecture roadmap document."
+    repository_effects:
+      - "documentation"
+      - "repository_write"
+    requirements_uncertainty: "bounded"
+    reversibility: "reversible"
+    schema_version: 2
+    scope_roots:
+      - "docs/internal/v0.7.9-v0.7.10-architecture-roadmap.md"
+  observed:
+    authority_violations: []
+    changed_components: []
+    changed_paths: []
+    external_effects: []
+    repository_effects: []
+    verification_results: []
+  reason_codes:
+    - "agent_preferred_branch_pr"
+    - "repository_branch_pr_floor"
+  repository_mode: "branch_pr"
+  safety:
+    approval_effects: []
+    requires_user_approval: false
+    requires_worktree: true
+  schema_version: 1
+  selected_mode: "branch_pr"
+  source: "agent_declared"
+  verification:
+    contract:
+      declared:
+        components:
+          - "docs/internal/v0.7.9-v0.7.10-architecture-roadmap.md"
+        evidence_requirements:
+          - "hosted_integration"
+          - "repository_effect:documentation"
+          - "repository_effect:repository_write"
+          - "task_outcome"
+        external_effects: []
+        repository_effects:
+          - "documentation"
+          - "repository_write"
+        risk:
+          implementation_uncertainty: "bounded"
+          requirements_uncertainty: "bounded"
+          reversibility: "reversible"
+      digest: "sha256:9f42706bc3a5024c87f4915710d8423520b16e159ffb9c3fa3611fd29226d488"
+      escalation_reasons: []
+      execution_groups:
+        - "docs-schema"
+        - "core"
+      observed:
+        changed_components: []
+        changed_files: []
+        external_effects: []
+        repository_effects: []
+      phase: "task"
+      policy_floor:
+        monotonic_strengthening: true
+        pr_full_regression: true
+        unknown_or_central_full_regression: true
+      requires_full_regression: false
+      requires_real_e2e: false
+      schema_version: 2
+      selected_checks:
+        - "docs_contract"
+        - "hosted_integration"
+        - "task_outcome"
+      selector:
+        bucket: null
+        buckets: []
+        execution_mode: "semantic"
+        kind: "semantic"
+        lint_targets: []
+        reason: "execution_declaration"
+        run_cli_docs_check: false
+        selected_test_files: []
+        vitest_pool: "forks"
+      source: "execution_contract"
+    required_evidence:
+      - "hosted_integration"
+      - "repository_effect:documentation"
+      - "repository_effect:repository_write"
+      - "task_outcome"
+commit: null
+comments:
+  -
+    author: "CODER"
+    body: "Start: continue branch_pr task in the dedicated task worktree."
+events:
+  -
+    type: "status"
+    at: "2026-09-12T10:00:36.409Z"
+    author: "CODER"
+    from: "DOING"
+    to: "DOING"
+    note: "Start: continue branch_pr task in the dedicated task worktree."
+doc_version: 3
+doc_updated_at: "2026-09-12T10:00:36.409Z"
+doc_updated_by: "CODER"
+description: "Recheck the three supplied architecture proposals against current main and write a standalone English roadmap document. Split implementation into atomic GitHub PR groups and assign each group to AgentPlane 0.7.9 or 0.7.10."
+sections:
+  Summary: |-
+    Create the AgentPlane 0.7.9 and 0.7.10 architecture improvement roadmap
+
+    Recheck the three supplied architecture proposals against current main and write a standalone English roadmap document. Split implementation into atomic GitHub PR groups and assign each group to AgentPlane 0.7.9 or 0.7.10.
+  Scope: |-
+    - In scope: Recheck the three supplied architecture proposals against current main and write a standalone English roadmap document. Split implementation into atomic GitHub PR groups and assign each group to AgentPlane 0.7.9 or 0.7.10.
+    - Out of scope: unrelated refactors not required for "Create the AgentPlane 0.7.9 and 0.7.10 architecture improvement roadmap".
+  Plan: "Plan one standalone, source-grounded roadmap document for the 0.7.9 stabilization release and the 0.7.10 architecture release."
+  Verify Steps: |-
+    1. Run `bunx prettier --check docs/internal/v0.7.9-v0.7.10-architecture-roadmap.md`. Expected: the roadmap document is formatted.
+    2. Run `node .agentplane/policy/check-routing.mjs`. Expected: policy routing passes.
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: ""
+extensions:
+  agentplane.execution_grant:
+    actor: "HOST:codex-desktop:USER"
+    approval_evidence_digest: "sha256:2fdbdb599aaf3822cc490aa79da481aaa08c285a6e820f5600923a52186afeb5"
+    approval_kind: "host_user_decision"
+    capabilities:
+      - "provider.merge"
+      - "provider.pr"
+      - "repository.integrate"
+      - "repository.write"
+      - "task.lifecycle"
+      - "task.scope.extend"
+    completion_contract_digest: "sha256:c16041dd9831e70f058eeaeeb9714afed884dbcb938e6734a0ee0f781506a2bf"
+    digest: "sha256:b33e01b85f2b6ab581f0424b091c959fa5e25d4540ee17666af4b2be57fa1432"
+    grant_id: "52336ba8-8270-4f31-81ca-27976228fc9a"
+    issued_at: "2026-09-12T09:58:49.406Z"
+    kind: "agentplane.execution_grant"
+    plan_digest: "sha256:0e28625532c49798d7c4f252ff3557a4b177fab955fd4cfc81dbc22a263b6e7f"
+    plan_revision: 3
+    repository_identity: "sha256:da6b1bd36fbd8902ecef3732738a9db0fd8478b8fcbe61ce4ba5a648cdccfd3b"
+    schema_version: 1
+    scope_digest: "sha256:cb7685d3adca039a80ab47777b617bbe0f2f4eb9f1783679bd96c9955a6470a7"
+    status: "active"
+    task_id: "202609120943-P11QPS"
+  agentplane.task_centric:
+    current_plan:
+      approval:
+        approved_at: "2026-09-12T09:58:49.406Z"
+        approved_by: "HOST:codex-desktop:USER"
+        approved_digest: "sha256:c04a3fd013c722ee840ae8588d230787fb244c40e180a5c82dd9b01c6f699ed5"
+        policy_facts:
+          - "host_user_decision"
+        state: "approved"
+      created_at: "2026-09-12T09:46:53.878Z"
+      digest: "sha256:c04a3fd013c722ee840ae8588d230787fb244c40e180a5c82dd9b01c6f699ed5"
+      proposal:
+        assumptions:
+          - "The 0.7.10 release may introduce versioned contracts and explicit migration while remaining within the stabilized 0.7 product line."
+          - "The source documents are design inputs and do not override repository policy or current implementation evidence."
+        planning_baseline:
+          captured_at: "2026-09-12T09:44:02.611Z"
+          config_digest: null
+          context_digest: "sha256:890b5e5c75bdf159d4314db2bb015c07f8837e3eddfa3dd65a6b41186d162086"
+          digest: "sha256:eee81ba7d2868c4326e71cd533e31895f430e945793d6be95b084425e56c5624"
+          dirty_paths:
+            - ".agentplane/tasks/202609111341-FK9C2T/README.md"
+            - ".agentplane/tasks/202609111341-SED9K5/README.md"
+            - ".agentplane/tasks/202609111502-4XSWZQ/README.md"
+            - ".agentplane/tasks/202609120943-P11QPS/README.md"
+          git:
+            kind: "commit"
+            ref: null
+            sha: "50b1810dda648be0c0762b47e885c6ad0b2d42af"
+          policy_digest: null
+          schema_version: 1
+          task_history_cursor: "task-revision:1"
+        schema_version: 1
+        task_id: "202609120943-P11QPS"
+        top_level_validation:
+          checks:
+            -
+              capability: "task.verify"
+              command: "bunx prettier --check docs/internal/v0.7.9-v0.7.10-architecture-roadmap.md"
+              id: "format-check"
+              kind: "deterministic"
+              required: true
+              timeout_ms: 120000
+            -
+              capability: "task.verify"
+              command: "node .agentplane/policy/check-routing.mjs"
+              id: "routing-check"
+              kind: "deterministic"
+              required: true
+              timeout_ms: 120000
+          criteria:
+            -
+              check_ids:
+                - "format-check"
+              description: "The document assigns only compatible stabilization, parity, observability, and preparation work to 0.7.9. It assigns new lifecycle semantics, Scenario V2, Blueprint migration, and subsystem removal to 0.7.10."
+              id: "release-boundary"
+              required: true
+            -
+              check_ids:
+                - "format-check"
+              description: "Every roadmap group represents one GitHub pull request and contains bounded atomic tasks, dependencies, acceptance criteria, and a release assignment."
+              id: "atomic-pr-groups"
+              required: true
+            -
+              check_ids:
+                - "format-check"
+              description: "The document distinguishes implemented behavior from proposals and records current-main evidence and unresolved companion-artifact limitations."
+              id: "current-source-grounding"
+              required: true
+            -
+              check_ids:
+                - "format-check"
+                - "routing-check"
+              description: "The new Markdown document is formatted and the repository policy routing check passes."
+              id: "repository-conformance"
+              required: true
+          evidence_fingerprint: "sha256:eee81ba7d2868c4326e71cd533e31895f430e945793d6be95b084425e56c5624"
+          schema_version: 1
+        unresolved_questions: []
+        work_items:
+          schema_version: 1
+          work_items:
+            -
+              acceptance_criteria:
+                -
+                  check_ids:
+                    - "format-check"
+                  description: "The document assigns only compatible stabilization, parity, observability, and preparation work to 0.7.9. It assigns new lifecycle semantics, Scenario V2, Blueprint migration, and subsystem removal to 0.7.10."
+                  id: "release-boundary"
+                  required: true
+                -
+                  check_ids:
+                    - "format-check"
+                  description: "Every roadmap group represents one GitHub pull request and contains bounded atomic tasks, dependencies, acceptance criteria, and a release assignment."
+                  id: "atomic-pr-groups"
+                  required: true
+                -
+                  check_ids:
+                    - "format-check"
+                  description: "The document distinguishes implemented behavior from proposals and records current-main evidence and unresolved companion-artifact limitations."
+                  id: "current-source-grounding"
+                  required: true
+                -
+                  check_ids:
+                    - "format-check"
+                    - "routing-check"
+                  description: "The new Markdown document is formatted and the repository policy routing check passes."
+                  id: "repository-conformance"
+                  required: true
+              capabilities:
+                - "task.verify"
+              context:
+                max_bytes: 240000
+                optional_sources:
+                  - "docs/internal/v0.7-agent-efficiency-baseline.md"
+                  - "docs/developer/verification-contract.mdx"
+                  - "docs/developer/task-execution-authority.mdx"
+                required_sources:
+                  - "docs/internal/v0.7-refactor-plan.md"
+                  - "docs/developer/architecture.mdx"
+                  - "docs/developer/blueprints.mdx"
+                  - "docs/developer/recipes-spec.mdx"
+                  - "packages/recipes/src/scenario-contracts.ts"
+                  - "packages/core/src/tasks/kernel-semantic.ts"
+                  - "packages/agentplane/src/commands/task/kernel-inspection.ts"
+                  - "packages/agentplane/src/commands/task/create.command.ts"
+                  - "packages/agentplane/src/commands/task/run.command.ts"
+                symbol_hints:
+                  - "ScenarioDefinition"
+                  - "kernelWorkContractSchema"
+                  - "acceptKernelInspection"
+                  - "TASK_KERNEL_EXTENSION"
+              depends_on: []
+              expected_outputs:
+                - "verified-versioned-architecture-roadmap"
+              id: "write-versioned-architecture-roadmap"
+              objective: "Recheck the supplied architecture proposals against current main. Write one standalone English roadmap document. Separate the work into 0.7.9 stabilization and 0.7.10 architecture delivery. Define one atomic GitHub pull request per roadmap group. Include dependencies, acceptance criteria, migration gates, and explicit non-goals. Run the declared deterministic checks."
+              optional: false
+              priority: 1
+              required_inputs: []
+              resource_claims:
+                -
+                  kind: "path"
+                  mode: "write"
+                  resource: "docs/internal/v0.7.9-v0.7.10-architecture-roadmap.md"
+              risk: "low"
+              scope_roots:
+                - "docs/internal/v0.7.9-v0.7.10-architecture-roadmap.md"
+              validation:
+                checks:
+                  -
+                    capability: "task.verify"
+                    command: "bunx prettier --check docs/internal/v0.7.9-v0.7.10-architecture-roadmap.md"
+                    id: "format-check"
+                    kind: "deterministic"
+                    required: true
+                    timeout_ms: 120000
+                  -
+                    capability: "task.verify"
+                    command: "node .agentplane/policy/check-routing.mjs"
+                    id: "routing-check"
+                    kind: "deterministic"
+                    required: true
+                    timeout_ms: 120000
+                criteria:
+                  -
+                    check_ids:
+                      - "format-check"
+                    description: "The document assigns only compatible stabilization, parity, observability, and preparation work to 0.7.9. It assigns new lifecycle semantics, Scenario V2, Blueprint migration, and subsystem removal to 0.7.10."
+                    id: "release-boundary"
+                    required: true
+                  -
+                    check_ids:
+                      - "format-check"
+                    description: "Every roadmap group represents one GitHub pull request and contains bounded atomic tasks, dependencies, acceptance criteria, and a release assignment."
+                    id: "atomic-pr-groups"
+                    required: true
+                  -
+                    check_ids:
+                      - "format-check"
+                    description: "The document distinguishes implemented behavior from proposals and records current-main evidence and unresolved companion-artifact limitations."
+                    id: "current-source-grounding"
+                    required: true
+                  -
+                    check_ids:
+                      - "format-check"
+                      - "routing-check"
+                    description: "The new Markdown document is formatted and the repository policy routing check passes."
+                    id: "repository-conformance"
+                    required: true
+                evidence_fingerprint: "sha256:eee81ba7d2868c4326e71cd533e31895f430e945793d6be95b084425e56c5624"
+                schema_version: 1
+      revision: 1
+      schema_version: 1
+      task_id: "202609120943-P11QPS"
+    event_cursor: 3
+    final_validation: null
+    id: "202609120943-P11QPS"
+    intent:
+      acceptance_criteria:
+        -
+          check_ids: []
+          description: "node .agentplane/policy/check-routing.mjs"
+          id: "legacy-1"
+          required: true
+      captured_at: "2026-09-12T09:43:53.147Z"
+      constraints: []
+      request: |-
+        Create the AgentPlane 0.7.9 and 0.7.10 architecture improvement roadmap
+
+        Recheck the three supplied architecture proposals against current main and write a standalone English roadmap document. Split implementation into atomic GitHub PR groups and assign each group to AgentPlane 0.7.9 or 0.7.10.
+      task_id: "202609120943-P11QPS"
+    lifecycle: "ACTIVE"
+    plan_amendments: []
+    plan_history: []
+    revision: 5
+    schema_version: 1
+    updated_at: "2026-09-12T10:00:36.409Z"
+    work_items:
+      write-versioned-architecture-roadmap:
+        attempt: 0
+        claim_id: null
+        id: "write-versioned-architecture-roadmap"
+        last_failure: null
+        output_manifests: []
+        revision: 1
+        state: "READY"
+        validation_result: null
+  agentplane.task_centric_runtime:
+    checkpoints: []
+    events: []
+    leases: []
+    mutation_receipts:
+      compatibility:sha256:5cf4a113e37185dc1c1dc1f10c538425a9e2108eff7114d36bc497ba3b96d444:
+        aggregate_digest: "sha256:bd5993941dee6cb6479db2afda719ffa46c46f7bb3394423660871c7c70fca44"
+        event:
+          actor_id: "agentplane"
+          at: "2026-09-12T09:57:35.758Z"
+          cause_refs:
+            - "compatibility_projection_mutation"
+          entity: "task"
+          from: "AWAITING_PLAN_APPROVAL"
+          id: "event_f7c2b0b99a056e8321363ed0"
+          mutation_id: "compatibility:sha256:5cf4a113e37185dc1c1dc1f10c538425a9e2108eff7114d36bc497ba3b96d444"
+          plan_digest: "sha256:c04a3fd013c722ee840ae8588d230787fb244c40e180a5c82dd9b01c6f699ed5"
+          plan_revision: 1
+          repository_fingerprint: null
+          schema_version: 1
+          task_id: "202609120943-P11QPS"
+          task_revision: 2
+          to: "AWAITING_PLAN_APPROVAL"
+          work_item_id: null
+        mutation_id: "compatibility:sha256:5cf4a113e37185dc1c1dc1f10c538425a9e2108eff7114d36bc497ba3b96d444"
+        next_revision: 3
+        previous_revision: 2
+        schema_version: 1
+        task_id: "202609120943-P11QPS"
+      compatibility:sha256:944a4be4b98f901498d5de07542660495c34dfe4f08de4dd8c2df948f5eccfdc:
+        aggregate_digest: "sha256:4e32e4956ac35e242bca23f582971ba8e634eb3280e80affc1578ce0ca6b2125"
+        event:
+          actor_id: "agentplane"
+          at: "2026-09-12T09:57:35.761Z"
+          cause_refs:
+            - "compatibility_projection_mutation"
+          entity: "task"
+          from: "AWAITING_PLAN_APPROVAL"
+          id: "event_e5f2f29e565e6d79a9f7150b"
+          mutation_id: "compatibility:sha256:944a4be4b98f901498d5de07542660495c34dfe4f08de4dd8c2df948f5eccfdc"
+          plan_digest: "sha256:c04a3fd013c722ee840ae8588d230787fb244c40e180a5c82dd9b01c6f699ed5"
+          plan_revision: 1
+          repository_fingerprint: null
+          schema_version: 1
+          task_id: "202609120943-P11QPS"
+          task_revision: 3
+          to: "ACTIVE"
+          work_item_id: null
+        mutation_id: "compatibility:sha256:944a4be4b98f901498d5de07542660495c34dfe4f08de4dd8c2df948f5eccfdc"
+        next_revision: 4
+        previous_revision: 3
+        schema_version: 1
+        task_id: "202609120943-P11QPS"
+      compatibility:sha256:da39a148e8940879c5025bfc28782d847f01d5348c26dd79c1446b1d438064ca:
+        aggregate_digest: "sha256:0e2b0dafaa613125b8920f263a52c81d30fe1534c63c077d86942de0ecd0bab7"
+        event:
+          actor_id: "agentplane"
+          at: "2026-09-12T10:00:36.409Z"
+          cause_refs:
+            - "compatibility_projection_mutation"
+          entity: "task"
+          from: "ACTIVE"
+          id: "event_672a32fb751f9796c77e142b"
+          mutation_id: "compatibility:sha256:da39a148e8940879c5025bfc28782d847f01d5348c26dd79c1446b1d438064ca"
+          plan_digest: "sha256:c04a3fd013c722ee840ae8588d230787fb244c40e180a5c82dd9b01c6f699ed5"
+          plan_revision: 1
+          repository_fingerprint: null
+          schema_version: 1
+          task_id: "202609120943-P11QPS"
+          task_revision: 4
+          to: "ACTIVE"
+          work_item_id: null
+        mutation_id: "compatibility:sha256:da39a148e8940879c5025bfc28782d847f01d5348c26dd79c1446b1d438064ca"
+        next_revision: 5
+        previous_revision: 4
+        schema_version: 1
+        task_id: "202609120943-P11QPS"
+    pending_effects: []
+    retry_budgets: []
+    schema_version: 1
+  task_execution_context:
+    base_ref: "main"
+    base_sha: "50b1810dda648be0c0762b47e885c6ad0b2d42af"
+    repository_identity: "sha256:da6b1bd36fbd8902ecef3732738a9db0fd8478b8fcbe61ce4ba5a648cdccfd3b"
+    schema_version: 1
+    source: "creation_checkout"
+  workflow_route_baseline:
+    start_head_sha: "50b1810dda648be0c0762b47e885c6ad0b2d42af"
+    version: 1
+id_source: "generated"
+---
+## Summary
+
+Create the AgentPlane 0.7.9 and 0.7.10 architecture improvement roadmap
+
+Recheck the three supplied architecture proposals against current main and write a standalone English roadmap document. Split implementation into atomic GitHub PR groups and assign each group to AgentPlane 0.7.9 or 0.7.10.
+
+## Scope
+
+- In scope: Recheck the three supplied architecture proposals against current main and write a standalone English roadmap document. Split implementation into atomic GitHub PR groups and assign each group to AgentPlane 0.7.9 or 0.7.10.
+- Out of scope: unrelated refactors not required for "Create the AgentPlane 0.7.9 and 0.7.10 architecture improvement roadmap".
+
+## Plan
+
+Plan one standalone, source-grounded roadmap document for the 0.7.9 stabilization release and the 0.7.10 architecture release.
+
+## Verify Steps
+
+1. Run `bunx prettier --check docs/internal/v0.7.9-v0.7.10-architecture-roadmap.md`. Expected: the roadmap document is formatted.
+2. Run `node .agentplane/policy/check-routing.mjs`. Expected: policy routing passes.
+
+## Verification
+
+<!-- BEGIN VERIFICATION RESULTS -->
+<!-- END VERIFICATION RESULTS -->
+
+## Rollback Plan
+
+- Revert task-related commit(s).
+- Re-run required checks to confirm rollback safety.
+
+## Findings

--- a/.agentplane/tasks/202609120943-P11QPS/README.md
+++ b/.agentplane/tasks/202609120943-P11QPS/README.md
@@ -4,7 +4,7 @@ title: "Create the AgentPlane 0.7.9 and 0.7.10 architecture improvement roadmap"
 status: "DOING"
 priority: "med"
 owner: "CODER"
-revision: 7
+revision: 8
 origin:
   system: "manual"
 depends_on: []
@@ -443,22 +443,79 @@ extensions:
     lifecycle: "ACTIVE"
     plan_amendments: []
     plan_history: []
-    revision: 7
+    revision: 8
     schema_version: 1
-    updated_at: "2026-09-12T10:10:12.453Z"
+    updated_at: "2026-09-12T10:10:19.338Z"
     work_items:
       write-versioned-architecture-roadmap:
-        attempt: 0
+        attempt: 1
         claim_id: null
         id: "write-versioned-architecture-roadmap"
         last_failure: null
-        output_manifests: []
-        revision: 1
-        state: "READY"
-        validation_result: null
+        output_manifests:
+          -
+            digest: "sha256:f7994cb23832889c50a3837d079318b2680eb2390e9de0844f105e1bea8e08fd"
+            id: "verified-versioned-architecture-roadmap"
+            kind: "semantic_output"
+            producer:
+              attempt: 1
+              plan_revision: 1
+              task_id: "202609120943-P11QPS"
+              work_item_id: "write-versioned-architecture-roadmap"
+            provenance:
+              - "sha256:ed843c203deef55fd42d2e15d1c3ae4ab5adfa0ec1ce191667a078f9c98f4cc7"
+              - ".agentplane/tasks/202609120943-P11QPS/supervision/declared-checks.json"
+            repository_snapshot_digest: "sha256:a731c705a93f375315726f1411fe34d4dc67b78bac2f34d34df74f3639971db7"
+            schema: "agentplane.semantic-output.v1"
+            schema_version: 1
+        revision: 2
+        state: "COMPLETED"
+        validation_result:
+          evidence:
+            -
+              artifact_refs:
+                - ".agentplane/tasks/202609120943-P11QPS/supervision/declared-checks.json"
+              check_id: "format-check"
+              command_identity: "bunx prettier --check docs/internal/v0.7.9-v0.7.10-architecture-roadmap.md"
+              detail: "Observed by bunx prettier --check docs/internal/v0.7.9-v0.7.10-architecture-roadmap.md."
+              exit_code: 0
+              observed_at: "2026-09-12T10:10:19.325Z"
+              repository_snapshot_digest: "sha256:a731c705a93f375315726f1411fe34d4dc67b78bac2f34d34df74f3639971db7"
+              status: "passed"
+            -
+              artifact_refs:
+                - ".agentplane/tasks/202609120943-P11QPS/supervision/declared-checks.json"
+              check_id: "routing-check"
+              command_identity: "node .agentplane/policy/check-routing.mjs"
+              detail: "Observed by node .agentplane/policy/check-routing.mjs."
+              exit_code: 0
+              observed_at: "2026-09-12T10:10:19.325Z"
+              repository_snapshot_digest: "sha256:a731c705a93f375315726f1411fe34d4dc67b78bac2f34d34df74f3639971db7"
+              status: "passed"
+          schema_version: 1
+          stale_evidence: []
+          status: "passed"
+          unsatisfied_criteria: []
   agentplane.task_centric_runtime:
     checkpoints: []
-    events: []
+    events:
+      -
+        at: "2026-09-12T10:10:19.338Z"
+        from: "READY"
+        to: "COMPLETED"
+        actor_id: "agentplane"
+        cause_refs:
+          - "semantic-result:sha256:c5da128dfdcdf9f5b5234bde9683de1b50b8e696327f9c9a3da566a16a03a5e1"
+        entity: "work_item"
+        id: "event_07bbdedfc64a5634d233e54f"
+        mutation_id: "external-result:work-order-202609120943-P11QPS-executor-8dbf0de450659d239436ecb2"
+        plan_digest: "sha256:c04a3fd013c722ee840ae8588d230787fb244c40e180a5c82dd9b01c6f699ed5"
+        plan_revision: 1
+        repository_fingerprint: null
+        schema_version: 1
+        task_id: "202609120943-P11QPS"
+        task_revision: 7
+        work_item_id: "write-versioned-architecture-roadmap"
     leases: []
     mutation_receipts:
       compatibility:sha256:4d26893f3cb2c6f90090af471ef0b9072bbd79a354bcf6a8141d109b5994ec60:
@@ -579,6 +636,30 @@ extensions:
         mutation_id: "compatibility:sha256:e7a2d51c6ba106f8c23479d4dae67f3fdb541a1e6f67a85f7f3546ecf03a4a67"
         next_revision: 7
         previous_revision: 6
+        schema_version: 1
+        task_id: "202609120943-P11QPS"
+      external-result:work-order-202609120943-P11QPS-executor-8dbf0de450659d239436ecb2:
+        aggregate_digest: "sha256:92a3bb2c6cba2cab5dcd854e20a533c34b516700cd46bd6b48b3d755f5834e24"
+        event:
+          actor_id: "agentplane"
+          at: "2026-09-12T10:10:19.338Z"
+          cause_refs:
+            - "semantic-result:sha256:c5da128dfdcdf9f5b5234bde9683de1b50b8e696327f9c9a3da566a16a03a5e1"
+          entity: "work_item"
+          from: "READY"
+          id: "event_07bbdedfc64a5634d233e54f"
+          mutation_id: "external-result:work-order-202609120943-P11QPS-executor-8dbf0de450659d239436ecb2"
+          plan_digest: "sha256:c04a3fd013c722ee840ae8588d230787fb244c40e180a5c82dd9b01c6f699ed5"
+          plan_revision: 1
+          repository_fingerprint: null
+          schema_version: 1
+          task_id: "202609120943-P11QPS"
+          task_revision: 7
+          to: "COMPLETED"
+          work_item_id: "write-versioned-architecture-roadmap"
+        mutation_id: "external-result:work-order-202609120943-P11QPS-executor-8dbf0de450659d239436ecb2"
+        next_revision: 8
+        previous_revision: 7
         schema_version: 1
         task_id: "202609120943-P11QPS"
     pending_effects: []

--- a/.agentplane/tasks/202609120943-P11QPS/blueprint/resolved-snapshot.json
+++ b/.agentplane/tasks/202609120943-P11QPS/blueprint/resolved-snapshot.json
@@ -1,0 +1,400 @@
+{
+  "schemaVersion": 1,
+  "artifactKind": "agentplane.blueprint.resolved_snapshot",
+  "resolverInput": {
+    "taskId": "202609120943-P11QPS",
+    "title": "Create the AgentPlane 0.7.9 and 0.7.10 architecture improvement roadmap",
+    "description": "Recheck the three supplied architecture proposals against current main and write a standalone English roadmap document. Split implementation into atomic GitHub PR groups and assign each group to AgentPlane 0.7.9 or 0.7.10.",
+    "tags": [
+      "docs"
+    ],
+    "owner": "CODER",
+    "taskKind": "docs",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "mutation": "docs",
+    "mutationScope": "docs",
+    "touchedPaths": [],
+    "recipeHints": [],
+    "riskFlags": []
+  },
+  "selectedBlueprint": {
+    "id": "docs.change",
+    "version": 1,
+    "title": "Documentation change",
+    "taskKinds": [
+      "docs"
+    ],
+    "workflowModes": [
+      "direct",
+      "branch_pr"
+    ]
+  },
+  "plan": {
+    "schemaVersion": 1,
+    "blueprintId": "docs.change",
+    "blueprintVersion": 1,
+    "title": "Documentation change",
+    "taskId": "202609120943-P11QPS",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "taskIntent": {
+      "taskKind": "docs",
+      "mutationScope": "docs"
+    },
+    "whySelected": [
+      "task kind resolved to docs",
+      "task intent kind: docs",
+      "workflow mode: branch_pr",
+      "task intent mutation scope: docs"
+    ],
+    "states": [
+      {
+        "id": "intake",
+        "kind": "intake",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": []
+      },
+      {
+        "id": "scope",
+        "kind": "scope",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "assumptions"
+        ]
+      },
+      {
+        "id": "context_resolve",
+        "kind": "context_resolve",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [
+          ".agentplane/policy/security.must.md",
+          ".agentplane/policy/dod.core.md",
+          ".agentplane/policy/dod.docs.md"
+        ],
+        "evidenceKinds": [
+          "context_manifest"
+        ]
+      },
+      {
+        "id": "work_unit",
+        "kind": "work_unit",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths",
+          "artifact"
+        ]
+      },
+      {
+        "id": "deterministic_check",
+        "kind": "deterministic_check",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "artifact_write",
+        "kind": "artifact_write",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "artifact"
+        ]
+      },
+      {
+        "id": "verify_record",
+        "kind": "verify_record",
+        "mode": "record",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "quality_gate",
+        "kind": "quality_gate",
+        "mode": "agentic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "quality_report"
+        ]
+      },
+      {
+        "id": "finish",
+        "kind": "finish",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit"
+        ]
+      }
+    ],
+    "requiredEvidence": [
+      {
+        "id": "docs.paths",
+        "kind": "changed_paths",
+        "producedBy": "work_unit",
+        "required": true,
+        "description": "Changed documentation paths."
+      },
+      {
+        "id": "docs.check",
+        "kind": "check_result",
+        "producedBy": "deterministic_check",
+        "required": true,
+        "description": "Documentation checks."
+      },
+      {
+        "id": "docs.artifact",
+        "kind": "artifact",
+        "producedBy": "artifact_write",
+        "required": true,
+        "description": "Updated documentation artifact."
+      },
+      {
+        "id": "docs.quality",
+        "kind": "quality_report",
+        "producedBy": "quality_gate",
+        "required": true,
+        "description": "EVALUATOR quality verdict."
+      }
+    ],
+    "policyModules": [
+      ".agentplane/policy/dod.core.md",
+      ".agentplane/policy/dod.docs.md",
+      ".agentplane/policy/security.must.md"
+    ],
+    "allowedCommands": [
+      "agentplane task verify-show <task-id>",
+      "agentplane verify <task-id> --ok|--rework",
+      "documentation checks"
+    ],
+    "contextBudget": {
+      "maxPolicyModules": 3,
+      "maxPromptBlocks": 10,
+      "rationale": "Documentation changes need docs DoD and minimal workflow/security policy."
+    },
+    "contextManifest": [],
+    "acceptedRecipeExtensions": [],
+    "rejectedRecipeExtensions": [],
+    "stopReasons": []
+  },
+  "nodes": [
+    {
+      "id": "intake",
+      "kind": "intake",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": []
+    },
+    {
+      "id": "scope",
+      "kind": "scope",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "assumptions"
+      ]
+    },
+    {
+      "id": "context_resolve",
+      "kind": "context_resolve",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [
+        ".agentplane/policy/security.must.md",
+        ".agentplane/policy/dod.core.md",
+        ".agentplane/policy/dod.docs.md"
+      ],
+      "evidenceKinds": [
+        "context_manifest"
+      ]
+    },
+    {
+      "id": "work_unit",
+      "kind": "work_unit",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths",
+        "artifact"
+      ]
+    },
+    {
+      "id": "deterministic_check",
+      "kind": "deterministic_check",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "artifact_write",
+      "kind": "artifact_write",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "artifact"
+      ]
+    },
+    {
+      "id": "verify_record",
+      "kind": "verify_record",
+      "mode": "record",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "quality_gate",
+      "kind": "quality_gate",
+      "mode": "agentic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "quality_report"
+      ]
+    },
+    {
+      "id": "finish",
+      "kind": "finish",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit"
+      ]
+    }
+  ],
+  "requiredEvidence": [
+    {
+      "id": "docs.paths",
+      "kind": "changed_paths",
+      "producedBy": "work_unit",
+      "required": true,
+      "description": "Changed documentation paths."
+    },
+    {
+      "id": "docs.check",
+      "kind": "check_result",
+      "producedBy": "deterministic_check",
+      "required": true,
+      "description": "Documentation checks."
+    },
+    {
+      "id": "docs.artifact",
+      "kind": "artifact",
+      "producedBy": "artifact_write",
+      "required": true,
+      "description": "Updated documentation artifact."
+    },
+    {
+      "id": "docs.quality",
+      "kind": "quality_report",
+      "producedBy": "quality_gate",
+      "required": true,
+      "description": "EVALUATOR quality verdict."
+    }
+  ],
+  "policyModules": [
+    ".agentplane/policy/dod.core.md",
+    ".agentplane/policy/dod.docs.md",
+    ".agentplane/policy/security.must.md"
+  ],
+  "allowedCommands": [
+    "agentplane task verify-show <task-id>",
+    "agentplane verify <task-id> --ok|--rework",
+    "documentation checks"
+  ],
+  "contextBudget": {
+    "maxPolicyModules": 3,
+    "maxPromptBlocks": 10,
+    "rationale": "Documentation changes need docs DoD and minimal workflow/security policy."
+  },
+  "contextManifest": [],
+  "acceptedRecipeExtensions": [],
+  "rejectedRecipeExtensions": [],
+  "stopReasons": [],
+  "selectionReasons": [
+    "task kind resolved to docs",
+    "task intent kind: docs",
+    "workflow mode: branch_pr",
+    "task intent mutation scope: docs"
+  ],
+  "digest": {
+    "algorithm": "sha256",
+    "value": "92f5963d074a2861d60abe80dd82a5b8f46262756cf1c64f7e1e5ba1f8eceefc"
+  }
+}

--- a/.agentplane/tasks/202609120943-P11QPS/pr/diffstat.txt
+++ b/.agentplane/tasks/202609120943-P11QPS/pr/diffstat.txt
@@ -1,0 +1,2 @@
+ .../v0.7.9-v0.7.10-architecture-roadmap.md         | 769 +++++++++++++++++++++
+ 1 file changed, 769 insertions(+)

--- a/.agentplane/tasks/202609120943-P11QPS/pr/github-body.md
+++ b/.agentplane/tasks/202609120943-P11QPS/pr/github-body.md
@@ -1,0 +1,34 @@
+Task: `202609120943-P11QPS`
+Title: Create the AgentPlane 0.7.9 and 0.7.10 architecture improvement roadmap
+Canonical task record: `.agentplane/tasks/202609120943-P11QPS/README.md`
+
+## Summary
+
+Create the AgentPlane 0.7.9 and 0.7.10 architecture improvement roadmap
+
+Recheck the three supplied architecture proposals against current main and write a standalone English roadmap document. Split implementation into atomic GitHub PR groups and assign each group to AgentPlane 0.7.9 or 0.7.10.
+
+## Scope
+
+- In scope: Recheck the three supplied architecture proposals against current main and write a standalone English roadmap document. Split implementation into atomic GitHub PR groups and assign each group to AgentPlane 0.7.9 or 0.7.10.
+- Out of scope: unrelated refactors not required for "Create the AgentPlane 0.7.9 and 0.7.10 architecture improvement roadmap".
+
+## Verification
+
+- State: pending
+- Note: Not recorded yet.
+- Canonical workflow state lives in the task README.
+
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-09-12T10:01:00.939Z
+- Branch: task/202609120943-P11QPS/create-the-agentplane-0-7-9-and-0-7-10-architect
+- Head: computed live by `agentplane pr check` / `agentplane integrate`
+
+```text
+ .../v0.7.9-v0.7.10-architecture-roadmap.md         | 769 +++++++++++++++++++++
+ 1 file changed, 769 insertions(+)
+```
+
+</details>

--- a/.agentplane/tasks/202609120943-P11QPS/pr/github-title.txt
+++ b/.agentplane/tasks/202609120943-P11QPS/pr/github-title.txt
@@ -1,0 +1,1 @@
+🚧 P11QPS task: Create the AgentPlane 0.7.9 and 0.7.10 architecture improvement roadmap [202609120943-P11QPS]

--- a/.agentplane/tasks/202609120943-P11QPS/pr/meta.json
+++ b/.agentplane/tasks/202609120943-P11QPS/pr/meta.json
@@ -1,0 +1,21 @@
+{
+  "base": "main",
+  "branch": "task/202609120943-P11QPS/create-the-agentplane-0-7-9-and-0-7-10-architect",
+  "created_at": "2026-09-12T10:01:00.939Z",
+  "diffstat_sha256": "sha256:c8fb8019fe3c09060a89dcb9bcb260b18f2fe15d8dcabbedf196f9025561d789",
+  "last_verified_at": null,
+  "provider": {
+    "hostname": "github.com",
+    "kind": "github",
+    "remote": "origin",
+    "schema_version": 1,
+    "source_project": "basilisk-labs/agentplane",
+    "target_project": "basilisk-labs/agentplane"
+  },
+  "schema_version": 1,
+  "task_id": "202609120943-P11QPS",
+  "updated_at": "2026-09-12T10:01:00.939Z",
+  "verify": {
+    "status": "skipped"
+  }
+}

--- a/.agentplane/tasks/202609120943-P11QPS/pr/review.md
+++ b/.agentplane/tasks/202609120943-P11QPS/pr/review.md
@@ -1,0 +1,37 @@
+# PR Review
+
+Created: 2026-09-12T10:01:00.939Z
+
+## Task
+
+- Task: `202609120943-P11QPS`
+- Title: Create the AgentPlane 0.7.9 and 0.7.10 architecture improvement roadmap
+- Status: DOING
+- Branch: `task/202609120943-P11QPS/create-the-agentplane-0-7-9-and-0-7-10-architect`
+- Canonical task record: `.agentplane/tasks/202609120943-P11QPS/README.md`
+
+## Verification
+
+- State: pending
+- Note: Not recorded yet.
+- Canonical workflow state lives in the task README.
+
+## Handoff Notes
+
+- No handoff notes recorded yet. Use `agentplane pr note ...` to append one.
+
+<!-- BEGIN AUTO SUMMARY -->
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-09-12T10:01:00.939Z
+- Branch: task/202609120943-P11QPS/create-the-agentplane-0-7-9-and-0-7-10-architect
+- Head: computed live by `agentplane pr check` / `agentplane integrate`
+
+```text
+ .../v0.7.9-v0.7.10-architecture-roadmap.md         | 769 +++++++++++++++++++++
+ 1 file changed, 769 insertions(+)
+```
+
+</details>
+<!-- END AUTO SUMMARY -->

--- a/.agentplane/tasks/202609120943-P11QPS/supervision/declared-checks.json
+++ b/.agentplane/tasks/202609120943-P11QPS/supervision/declared-checks.json
@@ -1,0 +1,45 @@
+{
+  "checks": [
+    {
+      "check_ids": [
+        "format-check"
+      ],
+      "command": "bunx prettier --check docs/internal/v0.7.9-v0.7.10-architecture-roadmap.md",
+      "duration_ms": 494,
+      "exit_code": 0,
+      "runtime": {
+        "environment_digest": "sha256:3308005fac9d32f69b94b3df9ca32d660556868e17bec2215bbf27726c7cc603",
+        "executable_digest": "sha256:35d20dd0263e5c950194434b925454fdfa9ba6e4467da960410fa05b08a7a5b5",
+        "kind": "local_runtime_resolution",
+        "status": "resolved",
+        "toolchain_digest": "sha256:b0442f22f0f60a5f05239995b3921d93a899858aa8529e64800e17f73da7fd8a"
+      },
+      "script": null,
+      "stderr_tail": "",
+      "stdout_tail": "Checking formatting...\nAll matched files use Prettier code style!\n"
+    },
+    {
+      "check_ids": [
+        "routing-check"
+      ],
+      "command": "node .agentplane/policy/check-routing.mjs",
+      "duration_ms": 253,
+      "exit_code": 0,
+      "runtime": {
+        "environment_digest": "sha256:3308005fac9d32f69b94b3df9ca32d660556868e17bec2215bbf27726c7cc603",
+        "executable_digest": "sha256:902b6a6984d5d825829ea9064ab73b734548df37bc0683990dca31c8dc2a9253",
+        "kind": "local_runtime_resolution",
+        "status": "resolved",
+        "toolchain_digest": "sha256:b0442f22f0f60a5f05239995b3921d93a899858aa8529e64800e17f73da7fd8a"
+      },
+      "script": null,
+      "stderr_tail": "",
+      "stdout_tail": "policy routing OK\n"
+    }
+  ],
+  "kind": "direct_task_declared_checks",
+  "reason": null,
+  "schema_version": 1,
+  "status": "passed",
+  "task_id": "202609120943-P11QPS"
+}

--- a/.agentplane/tasks/202609120943-P11QPS/supervision/implementation-evidence.json
+++ b/.agentplane/tasks/202609120943-P11QPS/supervision/implementation-evidence.json
@@ -1,0 +1,95 @@
+{
+  "checks": [
+    {
+      "command": "git diff --check 50b1810dda648be0c0762b47e885c6ad0b2d42af..9801378b67064bbcf70222607e32d7ba7d773bd8",
+      "id": "committed-diff-check",
+      "result": "pass",
+      "stdout": []
+    },
+    {
+      "command": "git diff --cached --check",
+      "id": "staged-diff-check",
+      "result": "pass",
+      "stdout": []
+    },
+    {
+      "command": "git diff --name-status --diff-filter=ACDMRTUXB 50b1810dda648be0c0762b47e885c6ad0b2d42af..9801378b67064bbcf70222607e32d7ba7d773bd8",
+      "id": "commit-paths",
+      "result": "pass",
+      "stdout": [
+        "A\t.agentplane/tasks/202609120943-P11QPS/README.md",
+        "A\t.agentplane/tasks/202609120943-P11QPS/blueprint/resolved-snapshot.json",
+        "A\t.agentplane/tasks/202609120943-P11QPS/pr/diffstat.txt",
+        "A\t.agentplane/tasks/202609120943-P11QPS/pr/github-body.md",
+        "A\t.agentplane/tasks/202609120943-P11QPS/pr/github-title.txt",
+        "A\t.agentplane/tasks/202609120943-P11QPS/pr/meta.json",
+        "A\t.agentplane/tasks/202609120943-P11QPS/pr/review.md",
+        "A\tdocs/internal/v0.7.9-v0.7.10-architecture-roadmap.md"
+      ]
+    },
+    {
+      "command": "git status --short --untracked-files=all",
+      "id": "final-repository-status",
+      "result": "pass",
+      "stdout": []
+    }
+  ],
+  "execution_base_commit": "50b1810dda648be0c0762b47e885c6ad0b2d42af",
+  "implementation_commit": "9801378b67064bbcf70222607e32d7ba7d773bd8",
+  "kind": "direct_task_implementation_evidence",
+  "repository_status": {
+    "baseline": [
+      "?? .agentplane/tasks/202609120943-P11QPS/README.md",
+      "?? .agentplane/tasks/202609120943-P11QPS/blueprint/resolved-snapshot.json",
+      "?? .agentplane/tasks/202609120943-P11QPS/pr/diffstat.txt",
+      "?? .agentplane/tasks/202609120943-P11QPS/pr/github-body.md",
+      "?? .agentplane/tasks/202609120943-P11QPS/pr/github-title.txt",
+      "?? .agentplane/tasks/202609120943-P11QPS/pr/meta.json",
+      "?? .agentplane/tasks/202609120943-P11QPS/pr/review.md"
+    ],
+    "classification": [
+      {
+        "classification": "removed_during_execution",
+        "line": "?? .agentplane/tasks/202609120943-P11QPS/README.md"
+      },
+      {
+        "classification": "removed_during_execution",
+        "line": "?? .agentplane/tasks/202609120943-P11QPS/blueprint/resolved-snapshot.json"
+      },
+      {
+        "classification": "removed_during_execution",
+        "line": "?? .agentplane/tasks/202609120943-P11QPS/pr/diffstat.txt"
+      },
+      {
+        "classification": "removed_during_execution",
+        "line": "?? .agentplane/tasks/202609120943-P11QPS/pr/github-body.md"
+      },
+      {
+        "classification": "removed_during_execution",
+        "line": "?? .agentplane/tasks/202609120943-P11QPS/pr/github-title.txt"
+      },
+      {
+        "classification": "removed_during_execution",
+        "line": "?? .agentplane/tasks/202609120943-P11QPS/pr/meta.json"
+      },
+      {
+        "classification": "removed_during_execution",
+        "line": "?? .agentplane/tasks/202609120943-P11QPS/pr/review.md"
+      }
+    ],
+    "final": [],
+    "introduced_after_execution_baseline": [],
+    "removed_after_execution_baseline": [
+      "?? .agentplane/tasks/202609120943-P11QPS/README.md",
+      "?? .agentplane/tasks/202609120943-P11QPS/blueprint/resolved-snapshot.json",
+      "?? .agentplane/tasks/202609120943-P11QPS/pr/diffstat.txt",
+      "?? .agentplane/tasks/202609120943-P11QPS/pr/github-body.md",
+      "?? .agentplane/tasks/202609120943-P11QPS/pr/github-title.txt",
+      "?? .agentplane/tasks/202609120943-P11QPS/pr/meta.json",
+      "?? .agentplane/tasks/202609120943-P11QPS/pr/review.md"
+    ],
+    "unchanged_from_execution_baseline": []
+  },
+  "schema_version": 1,
+  "task_id": "202609120943-P11QPS"
+}

--- a/docs/internal/v0.7.9-v0.7.10-architecture-roadmap.md
+++ b/docs/internal/v0.7.9-v0.7.10-architecture-roadmap.md
@@ -1,0 +1,769 @@
+# AgentPlane 0.7.9 and 0.7.10 architecture improvement roadmap
+
+Status: proposed implementation roadmap.
+
+Review baseline: `main@50b1810dda648be0c0762b47e885c6ad0b2d42af`, package
+`0.7.9-beta.1`, inspected on 2026-09-12.
+
+## Purpose
+
+This document converts the following design proposals into an ordered implementation roadmap:
+
+- `RFC-001-recipes.md`;
+- `RFC-002-architecture-simplification.md`;
+- `agentplane-adaptive-task-lifecycle-architecture.md`.
+
+The proposals are design inputs. They do not override current repository policy, current code, or
+enforced compatibility requirements.
+
+The roadmap keeps the work in the 0.7 release line:
+
+- `0.7.9` stabilizes and measures the existing architecture without changing the default lifecycle
+  or persisted task format.
+- `0.7.10` introduces the versioned adaptive lifecycle, Recipe Scenario V2, lifecycle convergence,
+  and removal of Blueprint from the active runtime.
+
+Each numbered group is one GitHub pull request. The tasks inside a group are atomic implementation
+steps for that pull request. A group must not be merged until its dependencies and acceptance
+criteria are satisfied.
+
+## Target architecture
+
+```text
+user intent + optional pinned Recipe + repository observations
+                            |
+                            v
+                  authoritative approved Plan
+                            |
+                            v
+         ProcessDecision + policy + issued USER authority
+                            |
+                            v
+               shared native lifecycle coordinator
+                   /           |             \
+             checks      semantic dispatch    Git/provider effects
+                            |
+                            v
+                  role-scoped WorkOrder
+                            |
+                            v
+           semantic result + supervisor observations
+                            |
+                            v
+            verification -> integration -> completion
+```
+
+The ownership rules are:
+
+1. Task owns the original objective and lifecycle identity.
+2. Recipe owns reusable domain strategy and immutable referenced assets.
+3. Plan owns the task-specific scope, work graph, outputs, acceptance, and verification intent.
+4. Repository policy and issued USER authority own mandatory constraints and effect permission.
+5. The canonical Task aggregate owns lifecycle state and accepted semantic results.
+6. The execution journal owns durable effect intent, receipts, and effect uncertainty.
+7. WorkOrder is a derived projection for one semantic episode.
+8. Verification evidence owns observed checks and their exact input identities.
+
+Recipe must not own a scheduler, lifecycle cursor, approval state, integration, or completion.
+Blueprint must not be renamed and recreated under another type.
+
+## Current-state findings
+
+The following statements were verified against the review baseline:
+
+1. `packages/recipes/src/scenario-contracts.ts` still defines Scenario V1 with `inputs` and
+   `outputs` as `unknown` and `steps` as `unknown[]`.
+2. `packages/core/src/tasks/kernel-semantic.ts` supports `PLANNER`, `EXECUTOR`, and `EVALUATOR`, but
+   not `CURATOR`.
+3. `packages/agentplane/src/commands/task/kernel-work-order.ts` emits a `PLANNER` WorkOrder when no
+   implementation contract exists.
+4. `packages/agentplane/src/commands/task/create.command.ts` returns
+   `semantic_input_required` and `required_role: PLANNER` even for caller-supplied structured
+   intent.
+5. `packages/agentplane/src/commands/task/kernel-inspection.ts` runs native validation from the
+   EVALUATOR result acceptance path.
+6. `packages/agentplane/src/commands/task/run.command.ts` selects canonical or legacy supervision
+   by the presence of `TASK_KERNEL_EXTENSION`.
+7. Blueprint snapshot writers and freshness consumers remain active.
+8. The inspected tree contains 41 tracked files under the main Blueprint implementation and command
+   directories. It contains 189 TypeScript files under `packages/` with Blueprint-related symbols.
+
+Changes after the proposal baseline improved runner liveness and verification-rework routing. They
+did not implement Scenario V2, optional planning or evaluation, lifecycle convergence, or Blueprint
+removal.
+
+The proposal set refers to companion schema, example, validator, and source-evidence files that were
+not available during this review. Their exact shapes are not accepted by this roadmap. The relevant
+implementation pull requests must add and review repository-native fixtures instead of copying an
+unreviewed external schema.
+
+## Release boundary
+
+### 0.7.9 compatibility boundary
+
+`0.7.9` may:
+
+- add characterization tests and inventory tooling;
+- fix requirement conservation or transport parity defects;
+- complete usage and latency observations;
+- separate internal native verification from semantic review while preserving current required
+  review behavior;
+- compute a new decision in shadow mode when it does not affect routing or persisted task state;
+- update implementation-status documentation.
+
+`0.7.9` must not:
+
+- write Scenario V2 or a new canonical Task format;
+- omit a currently required PLANNER or EVALUATOR episode;
+- change the default lifecycle owner;
+- stop writing Blueprint artifacts that current consumers require;
+- remove Blueprint CLI, API, schemas, or historical readers;
+- perform automatic migration of existing tasks.
+
+### 0.7.10 architecture boundary
+
+`0.7.10` may introduce versioned records and explicit migration. It must retain readable historical
+evidence and a bounded migration or completion path for old active tasks.
+
+Removal in `0.7.10` means removal of Blueprint from the active new-task runtime. A versioned,
+read-only historical audit reader may remain. Public audit commands must not disappear until their
+replacement and compatibility policy are documented and tested.
+
+`0.7.10` must not claim downgrade safety after it writes a format that `0.7.9` cannot read. Before
+the first new-format write, rollback is ordinary candidate rollback. After that write, recovery is
+version-aware export or an explicitly qualified reverse migration.
+
+## Dependency overview
+
+```text
+0.7.9-01 -> 0.7.9-02 -> 0.7.9-03
+       \-> 0.7.9-04
+0.7.9-02 -> 0.7.9-05 -> 0.7.9-06 -> 0.7.9-07
+
+0.7.9-07 -> 0.7.10-01
+0.7.10-01 -> adaptive track 0.7.10-02..08
+0.7.10-01 -> recipe track   0.7.10-09..16
+adaptive + recipe tracks -> Blueprint transfer 0.7.10-17..23
+Blueprint transfer -> entrypoint cutover 0.7.10-24..25
+entrypoint cutover -> migration 0.7.10-26..27
+migration -> writer shutdown 0.7.10-28
+writer shutdown -> subsystem removal 0.7.10-29
+all groups -> qualification 0.7.10-30
+```
+
+The adaptive and recipe tracks may run in parallel after `0.7.10-01`. Groups that modify the same
+Task aggregate, Plan schema, WorkOrder schema, verification binding, or execution journal must run
+sequentially.
+
+## AgentPlane 0.7.9 pull request groups
+
+### 0.7.9-01: Freeze the source and consumer inventory
+
+Dependencies: none.
+
+Atomic tasks:
+
+1. Add a reproducible inventory of Blueprint types, imports, writers, readers, CLI surfaces,
+   generated schemas, assets, and documentation.
+2. Include built-in, pinned-recipe, and project-local Blueprint sources.
+3. Record the invariant, input identity, proposed owner, and replacement test for every active
+   consumer.
+4. Mark unknown custom semantics as `manual_review_required`.
+
+Acceptance: a clean checkout reproduces the ledger, and every active Blueprint reference is either
+classified or explicitly unresolved. Runtime behavior does not change.
+
+### 0.7.9-02: Add frozen lifecycle parity fixtures
+
+Dependencies: `0.7.9-01`.
+
+Atomic tasks:
+
+1. Capture ordinary direct and `branch_pr` behavior.
+2. Capture planning, approval, CURATOR/context, evaluator rework, hosted waiting, and integration.
+3. Capture stale result, infrastructure retry, provider crash, effect-in-doubt, and terminal replay.
+4. Assert observable state and effects instead of Blueprint node names.
+
+Acceptance: fixtures describe current behavior without changing expected outcomes to match the
+target architecture.
+
+### 0.7.9-03: Close semantic requirement and transport parity gaps
+
+Dependencies: `0.7.9-02`.
+
+Atomic tasks:
+
+1. Trace objective, acceptance, scope, outputs, checks, and stop conditions across Plan, WorkOrder,
+   managed transport, and external transport.
+2. Fix only demonstrated loss or divergence.
+3. Preserve state fingerprints and exact WorkOrder result binding.
+4. Add adapter-boundary regressions for every corrected field.
+
+Acceptance: managed and external execution receive equivalent required semantics for the same
+current task. No new public schema version is introduced.
+
+### 0.7.9-04: Complete efficiency and usage observations
+
+Dependencies: `0.7.9-01`.
+
+Atomic tasks:
+
+1. Record semantic episodes separately from provider requests and adapter dispatches.
+2. Record input, cached input, output, reasoning, and total tokens when the provider exposes them.
+3. Preserve `unavailable` and `partial` instead of converting missing telemetry to zero.
+4. Separate local preparation, provider execution, checks, Git, filesystem, external waiting, and
+   USER waiting spans.
+
+Acceptance: every required metric has observed provenance or a typed unavailable reason. Subsets
+are not double-counted into totals.
+
+### 0.7.9-05: Separate native validation from EVALUATOR acceptance
+
+Dependencies: `0.7.9-02`, `0.7.9-03`.
+
+Atomic tasks:
+
+1. Extract the native check runner from `acceptKernelInspection` into an independent use case.
+2. Bind validation to implementation, command, toolchain, environment, and repository identities.
+3. Preserve infrastructure-only retry without a new EXECUTOR episode.
+4. Keep EVALUATOR mandatory wherever it is mandatory before this pull request.
+
+Acceptance: check evidence and semantic review are distinct records, but all existing completion
+routes still require the same review outcomes.
+
+### 0.7.9-06: Compute adaptive process decisions in shadow mode
+
+Dependencies: `0.7.9-02`, `0.7.9-05`.
+
+Atomic tasks:
+
+1. Implement a pure, non-authoritative decision result for planning, evaluation, authorization,
+   repository mode, and verification requirements.
+2. Derive it only from the accepted contract, policy, authority, and observations.
+3. Produce typed rule identifiers and reasons.
+4. Compare it with the actual route in diagnostics without changing the route or task record.
+
+Acceptance: shadow decisions are deterministic and explainable. They cannot skip a lifecycle stage
+or authorize an effect.
+
+### 0.7.9-07: Qualify and document the stabilization release
+
+Dependencies: `0.7.9-03`, `0.7.9-04`, `0.7.9-05`, `0.7.9-06`.
+
+Atomic tasks:
+
+1. Build and test the installed package from an exact clean SHA.
+2. Run the frozen parity and recovery corpus.
+3. Capture the final 0.7.9 efficiency baseline.
+4. Document implemented behavior and the deferred 0.7.10 contract.
+
+Acceptance: current lifecycle, persisted formats, Blueprint consumers, and public compatibility are
+unchanged except for bounded correctness fixes. All claims refer to exact evidence.
+
+## AgentPlane 0.7.10 pull request groups
+
+### 0.7.10-01: Select the canonical lifecycle owner and close role parity
+
+Dependencies: `0.7.9-07`.
+
+Atomic tasks:
+
+1. Use the parity ledger to select the existing aggregate and coordinator that will become the sole
+   owner for new tasks.
+2. Define the version marker and compatibility boundary for the selected state.
+3. Support `CURATOR` or an explicitly equivalent typed context-preparation episode.
+4. Add an architecture guard that prevents new lifecycle writers outside the selected owner.
+
+Acceptance: every frozen parity case has a mapped representation before default routing changes.
+The change does not create a third coordinator.
+
+### 0.7.10-02: Persist `ProcessDecision` V1
+
+Dependencies: `0.7.10-01`.
+
+Atomic tasks:
+
+1. Add a versioned decision record to the selected canonical aggregate.
+2. Represent planning, evaluation, authorization, repository mode, and verification independently.
+3. Bind the decision to the contract and policy versions used to produce it.
+4. Preserve decision revisions after observations strengthen requirements.
+
+Acceptance: absence of a stage requirement differs from a passed or waived stage. The agent cannot
+write or weaken the decision.
+
+### 0.7.10-03: Add inline task-contract transport
+
+Dependencies: `0.7.10-01`, `0.7.10-02`.
+
+Atomic tasks:
+
+1. Add a strict proposal schema for objective, acceptance, scope, effects, verification, and
+   unresolved questions.
+2. Accept the proposal through existing task creation or refinement entrypoints.
+3. Return exact missing fields for structurally incomplete proposals.
+4. Reject model-supplied hashes, approvals, authority, and lifecycle state.
+
+Acceptance: the transport records a proposal only. It cannot authorize mutation or claim USER
+approval.
+
+### 0.7.10-04: Materialize a deterministic one-item Plan
+
+Dependencies: `0.7.10-03`.
+
+Atomic tasks:
+
+1. Convert an accepted bounded inline contract into the ordinary Plan proposal shape.
+2. Run the common graph, scope, output, verification, and policy validators.
+3. Preserve real approval provenance.
+4. Avoid synthetic PLANNER results and synthetic `APPROVED` markers.
+
+Acceptance: a sufficient contract reaches the normal approval or execution boundary without a
+separate PLANNER episode. Insufficient semantic input still requests planning or USER clarification.
+
+### 0.7.10-05: Add optional-stage completion semantics
+
+Dependencies: `0.7.10-02`, `0.7.9-05`.
+
+Atomic tasks:
+
+1. Represent `required`, `performed`, `not_required`, and explicitly `waived` stage states.
+2. Recompute completion obligations against current observations.
+3. Keep native verification independent of evaluation requirement.
+4. Update Task and ACR projections without fabricating positive stage results.
+
+Acceptance: completion fails when any currently required stage is missing. A non-required stage is
+never rendered as passed.
+
+### 0.7.10-06: Add the first narrow adaptive policy rules
+
+Dependencies: `0.7.10-04`, `0.7.10-05`.
+
+Atomic tasks:
+
+1. Define a small allowlist for no-separate-PLANNER and no-independent-EVALUATOR cases.
+2. Require positive policy evidence instead of absence of a detected risk.
+3. Exclude policy, security, verification, authority, generated-contract, and release changes.
+4. Add malicious low-risk declarations and one-line critical-change regressions.
+
+Acceptance: policy may strengthen requirements automatically. It cannot lower an already required
+stage without an authorized, durable basis.
+
+### 0.7.10-07: Enable the adaptive external-agent route
+
+Dependencies: `0.7.10-06`.
+
+Atomic tasks:
+
+1. Execute an accepted inline contract without a separate PLANNER episode.
+2. Execute a qualified policy class without an independent EVALUATOR episode.
+3. Preserve authority, scope observation, native checks, Git requirements, and evidence.
+4. Escalate on new uncertainty or effects without repeating accepted implementation.
+
+Acceptance: the external route passes positive, stale-result, scope-violation, and escalation tests.
+
+### 0.7.10-08: Establish managed and external adaptive parity
+
+Dependencies: `0.7.10-07`.
+
+Atomic tasks:
+
+1. Use the same `ProcessDecision` and completion predicate in the managed runner.
+2. Stop managed execution at real approval, USER, external-wait, and effect-in-doubt boundaries.
+3. Keep transport capabilities observable and separate from semantic requirements.
+4. Add CLI status and explain projections for the applied rules.
+
+Acceptance: equal contracts and policies produce equal obligations across transports. No parity test
+executes two providers or two effects.
+
+### 0.7.10-09: Add the structural Recipe Scenario V2 contract
+
+Dependencies: `0.7.10-01`.
+
+Atomic tasks:
+
+1. Add a strict Scenario V2 parser in `@agentplaneorg/recipes`.
+2. Reject unknown fields.
+3. Add explicit `scenario_api_version: "2"` compatibility negotiation.
+4. Prevent a V1 runtime from accepting V2 as V1.
+
+Acceptance: positive and negative fixtures pass. Parsing has no shell, network, model, or lifecycle
+effects.
+
+### 0.7.10-10: Validate V2 parameters, references, and DAG semantics
+
+Dependencies: `0.7.10-09`.
+
+Atomic tasks:
+
+1. Validate IDs, dependencies, required inputs, outputs, context references, and guidance
+   references.
+2. Support only `string`, `repo_path`, `integer`, and `boolean` parameters.
+3. Perform one interpolation pass only in approved semantic and path fields.
+4. Reject interpolation in commands, capability IDs, WorkItem IDs, dependencies, and output IDs.
+
+Acceptance: cycle, dangling reference, duplicate output, injection, traversal, absolute path, and
+symlink escape fixtures fail closed.
+
+### 0.7.10-11: Add observation-bound Recipe applicability
+
+Dependencies: `0.7.10-10`.
+
+Atomic tasks:
+
+1. Implement `path_exists`, `capability_available`, and `observed_value_equals` predicates.
+2. Return `true`, `false`, or `unknown` with observation provenance.
+3. Require all required predicates and reject every true excluded predicate.
+4. Block deterministic instantiation when a required observation is unknown.
+
+Acceptance: an agent claim cannot substitute for a supervisor observation. An explicitly selected
+incompatible Recipe is not silently replaced.
+
+### 0.7.10-12: Pin and retain the Recipe closure
+
+Dependencies: `0.7.10-10`.
+
+Atomic tasks:
+
+1. Compute the digest of the scenario and only the assets and entrypoints actually used.
+2. Bind package, scenario, version, closure, compiler, parameters, and applicability evidence to the
+   Plan.
+3. Retain one immutable recovery copy or verified retained Git objects.
+4. Exclude secret values while retaining secret or capability references.
+
+Acceptance: update, removal, tamper, and restart tests recover the same closure without network
+resolution or selection of `latest`.
+
+### 0.7.10-13: Compile Recipe instantiate mode into an ordinary Plan
+
+Dependencies: `0.7.10-11`, `0.7.10-12`.
+
+Atomic tasks:
+
+1. Implement pure deterministic compilation from pinned inputs.
+2. Produce the selected ordinary Plan proposal shape.
+3. Apply common Plan and policy validation.
+4. Keep approval, scheduling, dispatch, verification, and completion outside the compiler.
+
+Acceptance: equal normalized inputs produce equal Plan semantics. Recipe requirements may strengthen
+but never weaken policy requirements.
+
+### 0.7.10-14: Add bounded Recipe specialization transport
+
+Dependencies: `0.7.10-13`.
+
+Atomic tasks:
+
+1. Add typed `add_work_item`, `replace_work_item`, and `remove_work_item` operations.
+2. Apply all operations transactionally to the pinned base template.
+3. Validate the full resulting Plan.
+4. Route material scope, output, acceptance, verification, or effect changes through normal
+   approval.
+
+Acceptance: stale, cross-task, authority, and duplicate-operation tampering is rejected. Large
+departures may still return a full Plan proposal.
+
+### 0.7.10-15: Integrate Recipe selection and bounded context projection
+
+Dependencies: `0.7.10-13`, `0.7.10-14`.
+
+Atomic tasks:
+
+1. Resolve an explicitly selected Recipe first.
+2. Build a stable bounded candidate list from compatible installed Recipes.
+3. Make semantic selection inside an already required PLANNER episode.
+4. Project only role-relevant guidance, context, constraints, and deviations into WorkOrder.
+
+Acceptance: no-match tasks use ordinary planning without a Recipe-selection episode. The full
+catalog and package manifests are not loaded into every episode.
+
+### 0.7.10-16: Add the Recipe V1 audit and conversion path
+
+Dependencies: `0.7.10-10`, `0.7.10-12`.
+
+Atomic tasks:
+
+1. Inventory V1 scenarios and project overlays without executing them.
+2. Convert only fields with deterministic semantic mappings.
+3. Preserve unknown steps and requirements in a `manual_review_required` report.
+4. Keep project overlays separate when they contain policy or assets but no procedural strategy.
+
+Acceptance: V1 unknown steps never become shell commands. Conversion does not install packages,
+invoke providers, grant authority, or create Tasks.
+
+### 0.7.10-17: Move Blueprint routing and strategy discovery
+
+Dependencies: `0.7.10-08`, `0.7.10-15`, `0.7.9-01`.
+
+Atomic tasks:
+
+1. Move task kind, workflow mode, and effect-risk routing to execution policy.
+2. Move reusable strategy applicability to Recipe selection.
+3. Replace `preferred_blueprint` with explicit strategy or requirements during conversion.
+4. Compare old and new pure decisions before switching consumers.
+
+Acceptance: policy works with and without a Recipe. An incompatible strategy cannot weaken or
+silently alter the execution route.
+
+### 0.7.10-18: Move Blueprint capability and context constraints
+
+Dependencies: `0.7.10-17`.
+
+Atomic tasks:
+
+1. Move `allowedCommands` to capability policy and per-episode tools.
+2. Move `policyModules` to the repository policy resolver.
+3. Move `contextBudget` to runtime and prompt budget policy.
+4. Remove each Blueprint consumer after its negative parity tests pass.
+
+Acceptance: effective authority is equal or narrower. Required constraints cannot disappear because
+of a context budget.
+
+### 0.7.10-19: Move Blueprint approval, stop, and rollback requirements
+
+Dependencies: `0.7.10-17`.
+
+Atomic tasks:
+
+1. Move protected approval and quality nodes to native admission and completion policy.
+2. Represent mandatory stops as typed native reasons or Plan constraints.
+3. Bind rollback requirements to the concrete Plan and verification contract.
+4. Remove only the replaced Blueprint decisions.
+
+Acceptance: malicious Recipes cannot remove approval, independent review, rollback, or effect
+reconciliation requirements.
+
+### 0.7.10-20: Move Blueprint evidence minimums
+
+Dependencies: `0.7.10-18`, `0.7.10-19`.
+
+Atomic tasks:
+
+1. Assign each evidence minimum to a current policy, Plan, verification, journal, or provider owner.
+2. Identify its producer, bound identity, and consumer.
+3. Switch one coherent consumer cluster.
+4. Preserve historical evidence identities without reinterpretation.
+
+Acceptance: the same forbidden traces remain rejected. A Recipe suggestion is never treated as
+observed evidence.
+
+### 0.7.10-21: Produce VerificationBinding V2
+
+Dependencies: `0.7.10-20`.
+
+Atomic tasks:
+
+1. Bind Task and Plan revision, policy, optional Recipe, WorkItem result, implementation, command,
+   toolchain, environment, and authority identities.
+2. Write the new structured binding alongside the current Blueprint reference.
+3. Add stale and mutation tests for every material input.
+4. Version the old format as historical evidence.
+
+Acceptance: a digest without available required bytes is insufficient. A derived report-only change
+does not create a new semantic attempt.
+
+### 0.7.10-22: Switch verification and finish consumers
+
+Dependencies: `0.7.10-21`.
+
+Atomic tasks:
+
+1. Switch verification-record freshness to VerificationBinding V2.
+2. Switch finish admission to the same binding.
+3. Remove new-record parsing of `BlueprintSnapshotRef` Markdown markers.
+4. Keep old records on their versioned historical validation path.
+
+Acceptance: changed Plan, policy, Recipe, implementation, check command, toolchain, or required
+environment causes rejection or renewed approval and verification as appropriate.
+
+### 0.7.10-23: Switch evaluator, quality, and ACR consumers
+
+Dependencies: `0.7.10-21`, `0.7.10-22`.
+
+Atomic tasks:
+
+1. Switch evaluator freshness and quality-gate identity.
+2. Switch ACR and human-readable status projection.
+3. Preserve reviewer independence provenance.
+4. Stop writing Blueprint digest into new quality records.
+
+Acceptance: new quality and ACR records contain no active Blueprint identity. Historical verdicts
+remain auditable against the format that produced them.
+
+### 0.7.10-24: Converge ordinary Task entrypoints
+
+Dependencies: `0.7.10-08`, `0.7.10-22`, `0.7.10-23`.
+
+Atomic tasks:
+
+1. Route new ordinary `task create` and `task advance` records to the selected coordinator.
+2. Preserve direct and `branch_pr` as effect policies rather than semantic lifecycle owners.
+3. Add explicit current-format versioning.
+4. Reject unknown current formats instead of falling back to the legacy executor.
+
+Acceptance: ordinary tasks use one lifecycle implementation. Direct and branch modes retain their
+worktree, provider, and integration guarantees.
+
+### 0.7.10-25: Converge Recipe and managed entrypoints
+
+Dependencies: `0.7.10-15`, `0.7.10-24`.
+
+Atomic tasks:
+
+1. Make scenario materialization create an ordinary Task and Plan binding.
+2. Route scenario execution through the selected coordinator.
+3. Route `task run` through the same coordinator.
+4. Preserve managed and external transport differences as observed capabilities only.
+
+Acceptance: entrypoint parity fixtures observe the same state transitions. No operation invokes two
+providers, runs two integrations, or repeats an accepted semantic result.
+
+### 0.7.10-26: Add task migration inventory and preview
+
+Dependencies: `0.7.10-24`, `0.7.10-25`, `0.7.10-16`.
+
+Atomic tasks:
+
+1. Inventory old Task, Blueprint, Recipe, verification, journal, and provider state.
+2. Produce a candidate new record without writing it.
+3. Report old and new digests and field mappings.
+4. Classify non-equivalent or custom cases as `manual_review_required`.
+
+Acceptance: preview is read-only and idempotent. It performs no model, check, provider, Git, or
+external effect.
+
+### 0.7.10-27: Apply migration through CAS and quarantine unsafe records
+
+Dependencies: `0.7.10-26`.
+
+Atomic tasks:
+
+1. Block tasks with a live provider claim, pending effect, effect in doubt, or unresolved external
+   operation.
+2. Apply exact-equivalent migrations through the existing transaction and CAS mechanisms.
+3. Store a migration receipt with old and new digests.
+4. Quarantine unsupported records without selecting a nearest Recipe or route.
+
+Acceptance: crash and repeat tests preserve old state and produce at most one accepted migration.
+Old approval never expands authority or verification coverage.
+
+### 0.7.10-28: Stop new Blueprint artifact writers
+
+Dependencies: `0.7.10-27` and proof that all active new-record consumers have moved.
+
+Atomic tasks:
+
+1. Stop writing resolved snapshots for new current-format tasks.
+2. Stop writing Blueprint plan, state, cursor, and marker projections.
+3. Remove now-unused artifact path types and writer imports.
+4. Preserve all pre-cutover evidence and migration references.
+
+Acceptance: representative new ordinary and Recipe tasks create zero Blueprint artifacts. Terminal
+replay creates no files, provider calls, or timestamp-only commits.
+
+### 0.7.10-29: Remove Blueprint from the active runtime
+
+Dependencies: `0.7.10-28`, migration or safe drainage of every supported active old record.
+
+Atomic tasks:
+
+1. Remove the active registry, resolver, graph compiler, cursor, extension resolver, and runtime
+   imports.
+2. Remove superseded compatibility branches and entrypoint dispatch.
+3. Isolate a versioned read-only historical audit reader outside the new-task hot path.
+4. Retain temporary compatibility code only when it has a named owner and removal condition.
+
+Acceptance: active new-task import and artifact graphs contain no Blueprint engine. Recipe does not
+recreate Blueprint nodes, edges, protected gates, or execution cursor under new names.
+
+### 0.7.10-30: Qualify and document the architecture release
+
+Dependencies: all `0.7.10` groups.
+
+Atomic tasks:
+
+1. Build and test the installed package from an exact clean SHA.
+2. Run positive, negative, recovery, migration, terminal replay, and historical audit suites.
+3. Run paired previous-baseline, no-Recipe, and Recipe workflows with equal models, authority, and
+   external verification criteria.
+4. Update CLI help and current workflow documentation.
+5. Publish exact limits when efficiency evidence is incomplete or mixed.
+
+Acceptance: safety, architecture, compatibility, and evidence gates pass. Efficiency is reported as
+improved, mixed, or not established according to observed data rather than release intent.
+
+## Global pull request rules
+
+Every group must satisfy these rules:
+
+1. Keep `main` executable and tests green after each merge.
+2. Add a new producer before switching its first consumer.
+3. Remove an old producer only after switching its last consumer.
+4. Keep shadow comparison pure. Do not duplicate provider or external effects for parity.
+5. Bind every state-changing command to current identity and authority.
+6. Preserve one accepted semantic result across infrastructure-only retry.
+7. Reject stale results and unresolved effect uncertainty.
+8. Keep generated views out of authoritative state decisions.
+9. Do not mix runtime migration, default cutover, and subsystem deletion in one pull request.
+10. Do not claim efficiency from file count, payload bytes, prompt bytes, or local compilation alone.
+
+## Mandatory negative scenarios
+
+The qualification corpus must cover:
+
+- a one-line change to critical authorization logic;
+- policy and verification-tool changes;
+- a false low-risk declaration;
+- a write outside approved scope;
+- an agent claiming its own USER authority;
+- a changed Plan, policy, Recipe, implementation, check, or environment after issuance;
+- a repeated result;
+- a crash after model completion;
+- a crash after native validation;
+- a crash after a saved verdict;
+- a provider or external effect in doubt;
+- missing evidence bytes in a fresh clone;
+- an incompatible or stale Recipe;
+- a custom Blueprint with no exact mapping;
+- downgrade attempt after a 0.7.10-format write;
+- terminal task replay.
+
+## Non-goals for 0.7.9 and 0.7.10
+
+- A new Recipe scheduler or general workflow DSL.
+- Nested or recursively composed Recipe workflows.
+- A universal LLM risk classifier.
+- A second fast-task database or lifecycle.
+- A new runtime service, event bus, or global optimizer.
+- A universal cross-environment check cache.
+- Automatic publication of Recipes from successful tasks.
+- A marketplace trust system.
+- A new long-term memory subsystem.
+- Replacement of the Git-backed canonical state backend.
+- Rewriting historical evidence into the new format.
+- Silent migration on ordinary `task run`.
+
+## Release completion criteria
+
+### 0.7.9 is complete when
+
+1. The consumer inventory and parity corpus are reproducible.
+2. Requirement and transport losses found by the corpus are fixed.
+3. Validation and review are internally separable without changing required review behavior.
+4. Usage and latency gaps are explicit.
+5. The exact-SHA package passes installed-package and recovery checks.
+6. No new lifecycle format, default route, or Blueprint removal has shipped.
+
+### 0.7.10 is complete when
+
+1. New tasks use one lifecycle owner and one authoritative Plan.
+2. Planning and evaluation requirements are independently policy-driven.
+3. Qualified tasks can omit unnecessary semantic episodes without losing authority or verification.
+4. Scenario V2 compiles an optional pinned Recipe into the ordinary Plan contract.
+5. Managed and external transports enforce equal obligations.
+6. New tasks neither load the Blueprint engine nor create Blueprint artifacts.
+7. Old supported tasks are drained, migrated, or explicitly quarantined.
+8. Historical evidence remains auditable through a versioned read-only path.
+9. Safety and recovery parity pass with no accepted unauthorized effect, stale result, or blind
+   retry.
+10. Efficiency claims are supported by complete paired evidence or explicitly remain not
+    established.


### PR DESCRIPTION
Task: `202609120943-P11QPS`
Title: Create the AgentPlane 0.7.9 and 0.7.10 architecture improvement roadmap
Canonical task record: `.agentplane/tasks/202609120943-P11QPS/README.md`

## Summary

Create the AgentPlane 0.7.9 and 0.7.10 architecture improvement roadmap

Recheck the three supplied architecture proposals against current main and write a standalone English roadmap document. Split implementation into atomic GitHub PR groups and assign each group to AgentPlane 0.7.9 or 0.7.10.

## Scope

- In scope: Recheck the three supplied architecture proposals against current main and write a standalone English roadmap document. Split implementation into atomic GitHub PR groups and assign each group to AgentPlane 0.7.9 or 0.7.10.
- Out of scope: unrelated refactors not required for "Create the AgentPlane 0.7.9 and 0.7.10 architecture improvement roadmap".

## Verification

- State: ok
- Note: Verified: CLI-owned declared checks passed; independent EVALUATOR review is pending.
- Canonical workflow state lives in the task README.

<details>
<summary>Raw evidence</summary>

- Updated: 2026-09-12T10:10:41.653Z
- Branch: task/202609120943-P11QPS/create-the-agentplane-0-7-9-and-0-7-10-architect
- Head: computed live by `agentplane pr check` / `agentplane integrate`

```text
 .../v0.7.9-v0.7.10-architecture-roadmap.md         | 769 +++++++++++++++++++++
 1 file changed, 769 insertions(+)
```

</details>
